### PR TITLE
Types: Added id attribute to RuleGroup

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ interface Rule {
 type AndOr = 'and' | 'or';
 
 interface RuleGroup {
+    id: string;
     combinator: AndOr;
     rules: Rule[] | RuleGroup;
 }


### PR DESCRIPTION
Missed one attribute in the type definition for RuleGroup.