### PR TITLE
Improve tests

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "semi": true,
+  "printWidth": 100,
+  "parser": "babylon",
+  "singleQuote": true,
+  "trailingComma": "none",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": true,
+  "arrowParens": "always"
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,52 +1,72 @@
 <html>
-
-<head>
+  <head>
     <title>React Query Builder</title>
     <style>
-        html,
-        body {
-            height: 100%;
-            margin: 0;
-            padding: 0;
-        }
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+        padding: 0;
+      }
 
-        .set-changer {
-          margin-bottom: 20px;
-        }
+      .set-changer {
+        margin-bottom: 20px;
+      }
 
-        .flex-box-outer {
-          padding: 20px;
-        }
+      .flex-box-outer {
+        padding: 20px;
+      }
 
-        .flex-box {
-            display: flex;
-        }
+      .flex-box {
+        display: flex;
+      }
 
-        .flex-box > * {
-            flex: 1;
-        }
+      .flex-box > * {
+        flex: 1;
+      }
 
-        .scroll {
-            overflow: auto;
-        }
+      .scroll {
+        overflow: auto;
+      }
 
-        .shrink {
-            flex: 0 1 auto;
-        }
+      .shrink {
+        flex: 0 1 auto;
+      }
 
-        .query-log {
-            font-family: Consolas, "Courier New", monospace;
-            white-space: nowrap;
-            max-width: 400px;
-            margin-left: 2rem;
-        }
+      .query-log {
+        font-family: Consolas, "Courier New", monospace;
+        white-space: nowrap;
+        max-width: 400px;
+        margin-left: 2rem;
+      }
+
+      .queryBuilder {
+        min-width: 405px;
+      }
+
+      .control-panel button {
+        color: #888;
+        font-size: 14px;
+        padding: 10px 15px;
+        margin-right: 10px;
+        cursor: pointer;
+        border-radius: 3px;
+        border: none;
+        background-color: #f1f1f1;
+      }
+
+      .control-panel button:hover {
+        color: #000;
+        background-color: #eaeaea;
+      }
+
+      hr {
+        border: 1px solid #eee;
+        margin-bottom: 15px;
+      }
     </style>
-</head>
-
-<body class="flex-box">
-
-<div class="container flex-box"></div>
-
-</body>
-
+  </head>
+  <body class="flex-box">
+    <div class="container flex-box"></div>
+  </body>
 </html>

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,135 +1,130 @@
 import '../src/query-builder.scss';
 import QueryBuilder from '../src/index';
-import ReactDOM from "react-dom";
+import ReactDOM from 'react-dom';
 import React from 'react';
 
-const fields1 = [
-    {name: 'firstName', label: 'First Name'},
-    {name: 'lastName', label: 'Last Name'},
-    {name: 'age', label: 'Age'},
-    {name: 'address', label: 'Address'},
-    {name: 'phone', label: 'Phone'},
-    {name: 'email', label: 'Email'},
-    {name: 'twitter', label: 'Twitter'},
-    {name: 'isDev', label: 'Is a Developer?', value: false},
-];
+const preparedFields = {
+  primary: [{ name: 'firstName', label: 'First Name' }, { name: 'lastName', label: 'Last Name' }],
+  secondary: [
+    { name: 'age', label: 'Age' },
+    { name: 'isMusician', label: 'Is a musician' },
+    { name: 'instrument', label: 'Instrument' }
+  ],
+  generic: [
+    { name: 'firstName', label: 'First name' },
+    { name: 'lastName', label: 'Last name' },
+    { name: 'age', label: 'Age' },
+    { name: 'gender', label: 'Gender' },
+    { name: 'height', label: 'Height' },
+    { name: 'job', label: 'Job' }
+  ]
+};
 
-const fields2 = [
-    {name: 'contactFirstName', label: 'Contact First Name'},
-    {name: 'contactLastName', label: 'Contact Last Name'},
-    {name: 'contactEmail', label: 'Contact Email'},
-];
-
-const fieldQuerySets = {
-    set1: {
-        fields: fields1,
-        query: {
-            "id": "g-fe7a7130-9d9f-4ec8-b5d3-79b5f0aff350",
-            "rules": [
-                {
-                    "id": "r-2c153586-5044-4ceb-9f36-cee6b06b035f",
-                    "field": "firstName",
-                    "value": "Steve",
-                    "operator": "="
-                }
-            ],
-            "combinator": "and"
-        }
-    },
-
-     set2: {
-        fields: fields2,
-        query: {
-            "rules": [
-                {
-                    "field": "contactFirstName",
-                    "value": "Sally",
-                    "operator": "="
-                }
-            ],
-            "combinator": "and"
-        }
-    }
+const preparedQueries = {
+  primary: {
+    id: 'g-8953ed65-f5ff-4b77-8d03-8d8788beb50b',
+    rules: [
+      {
+        id: 'r-32ef0844-07e3-4f3b-aeca-3873da3e208b',
+        field: 'firstName',
+        value: 'Steve',
+        operator: '='
+      },
+      {
+        id: 'r-3db9ba21-080d-4a5e-b4da-d949b4ad055b',
+        field: 'lastName',
+        value: 'Vai',
+        operator: '='
+      }
+    ],
+    combinator: 'and'
+  },
+  secondary: {
+    id: 'g-15e72d98-557f-4a09-af90-6d7afc05b0f7',
+    rules: [
+      {
+        field: 'age',
+        id: 'r-45b166dd-d69a-4008-9587-fe796aeda496',
+        operator: '>',
+        value: '28'
+      },
+      {
+        field: 'isMusician',
+        id: 'r-db6fded6-bd8c-4b4f-9a33-a00f7417a9a9',
+        operator: '=',
+        value: 'true'
+      },
+      {
+        field: 'instrument',
+        id: 'r-df23ba2b-e600-491d-967c-116ade6fe45e',
+        operator: '=',
+        value: 'Guitar'
+      }
+    ],
+    combinator: 'or'
+  },
+  generic: {
+    combinator: 'and',
+    rules: []
+  }
 };
 
 class RootView extends React.Component {
-    constructor() {
-        super();
-        this.state = {
-            query: {
-                set1: fieldQuerySets.set1.query,
-                set2: fieldQuerySets.set2.query
-            },
-            fields: {
-                set1:fieldQuerySets.set1.fields,
-                set2:fieldQuerySets.set2.fields
-            },
-            currentSet: "set1"
-        };
+  constructor(props) {
+    super(props);
+    this.handleQueryChange = this.handleQueryChange.bind(this);
+    this.state = {
+      query: preparedQueries.primary,
+      fields: preparedFields.primary
+    };
+  }
+
+  // Reloads a prepared query, a PoC for query updates by props change.
+  // If no target is supplied, clear query (generic query).
+  loadQuery(target) {
+    if (target) {
+      this.setState({
+        query: preparedQueries[target],
+        fields: preparedFields[target]
+      });
+    } else {
+      this.setState({
+        query: preparedQueries.generic,
+        fields: preparedFields.generic
+      });
     }
+  }
 
-    handleChange = (e) =>{
-        e.persist();
-        this.setState((prevState) => ({ currentSet: e.target.value }));
-    }
+  handleQueryChange(query) {
+    this.setState({ query });
+  }
 
-    render() {
-        let controlElements = {
-            valueEditor: this.customValueEditor()
-        }
-        const { currentSet } = this.state;
-
-        return (
-            <div className='flex-box-outer'>
-                <select className='set-changer' name="fieldToggle" value={this.state.currentSet} onChange={this.handleChange}>
-                    <option value="set1">Set 1</option>
-                    <option value="set2">Set 2</option>
-                </select>
-                <div className="flex-box">
-                    <div className="scroll">
-                        <QueryBuilder
-                            query={ this.state.query[currentSet]}
-                            fields={this.state.fields[currentSet]}
-                            controlElements={controlElements}
-                            controlClassnames={{fields: 'form-control'}}
-                            onQueryChange={this.logQuery.bind(this)}/>
-                    </div>
-                    <div className="shrink query-log scroll">
-                        <h4>Query</h4>
-                        <pre>{JSON.stringify(this.state.query[this.state.currentSet], null, 2)}</pre>
-                    </div>
-                </div>
-            </div>
-        );
-    }
-
-    customValueEditor() {
-        let checkbox = class MyCheckbox extends React.Component {
-            render() {
-                if (this.props.field !== 'isDev' || this.props.operator !== '=') {
-                    return <input type="text"
-                                  value={this.props.value}
-                                  onChange={e => this.props.handleOnChange(e.target.value)} />
-                }
-
-                return (
-                    <span>
-                        <input type="checkbox"
-                               value={!!this.props.value}
-                               onChange={e => this.props.handleOnChange(e.target.checked)} />
-                    </span>
-                );
-            }
-        };
-        return checkbox;
-    }
-
-    logQuery(query) {
-        const currentQuery = {...this.state.query[this.state.currentSet]}
-        currentQuery.query = query;
-        this.setState({ currentQuery  });
-    }
-
+  render() {
+    return (
+      <div className="flex-box-outer">
+        <div className="control-panel">
+          <button onClick={() => this.loadQuery('primary')}>Load primary query</button>
+          <button onClick={() => this.loadQuery('secondary')}>Load secondary query</button>
+          <button onClick={() => this.loadQuery()}>Clear query</button>
+        </div>
+        <hr />
+        <div className="flex-box">
+          <div className="scroll">
+            <QueryBuilder
+              query={this.state.query}
+              fields={this.state.fields}
+              controlClassnames={{ fields: 'form-control' }}
+              onQueryChange={this.handleQueryChange}
+            />
+          </div>
+          <div className="shrink query-log scroll">
+            <h4>Query</h4>
+            <pre>{JSON.stringify(this.state.query, null, 2)}</pre>
+          </div>
+        </div>
+      </div>
+    );
+  }
 }
 
 ReactDOM.render(<RootView />, document.querySelector('.container'));

--- a/src/QueryBuilder.jsx
+++ b/src/QueryBuilder.jsx
@@ -143,19 +143,17 @@ export default class QueryBuilder extends React.Component {
         };
     }
 
-
     componentWillReceiveProps(nextProps) {
-        let schema  = {...this.state.schema};
+        let schema  = { ...this.state.schema };
 
-         if (this.props.query !== nextProps.query) {
-             this.setState({ root: this.generateValidQuery(nextProps.query) });
-         }
+        if (this.props.query !== nextProps.query) {
+            this.setState({ root: this.generateValidQuery(nextProps.query) });
+        }
 
-         if(schema.fields !== nextProps.fields){
-             schema.fields = nextProps.fields;
-              this.setState({ schema });
-         }
-
+        if (schema.fields !== nextProps.fields) {
+            schema.fields = nextProps.fields;
+            this.setState({ schema });
+        }
     }
 
     componentWillMount() {

--- a/src/QueryBuilder.jsx
+++ b/src/QueryBuilder.jsx
@@ -2,7 +2,6 @@ import uniqueId from 'uuid/v4';
 import cloneDeep from 'lodash/cloneDeep';
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import RuleGroup from './RuleGroup';
 import { ActionElement, ValueEditor, ValueSelector } from './controls/index';
 
@@ -227,13 +226,14 @@ export default class QueryBuilder extends React.Component {
   }
 
   createRule() {
-    const { fields, operators } = this.state.schema;
+    const { fields } = this.state.schema;
+    const field = fields[0].name;
 
     return {
       id: `r-${uniqueId()}`,
-      field: fields[0].name,
+      field,
       value: '',
-      operator: operators[0].name
+      operator: this.getOperators(field)[0].name
     };
   }
 
@@ -248,9 +248,7 @@ export default class QueryBuilder extends React.Component {
   getOperators(field) {
     if (this.props.getOperators) {
       const ops = this.props.getOperators(field);
-      if (ops) {
-        return ops;
-      }
+      if (ops) return ops;
     }
 
     return this.props.operators;
@@ -273,6 +271,11 @@ export default class QueryBuilder extends React.Component {
   onPropChange(prop, value, ruleId) {
     const rule = this._findRule(ruleId, this.state.root);
     Object.assign(rule, { [prop]: value });
+
+    // Reset operator and value for field change
+    if (prop === 'field') {
+      Object.assign(rule, { operator: this.getOperators(rule.field)[0].name, value: '' });
+    }
 
     this.setState({ root: this.state.root });
   }

--- a/src/QueryBuilder.jsx
+++ b/src/QueryBuilder.jsx
@@ -7,351 +7,342 @@ import RuleGroup from './RuleGroup';
 import { ActionElement, ValueEditor, ValueSelector } from './controls/index';
 
 export default class QueryBuilder extends React.Component {
-    static get defaultProps() {
-        return {
-            query: null,
-            fields: [],
-            operators: QueryBuilder.defaultOperators,
-            combinators: QueryBuilder.defaultCombinators,
-            translations: QueryBuilder.defaultTranslations,
-            controlElements: null,
-            getOperators: null,
-            onQueryChange: null,
-            controlClassnames: null
-        };
+  static get defaultProps() {
+    return {
+      query: null,
+      fields: [],
+      operators: QueryBuilder.defaultOperators,
+      combinators: QueryBuilder.defaultCombinators,
+      translations: QueryBuilder.defaultTranslations,
+      controlElements: null,
+      getOperators: null,
+      onQueryChange: null,
+      controlClassnames: null
+    };
+  }
+
+  static get propTypes() {
+    return {
+      query: PropTypes.object,
+      fields: PropTypes.array.isRequired,
+      operators: PropTypes.array,
+      combinators: PropTypes.array,
+      controlElements: PropTypes.shape({
+        addGroupAction: PropTypes.func,
+        removeGroupAction: PropTypes.func,
+        addRuleAction: PropTypes.func,
+        removeRuleAction: PropTypes.func,
+        combinatorSelector: PropTypes.func,
+        fieldSelector: PropTypes.func,
+        operatorSelector: PropTypes.func,
+        valueEditor: PropTypes.func
+      }),
+      getOperators: PropTypes.func,
+      onQueryChange: PropTypes.func,
+      controlClassnames: PropTypes.object,
+      translations: PropTypes.object
+    };
+  }
+
+  constructor(...args) {
+    super(...args);
+    this.state = {
+      root: {},
+      schema: {}
+    };
+  }
+
+  static get defaultTranslations() {
+    return {
+      fields: {
+        title: 'Fields'
+      },
+      operators: {
+        title: 'Operators'
+      },
+      value: {
+        title: 'Value'
+      },
+      removeRule: {
+        label: 'x',
+        title: 'Remove rule'
+      },
+      removeGroup: {
+        label: 'x',
+        title: 'Remove group'
+      },
+      addRule: {
+        label: '+Rule',
+        title: 'Add rule'
+      },
+      addGroup: {
+        label: '+Group',
+        title: 'Add group'
+      },
+      combinators: {
+        title: 'Combinators'
+      }
+    };
+  }
+
+  static get defaultOperators() {
+    return [
+      { name: 'null', label: 'Is Null' },
+      { name: 'notNull', label: 'Is Not Null' },
+      { name: 'in', label: 'In' },
+      { name: 'notIn', label: 'Not In' },
+      { name: '=', label: '=' },
+      { name: '!=', label: '!=' },
+      { name: '<', label: '<' },
+      { name: '>', label: '>' },
+      { name: '<=', label: '<=' },
+      { name: '>=', label: '>=' }
+    ];
+  }
+
+  static get defaultCombinators() {
+    return [{ name: 'and', label: 'AND' }, { name: 'or', label: 'OR' }];
+  }
+
+  static get defaultControlClassnames() {
+    return {
+      queryBuilder: '',
+
+      ruleGroup: '',
+      combinators: '',
+      addRule: '',
+      addGroup: '',
+      removeGroup: '',
+
+      rule: '',
+      fields: '',
+      operators: '',
+      value: '',
+      removeRule: ''
+    };
+  }
+
+  static get defaultControlElements() {
+    return {
+      addGroupAction: ActionElement,
+      removeGroupAction: ActionElement,
+      addRuleAction: ActionElement,
+      removeRuleAction: ActionElement,
+      combinatorSelector: ValueSelector,
+      fieldSelector: ValueSelector,
+      operatorSelector: ValueSelector,
+      valueEditor: ValueEditor
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    let schema = { ...this.state.schema };
+
+    if (this.props.query !== nextProps.query) {
+      this.setState({ root: this.generateValidQuery(nextProps.query) });
     }
 
-    static get propTypes() {
-        return {
-            query: PropTypes.object,
-            fields: PropTypes.array.isRequired,
-            operators: PropTypes.array,
-            combinators: PropTypes.array,
-            controlElements: PropTypes.shape({
-                addGroupAction: PropTypes.func,
-                removeGroupAction: PropTypes.func,
-                addRuleAction: PropTypes.func,
-                removeRuleAction: PropTypes.func,
-                combinatorSelector: PropTypes.func,
-                fieldSelector: PropTypes.func,
-                operatorSelector: PropTypes.func,
-                valueEditor: PropTypes.func
-            }),
-            getOperators: PropTypes.func,
-            onQueryChange: PropTypes.func,
-            controlClassnames: PropTypes.object,
-            translations: PropTypes.object
-        };
+    if (schema.fields !== nextProps.fields) {
+      schema.fields = nextProps.fields;
+      this.setState({ schema });
+    }
+  }
+
+  componentWillMount() {
+    const { fields, operators, combinators, controlElements, controlClassnames } = this.props;
+    const classNames = Object.assign({}, QueryBuilder.defaultControlClassnames, controlClassnames);
+    const controls = Object.assign({}, QueryBuilder.defaultControlElements, controlElements);
+    this.setState({
+      root: this.getInitialQuery(),
+      schema: {
+        fields,
+        operators,
+        combinators,
+        classNames,
+        createRule: this.createRule.bind(this),
+        createRuleGroup: this.createRuleGroup.bind(this),
+        onRuleAdd: this._notifyQueryChange.bind(this, this.onRuleAdd),
+        onGroupAdd: this._notifyQueryChange.bind(this, this.onGroupAdd),
+        onRuleRemove: this._notifyQueryChange.bind(this, this.onRuleRemove),
+        onGroupRemove: this._notifyQueryChange.bind(this, this.onGroupRemove),
+        onPropChange: this._notifyQueryChange.bind(this, this.onPropChange),
+        getLevel: this.getLevel.bind(this),
+        isRuleGroup: this.isRuleGroup.bind(this),
+        controls,
+        getOperators: (...args) => this.getOperators(...args)
+      }
+    });
+  }
+
+  generateValidQuery(query) {
+    if (this.isRuleGroup(query)) {
+      return {
+        id: query.id || `g-${uniqueId()}`,
+        rules: query.rules.map((rule) => this.generateValidQuery(rule)),
+        combinator: query.combinator
+      };
+    }
+    return {
+      id: query.id || `r-${uniqueId()}`,
+      ...query
+    };
+  }
+
+  getInitialQuery() {
+    const { query } = this.props;
+    return (query && this.generateValidQuery(query)) || this.createRuleGroup();
+
+    // TODO: If we replace the above line with the below line, a test should fail.
+    // Must properly test that IDs exist, since we use them to generate component keys.
+    // return query || this.createRuleGroup();
+  }
+
+  componentDidMount() {
+    this._notifyQueryChange(null);
+  }
+
+  render() {
+    const {
+      root: { id, rules, combinator },
+      schema
+    } = this.state;
+    const { translations } = this.props;
+
+    return (
+      <div className={`queryBuilder ${schema.classNames.queryBuilder}`}>
+        <RuleGroup
+          translations={translations}
+          rules={rules}
+          combinator={combinator}
+          schema={schema}
+          id={id}
+          parentId={null}
+        />
+      </div>
+    );
+  }
+
+  isRuleGroup(rule) {
+    return !!(rule.combinator && rule.rules);
+  }
+
+  createRule() {
+    const { fields, operators } = this.state.schema;
+
+    return {
+      id: `r-${uniqueId()}`,
+      field: fields[0].name,
+      value: '',
+      operator: operators[0].name
+    };
+  }
+
+  createRuleGroup() {
+    return {
+      id: `g-${uniqueId()}`,
+      rules: [],
+      combinator: this.props.combinators[0].name
+    };
+  }
+
+  getOperators(field) {
+    if (this.props.getOperators) {
+      const ops = this.props.getOperators(field);
+      if (ops) {
+        return ops;
+      }
     }
 
+    return this.props.operators;
+  }
 
-    constructor(...args) {
-        super(...args);
-        this.state = {
-            root: {},
-            schema: {},
-        };
-    }
+  onRuleAdd(rule, parentId) {
+    const parent = this._findRule(parentId, this.state.root);
+    parent.rules.push(rule);
 
-    static get defaultTranslations() {
+    this.setState({ root: this.state.root });
+  }
 
-        return {
-            fields: {
-                title: "Fields",
-            },
-            operators: {
-                title: "Operators",
-            },
-            value: {
-                title: "Value",
-            },
-            removeRule: {
-                label: "x",
-                title: "Remove rule",
-            },
-            removeGroup: {
-                label: "x",
-                title: "Remove group",
-            },
-            addRule: {
-                label: "+Rule",
-                title: "Add rule",
-            },
-            addGroup: {
-                label: "+Group",
-                title: "Add group",
-            },
-            combinators: {
-                title: "Combinators",
-            }
+  onGroupAdd(group, parentId) {
+    const parent = this._findRule(parentId, this.state.root);
+    parent.rules.push(group);
+
+    this.setState({ root: this.state.root });
+  }
+
+  onPropChange(prop, value, ruleId) {
+    const rule = this._findRule(ruleId, this.state.root);
+    Object.assign(rule, { [prop]: value });
+
+    this.setState({ root: this.state.root });
+  }
+
+  onRuleRemove(ruleId, parentId) {
+    const parent = this._findRule(parentId, this.state.root);
+    const index = parent.rules.findIndex((x) => x.id === ruleId);
+
+    parent.rules.splice(index, 1);
+    this.setState({ root: this.state.root });
+  }
+
+  onGroupRemove(groupId, parentId) {
+    const parent = this._findRule(parentId, this.state.root);
+    const index = parent.rules.findIndex((x) => x.id === groupId);
+
+    parent.rules.splice(index, 1);
+    this.setState({ root: this.state.root });
+  }
+
+  getLevel(id) {
+    return this._getLevel(id, 0, this.state.root);
+  }
+
+  _getLevel(id, index, root) {
+    const { isRuleGroup } = this.state.schema;
+
+    var foundAtIndex = -1;
+    if (root.id === id) {
+      foundAtIndex = index;
+    } else if (isRuleGroup(root)) {
+      root.rules.forEach((rule) => {
+        if (foundAtIndex === -1) {
+          var indexForRule = index;
+          if (isRuleGroup(rule)) indexForRule++;
+          foundAtIndex = this._getLevel(id, indexForRule, rule);
         }
+      });
+    }
+    return foundAtIndex;
+  }
+
+  _findRule(id, parent) {
+    const { isRuleGroup } = this.state.schema;
+
+    if (parent.id === id) {
+      return parent;
     }
 
-    static get defaultOperators() {
-
-        return [
-            {name: 'null', label: 'Is Null'},
-            {name: 'notNull', label: 'Is Not Null'},
-            {name: 'in', label: 'In'},
-            {name: 'notIn', label: 'Not In'},
-            {name: '=', label: '='},
-            {name: '!=', label: '!='},
-            {name: '<', label: '<'},
-            {name: '>', label: '>'},
-            {name: '<=', label: '<='},
-            {name: '>=', label: '>='},
-        ];
-    }
-
-    static get defaultCombinators() {
-
-        return [
-            {name: 'and', label: 'AND'},
-            {name: 'or', label: 'OR'},
-        ];
-    }
-
-    static get defaultControlClassnames() {
-        return {
-            queryBuilder: '',
-
-            ruleGroup: '',
-            combinators: '',
-            addRule: '',
-            addGroup: '',
-            removeGroup: '',
-
-            rule: '',
-            fields: '',
-            operators: '',
-            value: '',
-            removeRule: '',
-
-        };
-    }
-
-    static get defaultControlElements() {
-        return {
-            addGroupAction: ActionElement,
-            removeGroupAction: ActionElement,
-            addRuleAction: ActionElement,
-            removeRuleAction: ActionElement,
-            combinatorSelector: ValueSelector,
-            fieldSelector: ValueSelector,
-            operatorSelector: ValueSelector,
-            valueEditor: ValueEditor
-        };
-    }
-
-    componentWillReceiveProps(nextProps) {
-        let schema  = { ...this.state.schema };
-
-        if (this.props.query !== nextProps.query) {
-            this.setState({ root: this.generateValidQuery(nextProps.query) });
+    for (const rule of parent.rules) {
+      if (rule.id === id) {
+        return rule;
+      } else if (isRuleGroup(rule)) {
+        const subRule = this._findRule(id, rule);
+        if (subRule) {
+          return subRule;
         }
+      }
+    }
+  }
 
-        if (schema.fields !== nextProps.fields) {
-            schema.fields = nextProps.fields;
-            this.setState({ schema });
-        }
+  _notifyQueryChange(fn, ...args) {
+    if (fn) {
+      fn.call(this, ...args);
     }
 
-    componentWillMount() {
-        const {fields, operators, combinators, controlElements, controlClassnames} = this.props;
-        const classNames = Object.assign({}, QueryBuilder.defaultControlClassnames, controlClassnames);
-        const controls = Object.assign({}, QueryBuilder.defaultControlElements, controlElements);
-        this.setState({
-            root: this.getInitialQuery(),
-            schema: {
-                fields,
-                operators,
-                combinators,
-
-                classNames,
-
-                createRule: this.createRule.bind(this),
-                createRuleGroup: this.createRuleGroup.bind(this),
-                onRuleAdd: this._notifyQueryChange.bind(this, this.onRuleAdd),
-                onGroupAdd: this._notifyQueryChange.bind(this, this.onGroupAdd),
-                onRuleRemove: this._notifyQueryChange.bind(this, this.onRuleRemove),
-                onGroupRemove: this._notifyQueryChange.bind(this, this.onGroupRemove),
-                onPropChange: this._notifyQueryChange.bind(this, this.onPropChange),
-                getLevel: this.getLevel.bind(this),
-                isRuleGroup: this.isRuleGroup.bind(this),
-                controls,
-                getOperators: (...args)=>this.getOperators(...args),
-            }
-        });
-
+    const { onQueryChange } = this.props;
+    if (onQueryChange) {
+      const query = cloneDeep(this.state.root);
+      onQueryChange(query);
     }
-
-    generateValidQuery(query) {
-        if(this.isRuleGroup(query)) {
-            return ({
-                id: query.id || `g-${uniqueId()}`,
-                rules: query.rules.map(rule => this.generateValidQuery(rule)),
-                combinator: query.combinator,
-            });
-        }
-        return ({
-            id: query.id || `r-${uniqueId()}`,
-            ...query,
-        });
-    }
-
-    getInitialQuery() {
-        const {query} = this.props;
-        return (query && this.generateValidQuery(query)) || this.createRuleGroup();
-    }
-
-    componentDidMount() {
-        this._notifyQueryChange(null);
-    }
-
-    render() {
-        const {root: {id, rules, combinator}, schema} = this.state;
-        const {translations} = this.props;
-
-        return (
-            <div className={`queryBuilder ${schema.classNames.queryBuilder}`}>
-                <RuleGroup
-                    translations={translations}
-                    rules={rules}
-                    combinator={combinator}
-                    schema={schema}
-                    id={id}
-                    parentId={null}
-                />
-            </div>
-        );
-    }
-
-
-    isRuleGroup(rule) {
-        return !!(rule.combinator && rule.rules);
-    }
-
-    createRule() {
-        const {fields, operators} = this.state.schema;
-
-        return {
-            id: `r-${uniqueId()}`,
-            field: fields[0].name,
-            value: '',
-            operator: operators[0].name
-        };
-    }
-
-    createRuleGroup() {
-        return {
-            id: `g-${uniqueId()}`,
-            rules: [],
-            combinator: this.props.combinators[0].name,
-        };
-    }
-
-    getOperators(field) {
-        if (this.props.getOperators) {
-            const ops = this.props.getOperators(field);
-            if (ops) {
-                return ops;
-            }
-        }
-
-
-        return this.props.operators;
-    }
-
-    onRuleAdd(rule, parentId) {
-        const parent = this._findRule(parentId, this.state.root);
-        parent.rules.push(rule);
-
-        this.setState({root: this.state.root});
-    }
-
-    onGroupAdd(group, parentId) {
-        const parent = this._findRule(parentId, this.state.root);
-        parent.rules.push(group);
-
-        this.setState({root: this.state.root});
-    }
-
-    onPropChange(prop, value, ruleId) {
-        const rule = this._findRule(ruleId, this.state.root);
-        Object.assign(rule, {[prop]: value});
-
-        this.setState({root: this.state.root});
-    }
-
-    onRuleRemove(ruleId, parentId) {
-        const parent = this._findRule(parentId, this.state.root);
-        const index = parent.rules.findIndex(x=>x.id === ruleId);
-
-        parent.rules.splice(index, 1);
-        this.setState({root: this.state.root});
-    }
-
-    onGroupRemove(groupId, parentId) {
-        const parent = this._findRule(parentId, this.state.root);
-        const index = parent.rules.findIndex(x=>x.id === groupId);
-
-        parent.rules.splice(index, 1);
-        this.setState({root: this.state.root});
-    }
-
-    getLevel(id) {
-        return this._getLevel(id, 0, this.state.root)
-    }
-
-    _getLevel(id, index, root) {
-        const {isRuleGroup} = this.state.schema;
-
-        var foundAtIndex = -1;
-        if(root.id === id ) {
-            foundAtIndex = index;
-        } else if(isRuleGroup(root)) {
-            root.rules.forEach(rule => {
-                if(foundAtIndex === -1) {
-                    var indexForRule = index;
-                    if(isRuleGroup(rule))
-                        indexForRule++;
-                    foundAtIndex = this._getLevel(id, indexForRule, rule);
-                }
-            });
-        }
-        return foundAtIndex;
-
-    }
-
-    _findRule(id, parent) {
-        const {isRuleGroup} = this.state.schema;
-
-        if (parent.id === id) {
-            return parent;
-        }
-
-        for (const rule of parent.rules) {
-            if (rule.id === id) {
-                return rule;
-            } else if (isRuleGroup(rule)) {
-                const subRule = this._findRule(id, rule);
-                if (subRule) {
-                    return subRule;
-                }
-            }
-        }
-
-    }
-
-    _notifyQueryChange(fn, ...args) {
-        if (fn) {
-            fn.call(this, ...args);
-        }
-
-        const {onQueryChange} = this.props;
-        if (onQueryChange) {
-            const query = cloneDeep(this.state.root);
-            onQueryChange(query);
-        }
-    }
+  }
 }

--- a/src/QueryBuilder.test.js
+++ b/src/QueryBuilder.test.js
@@ -17,12 +17,13 @@ describe('<QueryBuilder />', () => {
             expect(QueryBuilder.prototype.componentWillMount.calledOnce).to.equal(true);
             dom.unmount();
         });
+
         it('calls componentDidMount', () => {
             sinon.spy(QueryBuilder.prototype, 'componentDidMount');
             const dom = mount(<QueryBuilder />);
             expect(QueryBuilder.prototype.componentDidMount.calledOnce).to.equal(true);
-
         });
+
         it('should render the root RuleGroup', () => {
             const dom = shallow(<QueryBuilder />);
             expect(dom.find('RuleGroup')).to.have.length(1);
@@ -33,18 +34,14 @@ describe('<QueryBuilder />', () => {
             const options = dom.find('select option');
             expect(options).to.have.length(2); // and, or
         });
+
         it('should call  onQueryChange',()=>{
             const dom = mount(<QueryBuilder onQueryChange={()=>{}} />);
             dom.instance()._notifyQueryChange(()=>{});
             dom.update();
             expect(dom.props().query).to.equal(null);
         });
-
-
-
     });
-
-
 
     describe('when initial query is provided', () => {
         let dom, query;
@@ -68,13 +65,10 @@ describe('<QueryBuilder />', () => {
             };
 
             dom = mount(<QueryBuilder query={query} fields={fields} />);
-
         });
 
         afterEach(() => {
-            if (dom) {
-                dom.unmount();
-            }
+            if (dom) dom.unmount();
         });
 
         it('should generate valid query', () => {
@@ -101,16 +95,13 @@ describe('<QueryBuilder />', () => {
             expect(validQuery.rules[0].id).to.equal('r-12345');
         })
 
-
         it('should contain a <Rule />', () => {
-
             const rule = dom.find('Rule');
             expect(rule).to.have.length(1);
         });
 
         it('should have the Rule with the correct props', () => {
             const rule = dom.find('Rule');
-
             expect(rule.props().field).to.equal('firstName');
             expect(rule.props().value).to.equal('Test');
             expect(rule.props().operator).to.equal('=');
@@ -118,33 +109,27 @@ describe('<QueryBuilder />', () => {
 
         it('should have a select control with the provided fields', () => {
             const rule = dom.find('Rule');
-
             expect(rule.find('.rule-fields option')).to.have.length(3);
         });
 
         it('should have a field selector with the correct field', () => {
             const rule = dom.find('Rule');
-
             expect(rule.find('.rule-fields select').props().value).to.equal('firstName');
         });
 
         it('should have an operator selector with the correct operator', () => {
             const rule = dom.find('Rule');
-
             expect(rule.find('.rule-operators select').props().value).to.equal('=');
         });
 
         it('should have an input control with the correct value', () => {
             const rule = dom.find('Rule');
-
             expect(rule.find('input').props().value).to.equal('Test');
         });
+    });
 
-
-});
     describe('when new props are passed',()=>{
         it('calls componentWillRecieveProps', () => {
-
             const newFields = [
                 { name: 'domainName', label: 'Domain Name' },
                 { name: 'ownerName', label: 'Owner Name' },
@@ -163,10 +148,10 @@ describe('<QueryBuilder />', () => {
                     }
                 ]
             };
+
             //First mount with props
             sinon.spy(QueryBuilder.prototype, 'componentWillReceiveProps');
             const dom = mount(<QueryBuilder />);
-
             expect(QueryBuilder.prototype.componentWillReceiveProps.calledOnce).to.equal(false);
 
             //componentWillRecieveProps
@@ -180,7 +165,6 @@ describe('<QueryBuilder />', () => {
             expect(dom.find('RuleGroup')).to.have.length(1);
             expect(rule.find('input').props().value).to.equal('www.example.com');
         });
-
     });
 
     describe('when initial operators are provided', () => {
@@ -217,24 +201,22 @@ describe('<QueryBuilder />', () => {
                                       fields={fields}
                                       query={query} />);
         });
+
         it('should get operators for field', () => {
             let operators = dom.state('schema').getOperators('firstName');
-            //console.log('OPS',operators);
             expect(operators.length).to.equal(4);
         });
+
         it('should use the given operators', () => {
             const operatorOptions = dom.find('Rule').find('.rule-operators option');
-
             expect(operatorOptions.length).to.equal(4);
         });
 
         it('should match the label of the first operator', () => {
             const operatorOption = dom.find('Rule').find('.rule-operators option').first();
-
             expect(operatorOption.text()).to.equal('Custom Is Null');
         });
     });
-
 
     describe('when calculating the level of a rule', function () {
         let dom;

--- a/src/QueryBuilder.test.js
+++ b/src/QueryBuilder.test.js
@@ -1,272 +1,347 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-var sinon = require('sinon')
 import QueryBuilder from './QueryBuilder';
+var sinon = require('sinon');
 
 describe('<QueryBuilder />', () => {
+  it('should exist', () => {
+    expect(QueryBuilder).to.exist;
+  });
 
-    it('should exist', () => {
-        expect(QueryBuilder).to.exist;
+  describe('when rendered', () => {
+    let wrapper, cmpWillMount, cmpDidMount;
+
+    beforeEach(() => {
+      cmpWillMount = sinon.spy(QueryBuilder.prototype, 'componentWillMount');
+      cmpDidMount = sinon.spy(QueryBuilder.prototype, 'componentDidMount');
+      wrapper = mount(<QueryBuilder />);
     });
 
-    describe('when rendered', () => {
-
-        it('calls componentWillMount', () => {
-            sinon.spy(QueryBuilder.prototype, 'componentWillMount');
-            const dom = mount(<QueryBuilder />);
-            expect(QueryBuilder.prototype.componentWillMount.calledOnce).to.equal(true);
-            dom.unmount();
-        });
-
-        it('calls componentDidMount', () => {
-            sinon.spy(QueryBuilder.prototype, 'componentDidMount');
-            const dom = mount(<QueryBuilder />);
-            expect(QueryBuilder.prototype.componentDidMount.calledOnce).to.equal(true);
-        });
-
-        it('should render the root RuleGroup', () => {
-            const dom = shallow(<QueryBuilder />);
-            expect(dom.find('RuleGroup')).to.have.length(1);
-        });
-
-        it('should show the list of combinators in the RuleGroup', () => {
-            const dom = mount(<QueryBuilder />);
-            const options = dom.find('select option');
-            expect(options).to.have.length(2); // and, or
-        });
-
-        it('should call  onQueryChange',()=>{
-            const dom = mount(<QueryBuilder onQueryChange={()=>{}} />);
-            dom.instance()._notifyQueryChange(()=>{});
-            dom.update();
-            expect(dom.props().query).to.equal(null);
-        });
+    afterEach(() => {
+      cmpWillMount.restore();
+      cmpDidMount.restore();
+      wrapper.unmount();
     });
 
-    describe('when initial query is provided', () => {
-        let dom, query;
-
-        beforeEach(() => {
-            const fields = [
-                { name: 'firstName', label: 'First Name' },
-                { name: 'lastName', label: 'Last Name' },
-                { name: 'age', label: 'Age' },
-            ];
-
-            query = {
-                combinator: 'and',
-                rules: [
-                    {
-                        field: 'firstName',
-                        value: 'Test',
-                        operator: '='
-                    }
-                ]
-            };
-
-            dom = mount(<QueryBuilder query={query} fields={fields} />);
-        });
-
-        afterEach(() => {
-            if (dom) dom.unmount();
-        });
-
-        it('should generate valid query', () => {
-            const validQuery = QueryBuilder.prototype.generateValidQuery(query);
-            expect(validQuery).haveOwnProperty('id');
-            expect(validQuery.rules[0]).haveOwnProperty('id');
-        })
-
-        it('should not generate new id if query provides id', () => {
-            const queryWithId = {
-                id: 'g-12345',
-                combinator: 'and',
-                rules: [
-                    {
-                        id: 'r-12345',
-                        field: 'firstName',
-                        value: 'Test',
-                        operator: '='
-                    }
-                ]
-            };
-            const validQuery = QueryBuilder.prototype.generateValidQuery(queryWithId);
-            expect(validQuery.id).to.equal('g-12345');
-            expect(validQuery.rules[0].id).to.equal('r-12345');
-        })
-
-        it('should contain a <Rule />', () => {
-            const rule = dom.find('Rule');
-            expect(rule).to.have.length(1);
-        });
-
-        it('should have the Rule with the correct props', () => {
-            const rule = dom.find('Rule');
-            expect(rule.props().field).to.equal('firstName');
-            expect(rule.props().value).to.equal('Test');
-            expect(rule.props().operator).to.equal('=');
-        });
-
-        it('should have a select control with the provided fields', () => {
-            const rule = dom.find('Rule');
-            expect(rule.find('.rule-fields option')).to.have.length(3);
-        });
-
-        it('should have a field selector with the correct field', () => {
-            const rule = dom.find('Rule');
-            expect(rule.find('.rule-fields select').props().value).to.equal('firstName');
-        });
-
-        it('should have an operator selector with the correct operator', () => {
-            const rule = dom.find('Rule');
-            expect(rule.find('.rule-operators select').props().value).to.equal('=');
-        });
-
-        it('should have an input control with the correct value', () => {
-            const rule = dom.find('Rule');
-            expect(rule.find('input').props().value).to.equal('Test');
-        });
+    it('calls componentWillMount', () => {
+      expect(cmpWillMount.calledOnce).to.equal(true);
     });
 
-    describe('when new props are passed',()=>{
-        it('calls componentWillRecieveProps', () => {
-            const newFields = [
-                { name: 'domainName', label: 'Domain Name' },
-                { name: 'ownerName', label: 'Owner Name' },
-
-            ];
-
-            const newQuery = {
-                combinator: 'and',
-                id: '111',
-                rules: [
-                    {
-                        id: '222',
-                        field: 'domainName',
-                        value: 'www.example.com',
-                        operator: '!='
-                    }
-                ]
-            };
-
-            //First mount with props
-            sinon.spy(QueryBuilder.prototype, 'componentWillReceiveProps');
-            const dom = mount(<QueryBuilder />);
-            expect(QueryBuilder.prototype.componentWillReceiveProps.calledOnce).to.equal(false);
-
-            //componentWillRecieveProps
-            dom.setProps({
-                query: newQuery,
-                fields: newFields
-            });
-            expect(QueryBuilder.prototype.componentWillReceiveProps.calledOnce).to.equal(true);
-            expect(dom.props().query).to.equal(newQuery);
-            const rule = dom.find('Rule');
-            expect(dom.find('RuleGroup')).to.have.length(1);
-            expect(rule.find('input').props().value).to.equal('www.example.com');
-        });
+    it('calls componentDidMount', () => {
+      expect(cmpDidMount.calledOnce).to.equal(true);
     });
 
-    describe('when initial operators are provided', () => {
-
-        let dom;
-        beforeEach(() => {
-            const operators = [
-                { name: 'null', label: 'Custom Is Null' },
-                { name: 'notNull', label: 'Is Not Null' },
-                { name: 'in', label: 'In' },
-                { name: 'notIn', label: 'Not In' },
-            ];
-
-            const fields = [
-                { name: 'firstName', label: 'First Name' },
-                { name: 'lastName', label: 'Last Name' },
-                { name: 'age', label: 'Age' },
-            ];
-
-            const query = {
-                combinator: 'and',
-                id: '111',
-                rules: [
-                    {
-                        id: '222',
-                        field: 'firstName',
-                        value: 'Test',
-                        operator: '='
-                    }
-                ]
-            };
-
-            dom = mount(<QueryBuilder operators={operators}
-                                      fields={fields}
-                                      query={query} />);
-        });
-
-        it('should get operators for field', () => {
-            let operators = dom.state('schema').getOperators('firstName');
-            expect(operators.length).to.equal(4);
-        });
-
-        it('should use the given operators', () => {
-            const operatorOptions = dom.find('Rule').find('.rule-operators option');
-            expect(operatorOptions.length).to.equal(4);
-        });
-
-        it('should match the label of the first operator', () => {
-            const operatorOption = dom.find('Rule').find('.rule-operators option').first();
-            expect(operatorOption.text()).to.equal('Custom Is Null');
-        });
+    it('should render the root RuleGroup', () => {
+      expect(wrapper.find('RuleGroup')).to.have.length(1);
     });
 
-    describe('when calculating the level of a rule', function () {
-        let dom;
-        beforeEach(() => {
-            const fields = [
-                { name: 'firstName', label: 'First Name' },
-                { name: 'lastName', label: 'Last Name' },
-                { name: 'age', label: 'Age' },
-            ];
-            const query = {
-                combinator: 'and',
-                id: '111',
-                rules: [{
-                    id: '222',
-                    field: 'firstName',
-                    value: 'Test',
-                    operator: '='
-                }, {
-                    id: '333',
-                    field: 'firstName',
-                    value: 'Test',
-                    operator: '='
-                }, {
-                    combinator: 'and',
-                    id: '444',
-                    rules: [{
-                        id: '555',
-                        field: 'firstName',
-                        value: 'Test',
-                        operator: '='
-                    }]
-                }]
-            };
-
-            dom = mount(<QueryBuilder query={query} fields={fields} />);
-        });
-
-        it('should be 0 for the top level', function () {
-            expect(dom.state('schema').getLevel('111')).to.equal(0);
-            expect(dom.state('schema').getLevel('222')).to.equal(0);
-            expect(dom.state('schema').getLevel('333')).to.equal(0);
-        });
-
-        it('should be 1 for the second level', function () {
-            expect(dom.state('schema').getLevel('444')).to.equal(1);
-            expect(dom.state('schema').getLevel('555')).to.equal(1);
-        });
-
-        it('should handle an invalid id', function () {
-            expect(dom.state('schema').getLevel('546')).to.equal(-1);
-        });
+    it('should show the list of combinators in the RuleGroup', () => {
+      const options = wrapper.find('select option');
+      expect(options).to.have.length(2); // and, or
     });
+  });
+
+  describe('when rendered with queryChange callback', () => {
+    let wrapper, queryChange;
+
+    beforeEach(() => {
+      queryChange = sinon.spy();
+      wrapper = mount(<QueryBuilder onQueryChange={queryChange} />);
+    });
+
+    afterEach(() => {
+      queryChange.resetHistory();
+      wrapper.unmount();
+    });
+
+    it('should call onQueryChange', () => {
+      wrapper.instance()._notifyQueryChange(() => {});
+      wrapper.update();
+      expect(wrapper.props().query).to.equal(null);
+    });
+
+    it('should call onQueryChange with query', () => {
+      // Spy is called initially when mounting component (once)
+      expect(queryChange.calledOnce).to.equal(true);
+
+      const query = wrapper.state().root;
+      wrapper.instance()._notifyQueryChange(() => {});
+      wrapper.update();
+
+      expect(queryChange.callCount).to.equal(2);
+      expect(queryChange.calledWith(query)).to.equal(true);
+    });
+  });
+
+  describe('when initial query, with ID, is provided', () => {
+    const queryWithID = {
+      id: 'g-12345',
+      combinator: 'and',
+      rules: [
+        {
+          id: 'r-12345',
+          field: 'firstName',
+          value: 'Test',
+          operator: '='
+        }
+      ]
+    };
+
+    it('should not generate new ID if query provides ID', () => {
+      const validQuery = QueryBuilder.prototype.generateValidQuery(queryWithID);
+      expect(validQuery.id).to.equal('g-12345');
+      expect(validQuery.rules[0].id).to.equal('r-12345');
+    });
+  });
+
+  describe('when initial query, without ID, is provided', () => {
+    let wrapper;
+    const queryWithoutID = {
+      combinator: 'and',
+      rules: [
+        {
+          field: 'firstName',
+          value: 'Test without ID',
+          operator: '='
+        }
+      ]
+    };
+
+    const fields = [
+      { name: 'firstName', label: 'First Name' },
+      { name: 'lastName', label: 'Last Name' },
+      { name: 'age', label: 'Age' }
+    ];
+
+    beforeEach(() => {
+      wrapper = mount(<QueryBuilder query={queryWithoutID} fields={fields} />);
+    });
+
+    afterEach(() => {
+      wrapper.unmount();
+    });
+
+    it('should generate IDs if missing in query', () => {
+      expect(queryWithoutID).to.not.haveOwnProperty('id');
+      const validQuery = QueryBuilder.prototype.generateValidQuery(queryWithoutID);
+      expect(validQuery).haveOwnProperty('id');
+      expect(validQuery.rules[0]).haveOwnProperty('id');
+    });
+
+    it('should contain a <Rule />', () => {
+      const rule = wrapper.find('Rule');
+      expect(rule).to.have.length(1);
+    });
+
+    it('should have the Rule with the correct props', () => {
+      const rule = wrapper.find('Rule');
+      expect(rule.props().field).to.equal('firstName');
+      expect(rule.props().value).to.equal('Test without ID');
+      expect(rule.props().operator).to.equal('=');
+    });
+
+    it('should have a select control with the provided fields', () => {
+      const rule = wrapper.find('Rule');
+      expect(rule.find('.rule-fields option')).to.have.length(3);
+    });
+
+    it('should have a field selector with the correct field', () => {
+      const rule = wrapper.find('Rule');
+      expect(rule.find('.rule-fields select').props().value).to.equal('firstName');
+    });
+
+    it('should have an operator selector with the correct operator', () => {
+      const rule = wrapper.find('Rule');
+      expect(rule.find('.rule-operators select').props().value).to.equal('=');
+    });
+
+    it('should have an input control with the correct value', () => {
+      const rule = wrapper.find('Rule');
+      expect(rule.find('input').props().value).to.equal('Test without ID');
+    });
+  });
+
+  describe('when receiving new props', () => {
+    let wrapper, cmpWillReceiveProps;
+    const newFields = [
+      { name: 'domainName', label: 'Domain Name' },
+      { name: 'ownerName', label: 'Owner Name' }
+    ];
+
+    const newQuery = {
+      combinator: 'and',
+      rules: [
+        {
+          field: 'domainName',
+          value: 'www.example.com',
+          operator: '!='
+        }
+      ]
+    };
+
+    beforeEach(() => {
+      cmpWillReceiveProps = sinon.spy(QueryBuilder.prototype, 'componentWillReceiveProps');
+      wrapper = mount(<QueryBuilder />);
+    });
+
+    afterEach(() => {
+      QueryBuilder.prototype.componentWillReceiveProps.restore();
+      wrapper.unmount();
+    });
+
+    it('calls componentWillRecieveProps', () => {
+      expect(cmpWillReceiveProps.called).to.equal(false);
+
+      wrapper.setProps({
+        query: newQuery,
+        fields: newFields
+      });
+
+      expect(cmpWillReceiveProps.calledOnce).to.equal(true);
+      expect(wrapper.props().query).to.equal(newQuery);
+      expect(wrapper.find('RuleGroup')).to.have.length(1);
+
+      const rule = wrapper.find('Rule');
+      expect(rule.find('input').props().value).to.equal('www.example.com');
+    });
+
+    it('should generate new ID in state when receiving new props (query) with missing IDs', () => {
+      const initialID = wrapper.state().root.id;
+
+      expect(wrapper.props().query).to.be.null;
+      expect(initialID).to.not.be.undefined;
+      expect(initialID).to.be.a('string');
+
+      wrapper.setProps({
+        query: newQuery,
+        fields: newFields
+      });
+
+      expect(wrapper.props().query).to.not.be.null;
+      expect(wrapper.props().query).to.be.an('object');
+      expect(wrapper.props().query.id).to.be.undefined;
+
+      expect(wrapper.state().root.id).to.be.a('string');
+      expect(wrapper.state().root.rules[0].id).to.be.a('string');
+    });
+  });
+
+  describe('when initial operators are provided', () => {
+    let wrapper;
+    const operators = [
+      { name: 'null', label: 'Custom Is Null' },
+      { name: 'notNull', label: 'Is Not Null' },
+      { name: 'in', label: 'In' },
+      { name: 'notIn', label: 'Not In' }
+    ];
+
+    const fields = [
+      { name: 'firstName', label: 'First Name' },
+      { name: 'lastName', label: 'Last Name' },
+      { name: 'age', label: 'Age' }
+    ];
+
+    const query = {
+      combinator: 'and',
+      id: '111',
+      rules: [
+        {
+          id: '222',
+          field: 'firstName',
+          value: 'Test',
+          operator: '='
+        }
+      ]
+    };
+
+    beforeEach(() => {
+      wrapper = mount(<QueryBuilder operators={operators} fields={fields} query={query} />);
+    });
+
+    afterEach(() => {
+      wrapper.unmount();
+    });
+
+    it('should get operators for field', () => {
+      let operators = wrapper.state('schema').getOperators('firstName');
+      expect(operators.length).to.equal(4);
+    });
+
+    it('should use the given operators', () => {
+      const operatorOptions = wrapper.find('Rule').find('.rule-operators option');
+      expect(operatorOptions.length).to.equal(4);
+    });
+
+    it('should match the label of the first operator', () => {
+      const operatorOption = wrapper
+        .find('Rule')
+        .find('.rule-operators option')
+        .first();
+      expect(operatorOption.text()).to.equal('Custom Is Null');
+    });
+  });
+
+  describe('when calculating the level of a rule', function() {
+    let wrapper;
+
+    beforeEach(() => {
+      const fields = [
+        { name: 'firstName', label: 'First Name' },
+        { name: 'lastName', label: 'Last Name' },
+        { name: 'age', label: 'Age' }
+      ];
+
+      const query = {
+        combinator: 'and',
+        id: '111',
+        rules: [
+          {
+            id: '222',
+            field: 'firstName',
+            value: 'Test',
+            operator: '='
+          },
+          {
+            id: '333',
+            field: 'firstName',
+            value: 'Test',
+            operator: '='
+          },
+          {
+            combinator: 'and',
+            id: '444',
+            rules: [
+              {
+                id: '555',
+                field: 'firstName',
+                value: 'Test',
+                operator: '='
+              }
+            ]
+          }
+        ]
+      };
+
+      wrapper = mount(<QueryBuilder query={query} fields={fields} />);
+    });
+
+    afterEach(() => {
+      wrapper.unmount();
+    });
+
+    it('should be 0 for the top level', function() {
+      expect(wrapper.state('schema').getLevel('111')).to.equal(0);
+      expect(wrapper.state('schema').getLevel('222')).to.equal(0);
+      expect(wrapper.state('schema').getLevel('333')).to.equal(0);
+    });
+
+    it('should be 1 for the second level', function() {
+      expect(wrapper.state('schema').getLevel('444')).to.equal(1);
+      expect(wrapper.state('schema').getLevel('555')).to.equal(1);
+    });
+
+    it('should handle an invalid id', function() {
+      expect(wrapper.state('schema').getLevel('546')).to.equal(-1);
+    });
+  });
 });

--- a/src/QueryBuilder.test.js
+++ b/src/QueryBuilder.test.js
@@ -224,6 +224,20 @@ describe('<QueryBuilder />', () => {
       expect(wrapper.state().root.id).to.be.a('string');
       expect(wrapper.state().root.rules[0].id).to.be.a('string');
     });
+
+    it('should keep same state if same props are passed (root/fields)', () => {
+      const wrp = mount(<QueryBuilder query={newQuery} fields={newFields} />);
+      const stateQuery1 = wrp.state().root;
+      const stateFields1 = wrp.state().schema.fields;
+
+      wrp.setProps({
+        query: newQuery,
+        fields: newFields
+      });
+
+      expect(wrp.state().root).to.equal(stateQuery1);
+      expect(wrp.state().schema.fields).to.equal(stateFields1);
+    });
   });
 
   describe('when initial operators are provided', () => {
@@ -278,6 +292,51 @@ describe('<QueryBuilder />', () => {
         .find('.rule-operators option')
         .first();
       expect(operatorOption.text()).to.equal('Custom Is Null');
+    });
+  });
+
+  describe('when getOperators fn prop is provided', () => {
+    let wrapper, getOperators;
+
+    const fields = [
+      { name: 'firstName', label: 'First Name' },
+      { name: 'lastName', label: 'Last Name' },
+      { name: 'age', label: 'Age' }
+    ];
+
+    const query = {
+      id: 'g-012345',
+      combinator: 'or',
+      rules: [
+        {
+          id: 'r-0123456789',
+          field: 'lastName',
+          value: 'Another Test',
+          operator: '='
+        }
+      ]
+    };
+
+    beforeEach(() => {
+      getOperators = sinon.spy((fields, wada=123) => {
+        return [
+          { name: 'custom-operator-1', label: 'Op. 1' },
+          { name: 'custom-operator-2', label: 'Op. 2' },
+          { name: 'custom-operator-3', label: 'Op. 3' }
+        ];
+      });
+      wrapper = mount(<QueryBuilder query={query} fields={fields} getOperators={getOperators} />);
+    });
+
+    afterEach(() => {
+      getOperators.resetHistory();
+      wrapper.unmount();
+    });
+
+    it('should invoke custom getOperators function', () => {
+      expect(getOperators.callCount).to.equal(1); // 1 Rule in query
+      wrapper.instance().getOperators();
+      expect(getOperators.callCount).to.equal(2);
     });
   });
 

--- a/src/Rule.jsx
+++ b/src/Rule.jsx
@@ -1,98 +1,90 @@
 import React from 'react';
 
 export default class Rule extends React.Component {
-    static get defaultProps() {
-        return {
-            id: null,
-            parentId: null,
-            field: null,
-            operator: null,
-            value: null,
-            schema: null
-        };
-    }
+  static get defaultProps() {
+    return {
+      id: null,
+      parentId: null,
+      field: null,
+      operator: null,
+      value: null,
+      schema: null
+    };
+  }
 
-    render() {
-        const {field, operator, value, translations, schema: {fields, controls, getOperators, getLevel, classNames}} = this.props;
-        var level = getLevel(this.props.id);
-        return (
-            <div className={`rule ${classNames.rule}`}>
-                {
-                    React.createElement(controls.fieldSelector,
-                        {
-                            options: fields,
-                            title: translations.fields.title,
-                            value: field,
-                            className: `rule-fields ${classNames.fields}`,
-                            handleOnChange: this.onFieldChanged,
-                            level: level
-                        }
-                    )
-                }
-                {
-                    React.createElement(controls.operatorSelector,
-                        {
-                            field: field,
-                            title: translations.operators.title,
-                            options: getOperators(field),
-                            value: operator,
-                            className: `rule-operators ${classNames.operators}`,
-                            handleOnChange: this.onOperatorChanged,
-                            level: level
-                        }
-                    )
-                }
-                {
-                    React.createElement(controls.valueEditor,
-                        {
-                            field: field,
-                            title: translations.value.title,
-                            operator: operator,
-                            value: value,
-                            className: `rule-value ${classNames.value}`,
-                            handleOnChange: this.onValueChanged,
-                            level: level
-                        }
-                    )
-                }
-                {
-                    React.createElement(controls.removeRuleAction,
-                    {
-                        label: translations.removeRule.label,
-                        title: translations.removeRule.title,
-                        className: `rule-remove ${classNames.removeRule}`,
-                        handleOnClick: this.removeRule,
-                        level: level
-                    })
-                }
-            </div>
-        );
-    }
+  render() {
+    const {
+      field,
+      operator,
+      value,
+      translations,
+      schema: { fields, controls, getOperators, getLevel, classNames }
+    } = this.props;
+    const level = getLevel(this.props.id);
+    return (
+      <div className={`rule ${classNames.rule}`}>
+        {React.createElement(controls.fieldSelector, {
+          options: fields,
+          title: translations.fields.title,
+          value: field,
+          className: `rule-fields ${classNames.fields}`,
+          handleOnChange: this.onFieldChanged,
+          level: level
+        })}
+        {React.createElement(controls.operatorSelector, {
+          field: field,
+          title: translations.operators.title,
+          options: getOperators(field),
+          value: operator,
+          className: `rule-operators ${classNames.operators}`,
+          handleOnChange: this.onOperatorChanged,
+          level: level
+        })}
+        {React.createElement(controls.valueEditor, {
+          field: field,
+          title: translations.value.title,
+          operator: operator,
+          value: value,
+          className: `rule-value ${classNames.value}`,
+          handleOnChange: this.onValueChanged,
+          level: level
+        })}
+        {React.createElement(controls.removeRuleAction, {
+          label: translations.removeRule.label,
+          title: translations.removeRule.title,
+          className: `rule-remove ${classNames.removeRule}`,
+          handleOnClick: this.removeRule,
+          level: level
+        })}
+      </div>
+    );
+  }
 
-    onFieldChanged = (value) => {
-        this.onElementChanged('field', value);
-    }
+  onFieldChanged = (value) => {
+    this.onElementChanged('field', value);
+  };
 
-    onOperatorChanged = (value) => {
-        this.onElementChanged('operator', value);
-    }
+  onOperatorChanged = (value) => {
+    this.onElementChanged('operator', value);
+  };
 
-    onValueChanged = (value) => {
-        this.onElementChanged('value', value);
-    }
+  onValueChanged = (value) => {
+    this.onElementChanged('value', value);
+  };
 
-    onElementChanged = (property, value) => {
-        const {id, schema: {onPropChange}} = this.props;
+  onElementChanged = (property, value) => {
+    const {
+      id,
+      schema: { onPropChange }
+    } = this.props;
 
-        onPropChange(property, value, id);
-    }
+    onPropChange(property, value, id);
+  };
 
-    removeRule = (event) => {
-        event.preventDefault();
-        event.stopPropagation();
+  removeRule = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
 
-        this.props.schema.onRuleRemove(this.props.id, this.props.parentId);
-    }
-
-
+    this.props.schema.onRuleRemove(this.props.id, this.props.parentId);
+  };
 }

--- a/src/RuleGroup.jsx
+++ b/src/RuleGroup.jsx
@@ -2,133 +2,123 @@ import React from 'react';
 import Rule from './Rule';
 
 export default class RuleGroup extends React.Component {
-    static get defaultProps() {
-        return {
-            id: null,
-            parentId: null,
-            rules: [],
-            combinator: 'and',
-            schema: {},
-        };
-    }
+  static get defaultProps() {
+    return {
+      id: null,
+      parentId: null,
+      rules: [],
+      combinator: 'and',
+      schema: {}
+    };
+  }
 
-    render() {
-        const { combinator, rules, translations, schema: {combinators, controls, onRuleRemove, isRuleGroup, getLevel, classNames} } = this.props;
-        const level = getLevel(this.props.id);
-          return (
-            <div className={`ruleGroup ${classNames.ruleGroup}`}>
-                {
-                    React.createElement(controls.combinatorSelector,
-                        {
-                            options: combinators,
-                            value: combinator,
-                            title: translations.combinators.title,
-                            className: `ruleGroup-combinators ${classNames.combinators}`,
-                            handleOnChange: this.onCombinatorChange,
-                            rules: rules,
-                            level: level
-                        }
-                    )
-                }
-                {
-                    React.createElement(controls.addRuleAction,
-                        {
-                            label: translations.addRule.label,
-                            title: translations.addRule.title,
-                            className: `ruleGroup-addRule ${classNames.addRule}`,
-                            handleOnClick: this.addRule,
-                            rules: rules,
-                            level: level
-                        }
-                    )
-                }
-                {
-                    React.createElement(controls.addGroupAction,
-                        {
-                            label: translations.addGroup.label,
-                            title: translations.addGroup.title,
-                            className: `ruleGroup-addGroup ${classNames.addGroup}`,
-                            handleOnClick: this.addGroup,
-                            rules: rules,
-                            level: level
-                        }
-                    )
-                }
-                {
-                    this.hasParentGroup() ?
-                        React.createElement(controls.removeGroupAction,
-                            {
-                                label: translations.removeGroup.label,
-                                title: translations.removeGroup.title,
-                                className: `ruleGroup-remove ${classNames.removeGroup}`,
-                                handleOnClick: this.removeGroup,
-                                rules: rules,
-                                level: level
-                            }
-                        ) : null
-                }
-                 {
-                     rules.map(r=> {
-                         return (
-                             isRuleGroup(r)
-                                 ? <RuleGroup key={r.id}
-                                              id={r.id}
-                                              schema={this.props.schema}
-                                              parentId={this.props.id}
-                                              combinator={r.combinator}
-                                              translations={this.props.translations}
-                                              rules={r.rules}/>
-                                 : <Rule key={r.id}
-                                         id={r.id}
-                                         field={r.field}
-                                         value={r.value}
-                                         operator={r.operator}
-                                         schema={this.props.schema}
-                                         parentId={this.props.id}
-                                         translations={this.props.translations}
-                                         onRuleRemove={onRuleRemove}/>
-                         );
-                     })
-                 }
-            </div>
-        );
-    }
+  render() {
+    const {
+      combinator,
+      rules,
+      translations,
+      schema: { combinators, controls, onRuleRemove, isRuleGroup, getLevel, classNames }
+    } = this.props;
+    const level = getLevel(this.props.id);
+    return (
+      <div className={`ruleGroup ${classNames.ruleGroup}`}>
+        {React.createElement(controls.combinatorSelector, {
+          options: combinators,
+          value: combinator,
+          title: translations.combinators.title,
+          className: `ruleGroup-combinators ${classNames.combinators}`,
+          handleOnChange: this.onCombinatorChange,
+          rules: rules,
+          level: level
+        })}
+        {React.createElement(controls.addRuleAction, {
+          label: translations.addRule.label,
+          title: translations.addRule.title,
+          className: `ruleGroup-addRule ${classNames.addRule}`,
+          handleOnClick: this.addRule,
+          rules: rules,
+          level: level
+        })}
+        {React.createElement(controls.addGroupAction, {
+          label: translations.addGroup.label,
+          title: translations.addGroup.title,
+          className: `ruleGroup-addGroup ${classNames.addGroup}`,
+          handleOnClick: this.addGroup,
+          rules: rules,
+          level: level
+        })}
+        {this.hasParentGroup()
+          ? React.createElement(controls.removeGroupAction, {
+              label: translations.removeGroup.label,
+              title: translations.removeGroup.title,
+              className: `ruleGroup-remove ${classNames.removeGroup}`,
+              handleOnClick: this.removeGroup,
+              rules: rules,
+              level: level
+            })
+          : null}
+        {rules.map((r) => {
+          return isRuleGroup(r) ? (
+            <RuleGroup
+              key={r.id}
+              id={r.id}
+              schema={this.props.schema}
+              parentId={this.props.id}
+              combinator={r.combinator}
+              translations={this.props.translations}
+              rules={r.rules}
+            />
+          ) : (
+            <Rule
+              key={r.id}
+              id={r.id}
+              field={r.field}
+              value={r.value}
+              operator={r.operator}
+              schema={this.props.schema}
+              parentId={this.props.id}
+              translations={this.props.translations}
+              onRuleRemove={onRuleRemove}
+            />
+          );
+        })}
+      </div>
+    );
+  }
 
-    hasParentGroup() {
-        return this.props.parentId;
-    }
+  hasParentGroup() {
+    return this.props.parentId;
+  }
 
-    onCombinatorChange = (value) => {
-        const {onPropChange} = this.props.schema;
+  onCombinatorChange = (value) => {
+    const { onPropChange } = this.props.schema;
 
-        onPropChange('combinator', value, this.props.id);
-    }
+    onPropChange('combinator', value, this.props.id);
+  };
 
-    addRule = (event) => {
-        event.preventDefault();
-        event.stopPropagation();
+  addRule = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
 
-        const {createRule, onRuleAdd} = this.props.schema;
+    const { createRule, onRuleAdd } = this.props.schema;
 
-        const newRule = createRule();
-        onRuleAdd(newRule, this.props.id)
-    }
+    const newRule = createRule();
+    onRuleAdd(newRule, this.props.id);
+  };
 
-    addGroup = (event) => {
-        event.preventDefault();
-        event.stopPropagation();
+  addGroup = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
 
-        const {createRuleGroup, onGroupAdd} = this.props.schema;
-        const newGroup = createRuleGroup();
-        onGroupAdd(newGroup, this.props.id)
-    }
+    const { createRuleGroup, onGroupAdd } = this.props.schema;
+    const newGroup = createRuleGroup();
+    onGroupAdd(newGroup, this.props.id);
+  };
 
-    removeGroup = (event) => {
-        event.preventDefault();
-        event.stopPropagation();
+  removeGroup = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
 
-        this.props.schema.onGroupRemove(this.props.id, this.props.parentId);
-    }
-
-
+    this.props.schema.onGroupRemove(this.props.id, this.props.parentId);
+  };
 }

--- a/src/RuleGroup.test.js
+++ b/src/RuleGroup.test.js
@@ -1,351 +1,340 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-
 import RuleGroup from './RuleGroup';
 import { ActionElement, ValueSelector } from './controls/index';
 
-describe('<RuleGroup />', ()=> {
-    let controls, classNames, schema, props;
-    beforeEach(()=>{
-        //set defaults
-        controls = {
-            combinatorSelector: React.Component,
-            addRuleAction: React.Component,
-            addGroupAction: React.Component,
-            removeGroupAction: React.Component
+describe('<RuleGroup />', () => {
+  let controls, classNames, schema, props;
+  beforeEach(() => {
+    //set defaults
+    controls = {
+      combinatorSelector: React.Component,
+      addRuleAction: React.Component,
+      addGroupAction: React.Component,
+      removeGroupAction: React.Component
+    };
+    classNames = {
+      combinators: 'custom-combinators-class',
+      addRule: 'custom-addRule-class',
+      addGroup: 'custom-addGroup-class',
+      removeGroup: 'custom-removeGroup-class'
+    };
+    schema = {
+      combinators: [],
+      controls: controls,
+      classNames: classNames,
+      isRuleGroup: (rule) => {
+        return false;
+      },
+      onPropChange: (prop, value, id) => {},
+      onRuleAdd: (rule, parentId) => {},
+      onGroupAdd: (ruleGroup, id) => {},
+      createRule: () => {
+        return _createRule(1);
+      },
+      createRuleGroup: () => {
+        return _createRuleGroup(1, 'any_parent_id', []);
+      },
+      getLevel: (id) => 0
+    };
+    props = {
+      id: 'id',
+      parentId: 'parentId',
+      rules: [],
+      combinator: 'and',
+      schema: schema,
+      translations: {
+        fields: {
+          title: 'Fields'
+        },
+        operators: {
+          title: 'Operators'
+        },
+        value: {
+          title: 'Value'
+        },
+        removeRule: {
+          label: 'x',
+          title: 'Remove rule'
+        },
+        removeGroup: {
+          label: 'x',
+          title: 'Remove group'
+        },
+        addRule: {
+          label: '+Rule',
+          title: 'Add rule'
+        },
+        addGroup: {
+          label: '+Group',
+          title: 'Add group'
+        },
+        combinators: {
+          title: 'Combinators'
         }
-        classNames = {
-            combinators: 'custom-combinators-class',
-            addRule: 'custom-addRule-class',
-            addGroup: 'custom-addGroup-class',
-            removeGroup: 'custom-removeGroup-class'
-        }
-        schema = {
-            combinators: [],
-            controls: controls,
-            classNames: classNames,
-            isRuleGroup: (rule)=>{return false},
-            onPropChange: (prop, value, id)=>{},
-            onRuleAdd: (rule, parentId)=>{},
-            onGroupAdd: (ruleGroup, id)=>{},
-            createRule: ()=>{ return _createRule(1);},
-            createRuleGroup: ()=>{ return _createRuleGroup(1, 'any_parent_id', []);},
-            getLevel: (id) => 0
-        }
-        props = {
-            id: 'id',
-            parentId: 'parentId',
-            rules: [],
-            combinator: 'and',
-            schema: schema,
-            translations: {
-                fields: {
-                    title: "Fields",
-                },
-                operators: {
-                    title: "Operators",
-                },
-                value: {
-                    title: "Value",
-                },
-                removeRule: {
-                    label: "x",
-                    title: "Remove rule",
-                },
-                removeGroup: {
-                    label: "x",
-                    title: "Remove group",
-                },
-                addRule: {
-                    label: "+Rule",
-                    title: "Add rule",
-                },
-                addGroup: {
-                    label: "+Group",
-                    title: "Add group",
-                },
-                combinators: {
-                    title: "Combinators",
-                }
-            }
-        }
+      }
+    };
+  });
+
+  it('should exist', () => {
+    expect(RuleGroup).to.exist;
+  });
+
+  it('should have a className of "ruleGroup"', () => {
+    const dom = shallow(<RuleGroup {...props} />);
+    expect(dom.find('div').hasClass('ruleGroup')).to.be.true;
+  });
+
+  describe('combinator selector as <ValueSelector />', () => {
+    beforeEach(() => {
+      controls.combinatorSelector = ValueSelector;
     });
 
-    it('should exist', ()=> {
-        expect(RuleGroup).to.exist;
+    it('should have options set to expected combinators', () => {
+      const expected_combinators = [{ name: 'and', label: 'AND' }, { name: 'or', label: 'OR' }];
+      schema.combinators = expected_combinators;
+      const dom = shallow(<RuleGroup {...props} />);
+      expect(dom.find('ValueSelector').props().options).to.equal(expected_combinators);
     });
 
-    it('should have a className of "ruleGroup"', ()=> {
-        const dom = shallow(<RuleGroup {...props} />);
-
-        expect(dom.find('div').hasClass('ruleGroup')).to.be.true;
+    it('should have the default selected value set to "and"', () => {
+      const dom = shallow(<RuleGroup {...props} />);
+      expect(dom.find('ValueSelector').props().value).to.equal('and');
     });
 
-    describe('combinator selector as <ValueSelector />', ()=> {
-        beforeEach(() => {
-            controls.combinatorSelector = ValueSelector;
-        });
-
-        it('should have options set to expected combinators', ()=> {
-            const expected_combinators = [
-                {name: 'and', label: 'AND'},
-                {name: 'or', label: 'OR'}
-            ];
-            schema.combinators = expected_combinators;
-            const dom = shallow(<RuleGroup {...props} />);
-            expect(dom.find('ValueSelector').props().options).to.equal(expected_combinators);
-        });
-
-        it('should have the default selected value set to "and"', ()=> {
-            const dom = shallow(<RuleGroup {...props} />);
-            expect(dom.find('ValueSelector').props().value).to.equal('and');
-        });
-
-        it('should have the onChange method handler', ()=> {
-            const dom = shallow(<RuleGroup {...props} />);
-            expect(dom.find('ValueSelector').props().handleOnChange).to.be.a('function');
-        });
-
-        behavesLikeAnElementWithClassNames(
-            'ValueSelector',
-            'ruleGroup-combinators',
-            'custom-combinators-class'
-        );
+    it('should have the onChange method handler', () => {
+      const dom = shallow(<RuleGroup {...props} />);
+      expect(dom.find('ValueSelector').props().handleOnChange).to.be.a('function');
     });
 
-    describe('add rule action as an <ActionElement />', ()=> {
-        beforeEach(() => {
-            controls.addRuleAction = ActionElement;
-        });
+    behavesLikeAnElementWithClassNames(
+      'ValueSelector',
+      'ruleGroup-combinators',
+      'custom-combinators-class'
+    );
+  });
 
-        behavesLikeAnActionElement(
-            '+Rule',
-            'ruleGroup-addRule',
-            'custom-addRule-class');
+  describe('add rule action as an <ActionElement />', () => {
+    beforeEach(() => {
+      controls.addRuleAction = ActionElement;
     });
 
-    describe('add group action as an <ActionElement />', ()=> {
-        beforeEach(() => {
-            controls.addGroupAction = ActionElement;
-        });
+    behavesLikeAnActionElement('+Rule', 'ruleGroup-addRule', 'custom-addRule-class');
+  });
 
-        behavesLikeAnActionElement(
-            '+Group',
-            'ruleGroup-addGroup',
-            'custom-addGroup-class');
+  describe('add group action as an <ActionElement />', () => {
+    beforeEach(() => {
+      controls.addGroupAction = ActionElement;
     });
 
-    describe('remove group action as an <ActionElement />', ()=> {
-        beforeEach(() => {
-            controls.removeGroupAction = ActionElement;
-        });
+    behavesLikeAnActionElement('+Group', 'ruleGroup-addGroup', 'custom-addGroup-class');
+  });
 
-        it('does not exist if it does not have a parent', () => {
-            props.parentId = null;
-            const dom = shallow(<RuleGroup {...props} />);
-            expect(dom.find('ActionElement')).to.have.length(0);
-        });
-
-        behavesLikeAnActionElement(
-            'x',
-            'ruleGroup-remove',
-            'custom-removeGroup-class');
+  describe('remove group action as an <ActionElement />', () => {
+    beforeEach(() => {
+      controls.removeGroupAction = ActionElement;
     });
 
-    describe('when 2 rules exist', ()=> {
-        beforeEach(()=>{
-            props.rules = [
-                _createRule(1),
-                _createRule(2)
-            ]
-        });
-
-        it('has 2 <Rule /> elements', ()=>{
-            const dom = shallow(<RuleGroup {...props} />);
-            expect(dom.find('Rule')).to.have.length(2);
-        });
-
-        it('has the first rule with the correct values', ()=>{
-            const dom = shallow(<RuleGroup {...props} />);
-            const ruleProps = dom.find('Rule').first().props();
-            expect(ruleProps.id).to.equal('rule_id_1');
-            expect(ruleProps.field).to.equal('field_1');
-            expect(ruleProps.operator).to.equal('operator_1');
-            expect(ruleProps.value).to.equal('value_1');
-        });
+    it('does not exist if it does not have a parent', () => {
+      props.parentId = null;
+      const dom = shallow(<RuleGroup {...props} />);
+      expect(dom.find('ActionElement')).to.have.length(0);
     });
 
-    describe('when 1 rule group exists', ()=> {
-        beforeEach(()=>{
-            props.rules = [
-                _createRuleGroup(1, props.id, [])
-            ]
-            schema.isRuleGroup = (rule) => { return true; }
-        });
+    behavesLikeAnActionElement('x', 'ruleGroup-remove', 'custom-removeGroup-class');
+  });
 
-        it('has 1 <RuleGroup /> element', ()=> {
-            const dom = shallow(<RuleGroup {...props} />);
-            expect(dom.find('RuleGroup')).to.have.length(1);
-        })
-
-        it('has 1 <RuleGroup /> with expected properties', ()=> {
-            const dom = shallow(<RuleGroup {...props} />);
-            const groupProps = dom.find('RuleGroup').props();
-            expect(groupProps.id).to.equal('rule_group_id_1');
-            expect(groupProps.parentId).to.equal('id');
-            expect(groupProps.rules).to.be.an('array');
-            expect(groupProps.combinator).to.equal('and');
-        })
+  describe('when 2 rules exist', () => {
+    beforeEach(() => {
+      props.rules = [_createRule(1), _createRule(2)];
     });
 
-    describe('#hasParentGroup', ()=>{
-        describe('when it has a parentId', ()=>{
-            beforeEach(()=>{
-                props.parentId = 'any_parent_id';
-            });
-
-            it('returns truthy', ()=> {
-                const instance = shallow(<RuleGroup {...props} />).instance();
-                expect(instance.hasParentGroup()).isOk;
-            });
-        })
-
-        describe('when it does not have a parentId', ()=>{
-            beforeEach(()=>{
-                props.parentId = null;
-            });
-
-            it('returns falsey', ()=> {
-                const instance = shallow(<RuleGroup {...props} />).instance();
-                expect(instance.hasParentGroup()).isNotOk;
-            });
-        })
+    it('has 2 <Rule /> elements', () => {
+      const dom = shallow(<RuleGroup {...props} />);
+      expect(dom.find('Rule')).to.have.length(2);
     });
 
-    describe('#onCombinatorChange', ()=>{
-        it('calls the #onPropChange from the schema with expected values', ()=>{
-            let actualProperty, actualValue, actualId;
-            schema.onPropChange = (prop, value, id) => {
-                actualProperty = prop;
-                actualValue = value;
-                actualId = id;
-            }
-            const instance = shallow(<RuleGroup {...props} />).instance();
-            instance.onCombinatorChange('any_combinator_value');
+    it('has the first rule with the correct values', () => {
+      const dom = shallow(<RuleGroup {...props} />);
+      const ruleProps = dom
+        .find('Rule')
+        .first()
+        .props();
+      expect(ruleProps.id).to.equal('rule_id_1');
+      expect(ruleProps.field).to.equal('field_1');
+      expect(ruleProps.operator).to.equal('operator_1');
+      expect(ruleProps.value).to.equal('value_1');
+    });
+  });
 
-            expect(actualProperty).to.equal('combinator');
-            expect(actualValue).to.equal('any_combinator_value');
-            expect(actualId).to.equal('id');
-        });
+  describe('when 1 rule group exists', () => {
+    beforeEach(() => {
+      props.rules = [_createRuleGroup(1, props.id, [])];
+      schema.isRuleGroup = (rule) => {
+        return true;
+      };
     });
 
-    describe('#addRule', ()=>{
-        it('calls the #onRuleAdd from the schema with expected values', ()=>{
-            let actualRule, actualId;
-            schema.onRuleAdd = (rule, id) => {
-                actualRule = rule;
-                actualId = id;
-            }
-            const instance = shallow(<RuleGroup {...props} />).instance();
-            instance.addRule(_mockEvent());
-
-            expect(actualRule).to.include.keys('id', 'field', 'operator', 'value');
-            expect(actualId).to.equal('id');
-        });
+    it('has 1 <RuleGroup /> element', () => {
+      const dom = shallow(<RuleGroup {...props} />);
+      expect(dom.find('RuleGroup')).to.have.length(1);
     });
 
-    describe('#addGroup', ()=>{
-        it('calls the #onGroupAdd from the schema with expected values', ()=>{
-            let actualRuleGroup, actualId;
-            schema.onGroupAdd = (ruleGroup, id) => {
-                actualRuleGroup = ruleGroup;
-                actualId = id;
-            }
-            const instance = shallow(<RuleGroup {...props} />).instance();
-            instance.addGroup(_mockEvent());
+    it('has 1 <RuleGroup /> with expected properties', () => {
+      const dom = shallow(<RuleGroup {...props} />);
+      const groupProps = dom.find('RuleGroup').props();
+      expect(groupProps.id).to.equal('rule_group_id_1');
+      expect(groupProps.parentId).to.equal('id');
+      expect(groupProps.rules).to.be.an('array');
+      expect(groupProps.combinator).to.equal('and');
+    });
+  });
 
-            expect(actualRuleGroup).to.include.keys('id', 'parentId', 'rules');
-            expect(actualId).to.equal('id');
-        });
+  describe('#hasParentGroup', () => {
+    describe('when it has a parentId', () => {
+      beforeEach(() => {
+        props.parentId = 'any_parent_id';
+      });
+
+      it('returns truthy', () => {
+        const instance = shallow(<RuleGroup {...props} />).instance();
+        expect(instance.hasParentGroup()).isOk;
+      });
     });
 
-    describe('#removeGroup', ()=>{
-        it('calls the #onGroupRemove from the schema with expected values', ()=>{
-            let actualId, actualParentId;
-            schema.onGroupRemove = (id, parentId) => {
-                actualId = id;
-                actualParentId = parentId;
-            }
-            const instance = shallow(<RuleGroup {...props} />).instance();
-            instance.removeGroup(_mockEvent());
+    describe('when it does not have a parentId', () => {
+      beforeEach(() => {
+        props.parentId = null;
+      });
 
-            expect(actualId).to.equal('id');
-            expect(actualParentId).to.equal('parentId');
-        });
+      it('returns falsey', () => {
+        const instance = shallow(<RuleGroup {...props} />).instance();
+        expect(instance.hasParentGroup()).isNotOk;
+      });
+    });
+  });
+
+  describe('#onCombinatorChange', () => {
+    it('calls the #onPropChange from the schema with expected values', () => {
+      let actualProperty, actualValue, actualId;
+      schema.onPropChange = (prop, value, id) => {
+        actualProperty = prop;
+        actualValue = value;
+        actualId = id;
+      };
+      const instance = shallow(<RuleGroup {...props} />).instance();
+      instance.onCombinatorChange('any_combinator_value');
+
+      expect(actualProperty).to.equal('combinator');
+      expect(actualValue).to.equal('any_combinator_value');
+      expect(actualId).to.equal('id');
+    });
+  });
+
+  describe('#addRule', () => {
+    it('calls the #onRuleAdd from the schema with expected values', () => {
+      let actualRule, actualId;
+      schema.onRuleAdd = (rule, id) => {
+        actualRule = rule;
+        actualId = id;
+      };
+      const instance = shallow(<RuleGroup {...props} />).instance();
+      instance.addRule(_mockEvent());
+
+      expect(actualRule).to.include.keys('id', 'field', 'operator', 'value');
+      expect(actualId).to.equal('id');
+    });
+  });
+
+  describe('#addGroup', () => {
+    it('calls the #onGroupAdd from the schema with expected values', () => {
+      let actualRuleGroup, actualId;
+      schema.onGroupAdd = (ruleGroup, id) => {
+        actualRuleGroup = ruleGroup;
+        actualId = id;
+      };
+      const instance = shallow(<RuleGroup {...props} />).instance();
+      instance.addGroup(_mockEvent());
+
+      expect(actualRuleGroup).to.include.keys('id', 'parentId', 'rules');
+      expect(actualId).to.equal('id');
+    });
+  });
+
+  describe('#removeGroup', () => {
+    it('calls the #onGroupRemove from the schema with expected values', () => {
+      let actualId, actualParentId;
+      schema.onGroupRemove = (id, parentId) => {
+        actualId = id;
+        actualParentId = parentId;
+      };
+      const instance = shallow(<RuleGroup {...props} />).instance();
+      instance.removeGroup(_mockEvent());
+
+      expect(actualId).to.equal('id');
+      expect(actualParentId).to.equal('parentId');
+    });
+  });
+
+  //shared examples
+  function behavesLikeAnActionElement(label, defaultClassName, customClassName) {
+    it('should have the correct label', () => {
+      const dom = shallow(<RuleGroup {...props} />);
+      expect(dom.find('ActionElement').props().label).to.equal(label);
     });
 
-    //shared examples
-    function behavesLikeAnActionElement(label, defaultClassName, customClassName) {
-        it('should have the correct label', ()=>{
-            const dom = shallow(<RuleGroup {...props} />);
-            expect(dom.find('ActionElement').props().label).to.equal(label);
-        });
+    it('should have the onClick method handler', () => {
+      const dom = shallow(<RuleGroup {...props} />);
+      expect(dom.find('ActionElement').props().handleOnClick).to.be.a('function');
+    });
 
-        it('should have the onClick method handler', ()=> {
-            const dom = shallow(<RuleGroup {...props} />);
-            expect(dom.find('ActionElement').props().handleOnClick).to.be.a('function');
-        });
+    behavesLikeAnElementWithClassNames('ActionElement', defaultClassName, customClassName);
+  }
 
-        behavesLikeAnElementWithClassNames(
-            'ActionElement',
-            defaultClassName,
-            customClassName);
-    }
+  function behavesLikeAnElementWithClassNames(element, defaultClassName, customClassName) {
+    it('should have the default className', () => {
+      const dom = shallow(<RuleGroup {...props} />);
+      expect(dom.find(element).props().className).to.contain(defaultClassName);
+    });
 
-    function behavesLikeAnElementWithClassNames(element, defaultClassName, customClassName) {
-        it('should have the default className', ()=> {
-            const dom = shallow(<RuleGroup {...props} />);
-            expect(dom.find(element).props().className).to.contain(defaultClassName);
-        });
+    it('should have the custom className', () => {
+      const dom = shallow(<RuleGroup {...props} />);
+      expect(dom.find(element).props().className).to.contain(customClassName);
+    });
+    it('should pass down the existing rules array', () => {
+      props.rules = [_createRule(1), _createRule(2)];
+      const dom = shallow(<RuleGroup {...props} />);
+      expect(dom.find(element).props().rules).to.equal(props.rules);
+    });
+    it('should pass down the level of the element', () => {
+      props.rules = [_createRule(1), _createRule(2)];
+      const dom = shallow(<RuleGroup {...props} />);
+      expect(dom.find(element).props().level).to.equal(0);
+    });
+  }
 
-        it('should have the custom className', ()=> {
-            const dom = shallow(<RuleGroup {...props} />);
-            expect(dom.find(element).props().className).to.contain(customClassName);
-        });
-        it('should pass down the existing rules array', ()=> {
-            props.rules = [_createRule(1),_createRule(2)];
-            const dom = shallow(<RuleGroup {...props} />);
-            expect(dom.find(element).props().rules).to.equal(props.rules);
-        });
-         it('should pass down the level of the element', ()=> {
-            props.rules = [_createRule(1),_createRule(2)];
-            const dom = shallow(<RuleGroup {...props} />);
-            expect(dom.find(element).props().level).to.equal(0);
-        });
-    }
+  //helper functions
+  function _createRule(index) {
+    return {
+      id: 'rule_id_' + index,
+      field: 'field_' + index,
+      operator: 'operator_' + index,
+      value: 'value_' + index
+    };
+  }
 
-    //helper functions
-    function _createRule(index) {
-        return {
-            id: 'rule_id_' + index,
-            field: 'field_' + index,
-            operator: 'operator_' + index,
-            value: 'value_' + index
-        }
-    }
+  function _createRuleGroup(index, parentId, rules) {
+    return {
+      id: 'rule_group_id_' + index,
+      parentId: parentId,
+      rules: rules
+    };
+  }
 
-    function _createRuleGroup(index, parentId, rules) {
-        return {
-            id: 'rule_group_id_' + index,
-            parentId: parentId,
-            rules: rules
-        }
-    }
-
-    function _mockEvent() {
-        return {
-            preventDefault: ()=>{},
-            stopPropagation: ()=>{}
-        }
-    }
+  function _mockEvent() {
+    return {
+      preventDefault: () => {},
+      stopPropagation: () => {}
+    };
+  }
 });

--- a/src/controls/ValueSelector.jsx
+++ b/src/controls/ValueSelector.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ValueSelector = (props) => {
-  const {value, options, className, handleOnChange, title} = props;
+  const { value, options, className, handleOnChange, title } = props;
 
   return (
     <select className={className}
@@ -12,8 +12,9 @@ const ValueSelector = (props) => {
             onChange={e=>handleOnChange(e.target.value)}>
       {
         options.map(option=> {
+          const key = option.id ? `key-${option.id}` : `key-${option.name}`;
           return (
-            <option key={option.id || option.name} value={option.name}>{option.label}</option>
+            <option key={key} value={option.name}>{option.label}</option>
           );
         })
       }

--- a/src/controls/ValueSelector.test.js
+++ b/src/controls/ValueSelector.test.js
@@ -57,8 +57,8 @@ describe('<ValueSelector />', ()=> {
 
         it('the options should have keys 3 and 5', ()=> {
             const dom = shallow(<ValueSelector options={options} />);
-            expect(dom.find('option').at(0).key()).to.equal(fooId);
-            expect(dom.find('option').at(1).key()).to.equal(barId);
+            expect(dom.find('option').at(0).key()).to.equal(`key-${fooId}`);
+            expect(dom.find('option').at(1).key()).to.equal(`key-${barId}`);
         });
     });
 });


### PR DESCRIPTION
Refactor many QueryBuilder tests and make code formatting uniform.

Most test cases that were refactored are centred around making sure query IDs are generated properly if missing, both for initial query and for new given query through props, this is important since we're using IDs to generate keys.

This PR also improves the implementation of the demo, where we have an example of how the query builder behaves when it receives new props, which previously has been an issue.