### PR TITLE
Custom rule controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,25 @@ The default set includes:
 ]
 ```
 
-#### getEditor *(Optional)*
-function({field, operator, value, onChange}):ReactElement
+#### controls *(Optional)*
+```js
+React.PropTypes.shape({
+  valueEditor: React.PropTypes.element
+})
+```
 
-This is a callback function invoked by the internal `<Rule />` component to determine the
-editor for the field value. By default a `<input type="text" />` is used.
+This is a custom controls object invoked by the internal `<Rule />` component
+to determine the components to use.
+The following components are supported:
+- `valueEditor`: By default a `<input type="text" />` is used. The following props are passed:
+
+  ```js
+  {
+    field: React.PropTypes.string, //field name corresponding to this Rule
+    operator: React.PropTypes.string, //operator name corresponding to this Rule
+    handleOnChange: React.PropTypes.func //callback function to update the query representation
+  }
+  ```
 
 #### getOperators *(Optional)*
 function(field):[]

--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ The following components are supported:
 
   ```js
   {
+    options: React.PropTypes.array.isRequired, //same as 'fields' passed into QueryBuilder
+    value: React.PropTypes.string, //selected field from the existing query representation, if any
     className: React.PropTypes.string, //css classNames to be applied
-    options: React.PropTypes.array, //same as 'fields' passed into QueryBuilder
     handleOnChange: React.PropTypes.func //callback function to update query representation
   }
   ```
@@ -119,8 +120,9 @@ The following components are supported:
 
   ```js
   {
+    options: React.PropTypes.array.isRequired, //return value of getOperators(field)
+    value: React.PropTypes.string, //selected operator from the existing query representation, if any
     className: React.PropTypes.string, //css classNames to be applied
-    options: React.PropTypes.array, //return value of getOperators(field)
     handleOnChange: React.PropTypes.func //callback function to update query representation
   }
   ```
@@ -130,6 +132,7 @@ The following components are supported:
   {
     field: React.PropTypes.string, //field name corresponding to this Rule
     operator: React.PropTypes.string, //operator name corresponding to this Rule
+    value: React.PropTypes.string, //value from the existing query representation, if any
     handleOnChange: React.PropTypes.func //callback function to update the query representation
   }
   ```

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ The default set includes:
 #### controls *(Optional)*
 ```js
 React.PropTypes.shape({
+  fieldSelector: React.PropTypes.element,
+  operatorSelector: React.PropTypes.element,
   valueEditor: React.PropTypes.element
 })
 ```
@@ -104,6 +106,24 @@ React.PropTypes.shape({
 This is a custom controls object invoked by the internal `<Rule />` component
 to determine the components to use.
 The following components are supported:
+- `fieldSelector`: By default a `<select />` is used. The following props are passed:
+
+  ```js
+  {
+    className: React.PropTypes.string, //css classNames to be applied
+    options: React.PropTypes.array, //same as 'fields' passed into QueryBuilder
+    handleOnChange: React.PropTypes.func //callback function to update query representation
+  }
+  ```
+- `operatorSelector`: By default a `<select />` is used. The following props are passed:
+
+  ```js
+  {
+    className: React.PropTypes.string, //css classNames to be applied
+    options: React.PropTypes.array, //return value of getOperators(field)
+    handleOnChange: React.PropTypes.func //callback function to update query representation
+  }
+  ```
 - `valueEditor`: By default a `<input type="text" />` is used. The following props are passed:
 
   ```js

--- a/README.md
+++ b/README.md
@@ -94,18 +94,18 @@ The default set includes:
 ]
 ```
 
-#### controls *(Optional)*
+#### controlElements *(Optional)*
 ```js
 React.PropTypes.shape({
-  fieldSelector: React.PropTypes.element,
-  operatorSelector: React.PropTypes.element,
-  valueEditor: React.PropTypes.element
+  fieldSelector: React.PropTypes.func, //returns ReactClass
+  operatorSelector: React.PropTypes.func, //returns ReactClass
+  valueEditor: React.PropTypes.func //returns ReactClass
 })
 ```
 
 This is a custom controls object invoked by the internal `<Rule />` component
 to determine the components to use.
-The following components are supported:
+The following controls are supported:
 - `fieldSelector`: By default a `<select />` is used. The following props are passed:
 
   ```js

--- a/demo/main.js
+++ b/demo/main.js
@@ -23,11 +23,14 @@ class RootView extends React.Component {
     }
 
     render() {
+        let controls = {
+            valueEditor: this.customValueEditor()
+        }
         return (
             <div className="flex-box">
                 <div className="scroll">
                     <QueryBuilder fields={this.props.fields}
-                                  getEditor={this.getEditor}
+                                  controls={controls}
                                   controlClassnames={{fields: 'form-control'}}
                                   onQueryChange={this.logQuery.bind(this)}/>
                 </div>
@@ -39,19 +42,38 @@ class RootView extends React.Component {
         );
     }
 
-    getEditor({field, operator, value, onChange}) {
-        if (field !== 'isDev' || operator !== '=') {
-            return null;
-        }
+    customValueEditor() {
+        class MyCheckbox extends React.Component {
+            constructor(props) {
+                super(props);
+                this.state = {
+                    value: ''
+                }
+            }
 
-        const hasValue = !!value;
-        return (
-            <span>
-            <input type="checkbox"
-                   value={hasValue}
-                   onChange={event=>onChange(event.target.checked)}/>
-        </span>
-        );
+            render() {
+                const hasValue = !!this.state.value;
+                if (this.props.field !== 'isDev' || this.props.operator !== '=') {
+                    return <input type="text"
+                                  value={this.state.value}
+                                  onChange={e=>this._handleOnChange(e.target.value)} />
+                }
+
+                return (
+                    <span>
+                        <input type="checkbox"
+                               value={hasValue}
+                               onChange={e=>this._handleOnChange(e.target.checked)}/>
+                    </span>
+                );
+            }
+
+            _handleOnChange(value) {
+                this.setState({value: value});
+                this.props.handleOnChange(value);
+            }
+        };
+        return (<MyCheckbox />);
     }
 
     logQuery(query) {

--- a/demo/main.js
+++ b/demo/main.js
@@ -46,31 +46,22 @@ class RootView extends React.Component {
         class MyCheckbox extends React.Component {
             constructor(props) {
                 super(props);
-                this.state = {
-                    value: ''
-                }
             }
 
             render() {
-                const hasValue = !!this.state.value;
                 if (this.props.field !== 'isDev' || this.props.operator !== '=') {
                     return <input type="text"
-                                  value={this.state.value}
-                                  onChange={e=>this._handleOnChange(e.target.value)} />
+                                  value={this.props.value}
+                                  onChange={e=>this.props.handleOnChange(e.target.value)} />
                 }
 
                 return (
                     <span>
                         <input type="checkbox"
-                               value={hasValue}
-                               onChange={e=>this._handleOnChange(e.target.checked)}/>
+                               value={!!this.props.value}
+                               onChange={e=>this.props.handleOnChange(e.target.checked)}/>
                     </span>
                 );
-            }
-
-            _handleOnChange(value) {
-                this.setState({value: value});
-                this.props.handleOnChange(value);
             }
         };
         return (<MyCheckbox />);

--- a/demo/main.js
+++ b/demo/main.js
@@ -23,14 +23,14 @@ class RootView extends React.Component {
     }
 
     render() {
-        let controls = {
+        let controlElements = {
             valueEditor: this.customValueEditor()
         }
         return (
             <div className="flex-box">
                 <div className="scroll">
                     <QueryBuilder fields={this.props.fields}
-                                  controls={controls}
+                                  controlElements={controlElements}
                                   controlClassnames={{fields: 'form-control'}}
                                   onQueryChange={this.logQuery.bind(this)}/>
                 </div>
@@ -43,7 +43,7 @@ class RootView extends React.Component {
     }
 
     customValueEditor() {
-        class MyCheckbox extends React.Component {
+        let checkbox = class MyCheckbox extends React.Component {
             constructor(props) {
                 super(props);
             }
@@ -64,7 +64,7 @@ class RootView extends React.Component {
                 );
             }
         };
-        return (<MyCheckbox />);
+        return checkbox;
     }
 
     logQuery(query) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,6 @@
 process.env.BABEL_ENV = 'test'; // Set the proper environment for babel
 const testFileGlob = 'lib/**/*.test.js';
+const testDirectoryGlob = 'test/**/*.js';
 
 
 module.exports = function (config) {
@@ -8,13 +9,15 @@ module.exports = function (config) {
         frameworks: ['mocha', 'chai', 'es6-shim'],
 
         files: [
-            testFileGlob
+            testFileGlob,
+            testDirectoryGlob
         ],
         exclude: [],
 
 
         preprocessors: {
             [testFileGlob]: ['webpack'],
+            [testDirectoryGlob]: ['webpack']
         },
         webpack: require('./config/webpack-test.config'),
         webpackMiddleware: {noInfo: true},

--- a/lib/QueryBuilder.jsx
+++ b/lib/QueryBuilder.jsx
@@ -87,6 +87,8 @@ export default class QueryBuilder extends React.Component {
 
     static get defaultControls() {
         return {
+            fieldSelector: null,
+            operatorSelector: null,
             valueEditor: null
         };
     }

--- a/lib/QueryBuilder.jsx
+++ b/lib/QueryBuilder.jsx
@@ -11,7 +11,7 @@ export default class QueryBuilder extends React.Component {
             fields: [],
             operators: QueryBuilder.defaultOperators,
             combinators: QueryBuilder.defaultCombinators,
-            getEditor: null,
+            controls: QueryBuilder.defaultControls,
             getOperators: null,
             onQueryChange: null,
             controlClassnames: null
@@ -24,7 +24,9 @@ export default class QueryBuilder extends React.Component {
             fields: React.PropTypes.array.isRequired,
             operators: React.PropTypes.array,
             combinators: React.PropTypes.array,
-            getEditor: React.PropTypes.func,
+            controls: React.PropTypes.shape({
+              valueEditor: React.PropTypes.element
+            }),
             getOperators: React.PropTypes.func,
             onQueryChange: React.PropTypes.func,
             controlClassnames: React.PropTypes.object
@@ -83,10 +85,15 @@ export default class QueryBuilder extends React.Component {
         };
     }
 
-    componentWillMount() {
-        const {fields, operators, combinators, controlClassnames} = this.props;
-        const classNames = Object.assign({}, QueryBuilder.defaultControlClassnames, controlClassnames);
+    static get defaultControls() {
+        return {
+            valueEditor: null
+        };
+    }
 
+    componentWillMount() {
+        const {fields, operators, combinators, controls, controlClassnames} = this.props;
+        const classNames = Object.assign({}, QueryBuilder.defaultControlClassnames, controlClassnames);
         this.setState({
             root: this.getInitialQuery(),
             schema: {
@@ -104,7 +111,7 @@ export default class QueryBuilder extends React.Component {
                 onGroupRemove: this._notifyQueryChange.bind(this, this.onGroupRemove),
                 onPropChange: this._notifyQueryChange.bind(this, this.onPropChange),
                 isRuleGroup: this.isRuleGroup.bind(this),
-                getEditor: (...args)=>this.prepareEditor(...args),
+                controls,
                 getOperators: (...args)=>this.getOperators(...args),
             }
         });
@@ -155,26 +162,6 @@ export default class QueryBuilder extends React.Component {
             rules: [],
             combinator: this.props.combinators[0].name,
         };
-    }
-
-
-    prepareEditor(config) {
-        const {value, operator, onChange} = config;
-
-        const editor = this.props.getEditor && this.props.getEditor(config);
-        if (editor) {
-            return editor;
-        }
-
-        if (operator === 'null' || operator === 'notNull') {
-            return null;
-        }
-
-        return (
-            <input type="text"
-                   value={value}
-                   onChange={event=>onChange(event.target.value)}/>
-        );
     }
 
     getOperators(field) {

--- a/lib/QueryBuilder.jsx
+++ b/lib/QueryBuilder.jsx
@@ -2,6 +2,7 @@ import uniqueId from 'lodash/uniqueId';
 import React from 'react';
 
 import RuleGroup from './RuleGroup';
+import { ValueEditor, ValueSelector } from './controls/index';
 
 
 export default class QueryBuilder extends React.Component {
@@ -11,7 +12,7 @@ export default class QueryBuilder extends React.Component {
             fields: [],
             operators: QueryBuilder.defaultOperators,
             combinators: QueryBuilder.defaultCombinators,
-            controls: QueryBuilder.defaultControls,
+            controlElements: null,
             getOperators: null,
             onQueryChange: null,
             controlClassnames: null
@@ -24,8 +25,10 @@ export default class QueryBuilder extends React.Component {
             fields: React.PropTypes.array.isRequired,
             operators: React.PropTypes.array,
             combinators: React.PropTypes.array,
-            controls: React.PropTypes.shape({
-              valueEditor: React.PropTypes.element
+            controlElements: React.PropTypes.shape({
+                fieldSelector: React.PropTypes.func,
+                operatorSelector: React.PropTypes.func,
+                valueEditor: React.PropTypes.func
             }),
             getOperators: React.PropTypes.func,
             onQueryChange: React.PropTypes.func,
@@ -85,17 +88,18 @@ export default class QueryBuilder extends React.Component {
         };
     }
 
-    static get defaultControls() {
+    static get defaultControlElements() {
         return {
-            fieldSelector: null,
-            operatorSelector: null,
-            valueEditor: null
+            fieldSelector: ValueSelector,
+            operatorSelector: ValueSelector,
+            valueEditor: ValueEditor
         };
     }
 
     componentWillMount() {
-        const {fields, operators, combinators, controls, controlClassnames} = this.props;
+        const {fields, operators, combinators, controlElements, controlClassnames} = this.props;
         const classNames = Object.assign({}, QueryBuilder.defaultControlClassnames, controlClassnames);
+        const controls = Object.assign({}, QueryBuilder.defaultControlElements, controlElements);
         this.setState({
             root: this.getInitialQuery(),
             schema: {

--- a/lib/QueryBuilder.test.js
+++ b/lib/QueryBuilder.test.js
@@ -69,6 +69,23 @@ describe('<QueryBuilder />', ()=> {
             expect(rule.find('.rule-fields option')).to.have.length(3);
         });
 
+        it('should have an field selector with the correct field', ()=> {
+            const rule = dom.find('Rule');
+
+            expect(rule.find('.rule-fields').props().value).to.equal('firstName');
+        });
+
+        it('should have an operator selector with the correct operator', ()=> {
+            const rule = dom.find('Rule');
+
+            expect(rule.find('.rule-operators').props().value).to.equal('=');
+        });
+
+        it('should have an input control with the correct value', ()=> {
+            const rule = dom.find('Rule');
+
+            expect(rule.find('input').props().value).to.equal('Test');
+        });
 
     });
 

--- a/lib/Rule.jsx
+++ b/lib/Rule.jsx
@@ -19,19 +19,22 @@ export default class Rule extends React.Component {
         return (
             <div className={`rule ${classNames.rule}`}>
 
-                <ValueSelector className={`rule-fields ${classNames.fields}`}
-                               handleOnChange={this.onValueChanged.bind(this, 'field')}
-                               options={fields}>
+                <ValueSelector options={fields}
+                               value={field}
+                               className={`rule-fields ${classNames.fields}`}
+                               handleOnChange={this.onValueChanged.bind(this, 'field')}>
                     {controls.fieldSelector}
                 </ValueSelector>
-                <ValueSelector className={`rule-operators ${classNames.operators}`}
-                               handleOnChange={this.onValueChanged.bind(this, 'operator')}
-                               options={getOperators(field)}>
+                <ValueSelector options={getOperators(field)}
+                               value={operator}
+                               className={`rule-operators ${classNames.operators}`}
+                               handleOnChange={this.onValueChanged.bind(this, 'operator')}>
                     {controls.operatorSelector}
                 </ValueSelector>
 
                 <ValueEditor field={field}
                              operator={operator}
+                             value={value}
                              handleOnChange={this.onValueChanged.bind(this, 'value')}>
                     {controls.valueEditor}
                 </ValueEditor>

--- a/lib/Rule.jsx
+++ b/lib/Rule.jsx
@@ -18,26 +18,36 @@ export default class Rule extends React.Component {
         const {field, operator, value, schema: {fields, operators, controls, getOperators, classNames}} = this.props;
         return (
             <div className={`rule ${classNames.rule}`}>
-
-                <ValueSelector options={fields}
-                               value={field}
-                               className={`rule-fields ${classNames.fields}`}
-                               handleOnChange={this.onValueChanged.bind(this, 'field')}>
-                    {controls.fieldSelector}
-                </ValueSelector>
-                <ValueSelector options={getOperators(field)}
-                               value={operator}
-                               className={`rule-operators ${classNames.operators}`}
-                               handleOnChange={this.onValueChanged.bind(this, 'operator')}>
-                    {controls.operatorSelector}
-                </ValueSelector>
-
-                <ValueEditor field={field}
-                             operator={operator}
-                             value={value}
-                             handleOnChange={this.onValueChanged.bind(this, 'value')}>
-                    {controls.valueEditor}
-                </ValueEditor>
+                {
+                    React.createElement(controls.fieldSelector,
+                        {
+                            options: fields,
+                            value: field,
+                            className: `rule-fields ${classNames.fields}`,
+                            handleOnChange: this.onValueChanged.bind(this, 'field')
+                        }
+                    )
+                }
+                {
+                    React.createElement(controls.operatorSelector,
+                        {
+                            options: getOperators(field),
+                            value: operator,
+                            className: `rule-operators ${classNames.operators}`,
+                            handleOnChange: this.onValueChanged.bind(this, 'operator')
+                        }
+                    )
+                }
+                {
+                    React.createElement(controls.valueEditor,
+                        {
+                            field: field,
+                            operator: operator,
+                            value: value,
+                            handleOnChange: this.onValueChanged.bind(this, 'value')
+                        }
+                    )
+                }
 
                 <button className={`rule-remove ${classNames.removeRule}`}
                         onClick={event=>this.removeRule(event)}>x

--- a/lib/Rule.jsx
+++ b/lib/Rule.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ValueEditor from './controls/ValueEditor';
+import ValueSelector from './controls/ValueSelector';
 
 export default class Rule extends React.Component {
     static get defaultProps() {
@@ -17,28 +18,17 @@ export default class Rule extends React.Component {
         const {field, operator, value, schema: {fields, operators, controls, getOperators, classNames}} = this.props;
         return (
             <div className={`rule ${classNames.rule}`}>
-                <select className={`rule-fields ${classNames.fields}`}
-                        value={field}
-                        onChange={event=>this.onValueChanged('field', event.target.value)}>
-                        {
-                            fields.map(field=> {
-                                return (
-                                    <option key={field.name} value={field.name}>{field.label}</option>
-                                );
-                            })
-                        }
-                </select>
-                <select className={`rule-operators ${classNames.operators}`}
-                        value={operator}
-                        onChange={event=>this.onValueChanged('operator', event.target.value)}>
-                        {
-                            getOperators(field).map(op=> {
-                                return (
-                                    <option value={op.name} key={op.name}>{op.label}</option>
-                                );
-                            })
-                        }
-                </select>
+
+                <ValueSelector className={`rule-fields ${classNames.fields}`}
+                               handleOnChange={this.onValueChanged.bind(this, 'field')}
+                               options={fields}>
+                    {controls.fieldSelector}
+                </ValueSelector>
+                <ValueSelector className={`rule-operators ${classNames.operators}`}
+                               handleOnChange={this.onValueChanged.bind(this, 'operator')}
+                               options={getOperators(field)}>
+                    {controls.operatorSelector}
+                </ValueSelector>
 
                 <ValueEditor field={field}
                              operator={operator}

--- a/lib/Rule.jsx
+++ b/lib/Rule.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ValueEditor from './controls/ValueEditor';
 
 export default class Rule extends React.Component {
     static get defaultProps() {
@@ -13,8 +14,7 @@ export default class Rule extends React.Component {
     }
 
     render() {
-        const {field, operator, value, schema: {fields, operators, getEditor, getOperators, classNames}} = this.props;
-
+        const {field, operator, value, schema: {fields, operators, controls, getOperators, classNames}} = this.props;
         return (
             <div className={`rule ${classNames.rule}`}>
                 <select className={`rule-fields ${classNames.fields}`}
@@ -40,14 +40,11 @@ export default class Rule extends React.Component {
                         }
                 </select>
 
-                 {
-                     getEditor({
-                         field,
-                         value,
-                         operator,
-                         onChange: value=>this.onValueChanged('value', value)
-                     })
-                 }
+                <ValueEditor field={field}
+                             operator={operator}
+                             handleOnChange={this.onValueChanged.bind(this, 'value')}>
+                    {controls.valueEditor}
+                </ValueEditor>
 
                 <button className={`rule-remove ${classNames.removeRule}`}
                         onClick={event=>this.removeRule(event)}>x

--- a/lib/controls/ValueEditor.jsx
+++ b/lib/controls/ValueEditor.jsx
@@ -5,19 +5,17 @@ export default class ValueEditor extends React.Component {
     return {
       field: React.PropTypes.string,
       operator: React.PropTypes.string,
+      value: React.PropTypes.string,
       handleOnChange: React.PropTypes.func
     };
   }
 
   constructor(props) {
     super(props);
-    this.state = {
-      value: ''
-    }
   }
 
   render() {
-    const {field, operator, children, handleOnChange} = this.props;
+    const {field, operator, value, children, handleOnChange} = this.props;
 
     if (operator === 'null' || operator === 'notNull') {
       return null;
@@ -27,6 +25,7 @@ export default class ValueEditor extends React.Component {
       React.cloneElement(children, {
         field: field,
         operator: operator,
+        value: value,
         handleOnChange: handleOnChange
       }) : this._defaultValueEditor()
     );
@@ -36,13 +35,8 @@ export default class ValueEditor extends React.Component {
   _defaultValueEditor() {
     return (
       <input type="text"
-             value={this.state.value}
-             onChange={e=>this._handleOnChange(e.target.value)} />
+             value={this.props.value}
+             onChange={e=>this.props.handleOnChange(e.target.value)} />
     );
-  }
-
-  _handleOnChange(value) {
-    this.setState({value: value});
-    this.props.handleOnChange(value);
   }
 }

--- a/lib/controls/ValueEditor.jsx
+++ b/lib/controls/ValueEditor.jsx
@@ -15,28 +15,17 @@ export default class ValueEditor extends React.Component {
   }
 
   render() {
-    const {field, operator, value, children, handleOnChange} = this.props;
+    const {field, operator, value, handleOnChange} = this.props;
 
     if (operator === 'null' || operator === 'notNull') {
       return null;
     }
 
-    return (children ?
-      React.cloneElement(children, {
-        field: field,
-        operator: operator,
-        value: value,
-        handleOnChange: handleOnChange
-      }) : this._defaultValueEditor()
-    );
-
-  }
-
-  _defaultValueEditor() {
     return (
       <input type="text"
-             value={this.props.value}
-             onChange={e=>this.props.handleOnChange(e.target.value)} />
+             value={value}
+             onChange={e=>handleOnChange(e.target.value)} />
     );
+
   }
 }

--- a/lib/controls/ValueEditor.jsx
+++ b/lib/controls/ValueEditor.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+export default class ValueEditor extends React.Component {
+  static get propTypes() {
+    return {
+      field: React.PropTypes.string,
+      operator: React.PropTypes.string,
+      handleOnChange: React.PropTypes.func
+    };
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: ''
+    }
+  }
+
+  render() {
+    const {field, operator, children, handleOnChange} = this.props;
+
+    if (operator === 'null' || operator === 'notNull') {
+      return null;
+    }
+
+    return (children ?
+      React.cloneElement(children, {
+        field: field,
+        operator: operator,
+        handleOnChange: handleOnChange
+      }) : this._defaultValueEditor()
+    );
+
+  }
+
+  _defaultValueEditor() {
+    return (
+      <input type="text"
+             value={this.state.value}
+             onChange={e=>this._handleOnChange(e.target.value)} />
+    );
+  }
+
+  _handleOnChange(value) {
+    this.setState({value: value});
+    this.props.handleOnChange(value);
+  }
+}

--- a/lib/controls/ValueSelector.jsx
+++ b/lib/controls/ValueSelector.jsx
@@ -15,27 +15,14 @@ export default class ValueSelector extends React.Component {
   }
 
   render() {
-    const {value, options, className, handleOnChange, children} = this.props;
+    const {value, options, className, handleOnChange} = this.props;
 
-    return (children ?
-      React.cloneElement(children,
-        {
-          value: value,
-          options: options,
-          className: className,
-          handleOnChange: handleOnChange
-        }
-      ) : this._defaultValueSelector()
-    );
-  }
-
-  _defaultValueSelector() {
     return (
-      <select className={this.props.className}
-              value={this.props.value}
-              onChange={e=>this.props.handleOnChange(e.target.value)}>
+      <select className={className}
+              value={value}
+              onChange={e=>handleOnChange(e.target.value)}>
         {
-          this.props.options.map(option=> {
+          options.map(option=> {
             return (
               <option key={option.name} value={option.name}>{option.label}</option>
             );

--- a/lib/controls/ValueSelector.jsx
+++ b/lib/controls/ValueSelector.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+export default class ValueSelector extends React.Component {
+  static get propTypes() {
+    return {
+      options: React.PropTypes.array.isRequired,
+      className: React.PropTypes.string,
+      handleOnChange: React.PropTypes.func
+    }
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: ''
+    }
+  }
+
+  render() {
+    const {options, className, handleOnChange, children} = this.props;
+
+    return (children ?
+      React.cloneElement(children,
+        {
+          options: options,
+          className: className,
+          handleOnChange: handleOnChange
+        }
+      ) : this._defaultValueSelector()
+    );
+  }
+
+  _defaultValueSelector() {
+    return (
+      <select className={this.props.className}
+              value={this.state.value}
+              onChange={e=>this._handleOnChange(e.target.value)}>
+        {
+          this.props.options.map(option=> {
+            return (
+              <option key={option.name} value={option.name}>{option.label}</option>
+            );
+          })
+        }
+      </select>
+    );
+  }
+
+  _handleOnChange(value) {
+    this.setState({value: value});
+    this.props.handleOnChange(value);
+  }
+}

--- a/lib/controls/ValueSelector.jsx
+++ b/lib/controls/ValueSelector.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 export default class ValueSelector extends React.Component {
   static get propTypes() {
     return {
+      value: React.PropTypes.string,
       options: React.PropTypes.array.isRequired,
       className: React.PropTypes.string,
       handleOnChange: React.PropTypes.func
@@ -11,17 +12,15 @@ export default class ValueSelector extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {
-      value: ''
-    }
   }
 
   render() {
-    const {options, className, handleOnChange, children} = this.props;
+    const {value, options, className, handleOnChange, children} = this.props;
 
     return (children ?
       React.cloneElement(children,
         {
+          value: value,
           options: options,
           className: className,
           handleOnChange: handleOnChange
@@ -33,8 +32,8 @@ export default class ValueSelector extends React.Component {
   _defaultValueSelector() {
     return (
       <select className={this.props.className}
-              value={this.state.value}
-              onChange={e=>this._handleOnChange(e.target.value)}>
+              value={this.props.value}
+              onChange={e=>this.props.handleOnChange(e.target.value)}>
         {
           this.props.options.map(option=> {
             return (
@@ -44,10 +43,5 @@ export default class ValueSelector extends React.Component {
         }
       </select>
     );
-  }
-
-  _handleOnChange(value) {
-    this.setState({value: value});
-    this.props.handleOnChange(value);
   }
 }

--- a/lib/controls/index.js
+++ b/lib/controls/index.js
@@ -1,1 +1,2 @@
 export {default as ValueEditor} from './ValueEditor';
+export {default as ValueSelector} from './ValueSelector';

--- a/lib/controls/index.js
+++ b/lib/controls/index.js
@@ -1,0 +1,1 @@
+export {default as ValueEditor} from './ValueEditor';

--- a/test/controls/ValueEditor.js
+++ b/test/controls/ValueEditor.js
@@ -15,6 +15,11 @@ describe('<ValueEditor />', ()=> {
             expect(dom.find('input')).to.have.length(1);
         });
 
+        it('should have the value passed into the <input />', ()=> {
+            const dom = shallow(<ValueEditor value='test'/>);
+            expect(dom.find('input').props().value).to.equal('test');
+        });
+
         it('should render nothing for operator "null"', ()=> {
             const dom = shallow(<ValueEditor operator="null" />);
             expect(dom.type()).to.be.null;

--- a/test/controls/ValueEditor.js
+++ b/test/controls/ValueEditor.js
@@ -40,18 +40,4 @@ describe('<ValueEditor />', ()=> {
             expect(count).to.equal(1);
         });
     });
-
-    describe('when a custom component is used', ()=> {
-        class MyComponent extends React.Component {
-            render() {
-                return(<div />);
-            }
-        };
-
-        it('should render the custom component', ()=> {
-            const dom = mount(<ValueEditor><MyComponent /></ValueEditor>);
-            expect(dom.find('input')).to.have.length(0);
-            expect(dom.find('div')).to.have.length(1);
-        });
-    });
 });

--- a/test/controls/ValueEditor.js
+++ b/test/controls/ValueEditor.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+
+import { ValueEditor } from '../../lib/controls/index';
+
+describe('<ValueEditor />', ()=> {
+
+    it('should exist', ()=> {
+        expect(ValueEditor).to.exist;
+    });
+
+    describe('when using default rendering', ()=> {
+        it('should have an <input /> element', ()=> {
+            const dom = shallow(<ValueEditor />);
+            expect(dom.find('input')).to.have.length(1);
+        });
+
+        it('should render nothing for operator "null"', ()=> {
+            const dom = shallow(<ValueEditor operator="null" />);
+            expect(dom.type()).to.be.null;
+        });
+
+        it('should render nothing for operator "notNull"', ()=> {
+            const dom = shallow(<ValueEditor operator="notNull" />);
+            expect(dom.type()).to.be.null;
+        });
+
+        it('should call the onChange method passed in', ()=> {
+            let count = 0;
+            const mockEvent = {target:{value:"foo"}};
+            const onChange = ()=>count++;
+            const dom = shallow(<ValueEditor handleOnChange={onChange} />);
+
+            dom.find('input').simulate('change', mockEvent);
+            expect(count).to.equal(1);
+        });
+    });
+
+    describe('when a custom component is used', ()=> {
+        class MyComponent extends React.Component {
+            render() {
+                return(<div />);
+            }
+        };
+
+        it('should render the custom component', ()=> {
+            const dom = mount(<ValueEditor><MyComponent /></ValueEditor>);
+            expect(dom.find('input')).to.have.length(0);
+            expect(dom.find('div')).to.have.length(1);
+        });
+    });
+});

--- a/test/controls/ValueSelector.js
+++ b/test/controls/ValueSelector.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+
+import { ValueSelector } from '../../lib/controls/index';
+
+describe('<ValueSelector />', ()=> {
+
+    it('should exist', ()=> {
+        expect(ValueSelector).to.exist;
+    });
+
+    describe('when using default rendering', ()=> {
+        const options = [
+            {name: "foo", label: "foo label"},
+            {name: "bar", label: "bar label"}
+        ]
+
+        it('should have an <select /> element', ()=> {
+            const dom = shallow(<ValueSelector options={options}/>);
+            expect(dom.find('select')).to.have.length(1);
+        });
+
+        it('should have the options passed into the <select />', ()=> {
+            const dom = shallow(<ValueSelector options={options} />);
+            expect(dom.find('option')).to.have.length(2);
+        });
+
+        it('should have the className passed into the <select />', ()=> {
+            const dom = shallow(<ValueSelector options={options} className='foo bar'/>);
+            expect(dom.find('select').props().className).to.equal('foo bar');
+        });
+
+        it('should call the onChange method passed in', ()=> {
+            let count = 0;
+            const mockEvent = {target:{value:"foo"}};
+            const onChange = ()=>count++;
+            const dom = shallow(<ValueSelector options={options} handleOnChange={onChange} />);
+
+            dom.find('select').simulate('change', mockEvent);
+            expect(count).to.equal(1);
+        });
+    });
+
+    describe('when a custom component is used', ()=> {
+        class MyComponent extends React.Component {
+            render() {
+                return(<div />);
+            }
+        };
+
+        it('should render the custom component', ()=> {
+            const dom = mount(<ValueSelector options={[]}><MyComponent /></ValueSelector>);
+            expect(dom.find('select')).to.have.length(0);
+            expect(dom.find('div')).to.have.length(1);
+        });
+    });
+});

--- a/test/controls/ValueSelector.js
+++ b/test/controls/ValueSelector.js
@@ -25,6 +25,11 @@ describe('<ValueSelector />', ()=> {
             expect(dom.find('option')).to.have.length(2);
         });
 
+        it('should have the value passed into the <select />', ()=> {
+            const dom = shallow(<ValueSelector options={options} value='foo'/>);
+            expect(dom.find('select').props().value).to.equal('foo');
+        });
+
         it('should have the className passed into the <select />', ()=> {
             const dom = shallow(<ValueSelector options={options} className='foo bar'/>);
             expect(dom.find('select').props().className).to.equal('foo bar');

--- a/test/controls/ValueSelector.js
+++ b/test/controls/ValueSelector.js
@@ -45,18 +45,4 @@ describe('<ValueSelector />', ()=> {
             expect(count).to.equal(1);
         });
     });
-
-    describe('when a custom component is used', ()=> {
-        class MyComponent extends React.Component {
-            render() {
-                return(<div />);
-            }
-        };
-
-        it('should render the custom component', ()=> {
-            const dom = mount(<ValueSelector options={[]}><MyComponent /></ValueSelector>);
-            expect(dom.find('select')).to.have.length(0);
-            expect(dom.find('div')).to.have.length(1);
-        });
-    });
 });


### PR DESCRIPTION
Adds in the ability to customize the components used for the controls for the <select /> and <input /> elements in the <Rule /> element.

Can be utilized similar to how the `getEditor` command worked before:

``` js
//create a custom component that has access to the original props
class MyCustomComponent extends React.Component {
  render() {
    return(<div />);
  }
}

//make a controls object
const controls = {
  valueEditor: <MyCustomComponent />
}

//pass it into the QueryBuilder
<QueryBuilder fields={[]} controls={controls} />
```

Addresses #2 
