### PR TITLE
Pass in new root to _notifyQueryChange

### DIFF
--- a/src/QueryBuilder.jsx
+++ b/src/QueryBuilder.jsx
@@ -257,10 +257,10 @@ const QueryBuilder = (props) => {
   /**
    * Executes the `onQueryChange` function, if provided
    */
-  const _notifyQueryChange = (root) => {
+  const _notifyQueryChange = (newRoot) => {
     const { onQueryChange } = props;
     if (onQueryChange) {
-      const query = cloneDeep(root);
+      const query = cloneDeep(newRoot);
       onQueryChange(query);
     }
   };

--- a/src/QueryBuilder.jsx
+++ b/src/QueryBuilder.jsx
@@ -179,7 +179,7 @@ const QueryBuilder = (props) => {
     const parent = findRule(parentId, rootCopy);
     parent.rules.push(rule);
     setRoot(rootCopy);
-    _notifyQueryChange();
+    _notifyQueryChange(rootCopy);
   };
 
   /**
@@ -192,7 +192,7 @@ const QueryBuilder = (props) => {
     const parent = findRule(parentId, rootCopy);
     parent.rules.push(group);
     setRoot(rootCopy);
-    _notifyQueryChange();
+    _notifyQueryChange(rootCopy);
   };
 
   /**
@@ -211,7 +211,7 @@ const QueryBuilder = (props) => {
     }
 
     setRoot(rootCopy);
-    _notifyQueryChange();
+    _notifyQueryChange(rootCopy);
   };
 
   /**
@@ -227,7 +227,7 @@ const QueryBuilder = (props) => {
     parent.rules.splice(index, 1);
 
     setRoot(rootCopy);
-    _notifyQueryChange();
+    _notifyQueryChange(rootCopy);
   };
 
   /**
@@ -243,7 +243,7 @@ const QueryBuilder = (props) => {
     parent.rules.splice(index, 1);
 
     setRoot(rootCopy);
-    _notifyQueryChange();
+    _notifyQueryChange(rootCopy);
   };
 
   /**
@@ -257,7 +257,7 @@ const QueryBuilder = (props) => {
   /**
    * Executes the `onQueryChange` function, if provided
    */
-  const _notifyQueryChange = () => {
+  const _notifyQueryChange = (root) => {
     const { onQueryChange } = props;
     if (onQueryChange) {
       const query = cloneDeep(root);
@@ -292,7 +292,7 @@ const QueryBuilder = (props) => {
 
   // Notify a query change on mount
   useEffect(() => {
-    _notifyQueryChange();
+    _notifyQueryChange(root);
   }, []);
 
   return (


### PR DESCRIPTION
The issue is that onPropChange() is updating the query asynchronously using setRoot(), then calling the onQueryChange function in the same thread, reading the root, and seeing the old value since the async update hasn't happened yet.

Fix is to pass the updated root directly to _notifyQueryChange().

Fixes #92.