### PR TITLE
Pass options to value editor

### DIFF
--- a/src/Rule.jsx
+++ b/src/Rule.jsx
@@ -46,6 +46,7 @@ export default class Rule extends React.Component {
                     React.createElement(controls.valueEditor,
                         {
                             field: field,
+                            options: options,
                             title: translations.value.title,
                             operator: operator,
                             value: value,


### PR DESCRIPTION
If `options` is an array such as [{ name: "field 1", type: "number" },{ name: "field 2", type: "string" }], exposing `options` to the valueEditor would allow custom rendering depending upon the option chosen, such as a numeric slider or a dropdown of options