### PR TITLE
#91 - Add functionality to pass custom data to CustomValueEditor and CustomOperatorSelector

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ This library exposes a React component, [`<QueryBuilder />`](#QueryBuilder), and
 
 #### fields _(Required)_
 
-`[ {name:String, label:String, id:ID} ]`
+`[ {name:String, label:String, id:ID, context: any} ]`
 
 The array of fields that should be used. Each field should be an object with:
 
-`{name:String, label:String, id:ID}` |
+`{name:String, label:String, id:ID, context: any}` |
 
 The `id` is optional, if you do not provide an id for a field then the name will be used.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ The array of fields that should be used. Each field should be an object with:
 
 `{name:String, label:String, id:ID, context: any}` |
 
-The `id` is optional, if you do not provide an id for a field then the name will be used.
+The `id` is optional, if you do not provide an id for a field then the name will be used. 
+
+Use the optional `context` property to pass any custom data to custom `valueEditor` and custom `operatorSelector`.
 
 #### operators _(Optional)_
 
@@ -202,7 +204,8 @@ This is a custom controls object that allows you to override the control element
   value: React.PropTypes.string, //selected operator from the existing query representation, if any
   className: React.PropTypes.string, //CSS classNames to be applied
   handleOnChange: React.PropTypes.func, //callback function to update query representation
-  level: React.PropTypes.number //The level the group this rule belongs to
+  level: React.PropTypes.number, //The level the group this rule belongs to
+  context: object //The optional context object attached to the field definition, null if not supplied
 }
 ```
 
@@ -218,7 +221,8 @@ This is a custom controls object that allows you to override the control element
   inputType: React.PropTypes.string, //type of <input> if type is "text"
   values: React.PropTypes.arrayOf(React.PropTypes.object), //
   level: React.PropTypes.number, //The level the group this rule belongs to
-  className: React.PropTypes.string, //CSS classNames to be applied
+  className: React.PropTypes.string, //CSS classNames to be applied,
+  context: object //The optional context object attached to the field definition, null if not supplied
 }
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,21 +70,24 @@ interface FieldSelectorCustomControlProps extends SelectorEditorCustomControlPro
   options: NameLabelPair[];
 }
 
-interface OperatorSelectorCustomControlProps extends SelectorEditorCustomControlProps {
+interface OperatorSelectorCustomControlProps<T = any> extends SelectorEditorCustomControlProps {
   field?: string;
   options: NameLabelPair[];
+  context?: T;
 }
 
-interface ValueEditorCustomControlProps extends SelectorEditorCustomControlProps {
+interface ValueEditorCustomControlProps<T = any> extends SelectorEditorCustomControlProps {
   field?: string;
   operator?: string;
   type?: ValueEditorType;
   inputType?: string;
   values?: any[];
+  context?: T;
 }
 
-interface Field extends NameLabelPair {
+interface Field<T = any> extends NameLabelPair {
   id?: string;
+  context?: T;
 }
 
 interface QueryBuilderProps {

--- a/src/QueryBuilder.test.js
+++ b/src/QueryBuilder.test.js
@@ -69,7 +69,7 @@ describe('<QueryBuilder />', () => {
     };
 
     const fields = [
-      { name: 'firstName', label: 'First Name' },
+      { name: 'firstName', label: 'First Name', context: { prop: 'prop_value' } },
       { name: 'lastName', label: 'Last Name' },
       { name: 'age', label: 'Age' }
     ];
@@ -91,9 +91,14 @@ describe('<QueryBuilder />', () => {
 
     it('should have the Rule with the correct props', () => {
       const rule = wrapper.find('Rule');
+
+      console.log(rule.props().schema.fields);
+
       expect(rule.props().field).to.equal('firstName');
       expect(rule.props().value).to.equal('Test without ID');
       expect(rule.props().operator).to.equal('=');
+      expect(rule.props().context === null || rule.props().context === undefined).to.be.false;
+      expect(rule.props().context.prop).to.equal('prop_value');
     });
 
     it('should have a select control with the provided fields', () => {

--- a/src/Rule.jsx
+++ b/src/Rule.jsx
@@ -7,6 +7,7 @@ const Rule = ({
   operator,
   value,
   translations,
+  context,
   schema: {
     classNames,
     controls,
@@ -63,6 +64,7 @@ const Rule = ({
         className={`rule-operators ${classNames.operators}`}
         handleOnChange={onOperatorChanged}
         level={level}
+        context={context}
       />
       <controls.valueEditor
         field={field}
@@ -75,6 +77,7 @@ const Rule = ({
         className={`rule-value ${classNames.value}`}
         handleOnChange={onValueChanged}
         level={level}
+        context={context}
       />
       <controls.removeRuleAction
         label={translations.removeRule.label}
@@ -93,7 +96,8 @@ Rule.defaultProps = {
   field: null,
   operator: null,
   value: null,
-  schema: null
+  schema: null,
+  context: null
 };
 
 Rule.displayName = 'Rule';

--- a/src/Rule.test.js
+++ b/src/Rule.test.js
@@ -138,6 +138,23 @@ describe('<Rule />', () => {
       expect(dom.find('ValueSelector').props().field).to.equal('selected_field');
     });
 
+    it('should have context set to specified value if supplied', () => {
+      props.context = { prop1: 'prop1_value'};
+      const dom = shallow(<Rule {...props} />);
+
+      const contextFromProps = dom.find('ValueSelector').props().context;
+
+      expect(contextFromProps === undefined || contextFromProps === null).to.be.false;
+      expect(contextFromProps.prop1 === undefined || contextFromProps.prop1 === null).to.be.false;
+      expect(contextFromProps.prop1).to.equal('prop1_value');
+    });
+
+    it('should have context set to null if not supplied', () => {
+      const dom = shallow(<Rule {...props} />);
+
+      expect(dom.find('ValueSelector').props().context === null).to.be.true;
+    });
+
     behavesLikeASelector('operator', 'rule-operators', 'custom-operators-class');
   });
 
@@ -165,6 +182,23 @@ describe('<Rule />', () => {
       const dom = shallow(<Rule {...props} />);
 
       expect(dom.find('ValueEditor').props().value).to.equal('specified_value');
+    });
+
+    it('should have context set to specified value if supplied', () => {
+      props.context = { prop1: 'prop1_value'};
+      const dom = shallow(<Rule {...props} />);
+
+      const contextFromProps = dom.find('ValueEditor').props().context;
+
+      expect(contextFromProps === undefined || contextFromProps === null).to.be.false;
+      expect(contextFromProps.prop1 === undefined || contextFromProps.prop1 === null).to.be.false;
+      expect(contextFromProps.prop1).to.equal('prop1_value');
+    });
+
+    it('should have context set to null if not supplied', () => {
+      const dom = shallow(<Rule {...props} />);
+
+      expect(dom.find('ValueEditor').props().context === null).to.be.true;
     });
 
     it('should have the onChange method handler', () => {

--- a/src/Rule.test.js
+++ b/src/Rule.test.js
@@ -139,7 +139,7 @@ describe('<Rule />', () => {
     });
 
     it('should have context set to specified value if supplied', () => {
-      props.context = { prop1: 'prop1_value'};
+      props.context = { prop1: 'prop1_value' };
       const dom = shallow(<Rule {...props} />);
 
       const contextFromProps = dom.find('ValueSelector').props().context;
@@ -185,7 +185,7 @@ describe('<Rule />', () => {
     });
 
     it('should have context set to specified value if supplied', () => {
-      props.context = { prop1: 'prop1_value'};
+      props.context = { prop1: 'prop1_value' };
       const dom = shallow(<Rule {...props} />);
 
       const contextFromProps = dom.find('ValueEditor').props().context;

--- a/src/RuleGroup.jsx
+++ b/src/RuleGroup.jsx
@@ -53,6 +53,16 @@ const RuleGroup = ({ id, parentId, combinator, rules, translations, schema, not 
 
   const level = getLevel(id);
 
+  const getContextData = (rule) => {
+    const field = rule && schema && schema.fields
+      ? schema.fields.find((f) => f.name === rule.field) 
+      : null;
+
+    return field
+      ? field.context
+      : null;
+  };
+
   return (
     <div className={`ruleGroup ${classNames.ruleGroup}`} data-rule-group-id={id} data-level={level}>
       {showCombinatorsBetweenRules ? null : (
@@ -131,6 +141,7 @@ const RuleGroup = ({ id, parentId, combinator, rules, translations, schema, not 
               schema={schema}
               parentId={id}
               translations={translations}
+              context={getContextData(r)}
             />
           )}
         </Fragment>

--- a/src/RuleGroup.jsx
+++ b/src/RuleGroup.jsx
@@ -54,13 +54,10 @@ const RuleGroup = ({ id, parentId, combinator, rules, translations, schema, not 
   const level = getLevel(id);
 
   const getContextData = (rule) => {
-    const field = rule && schema && schema.fields
-      ? schema.fields.find((f) => f.name === rule.field) 
-      : null;
+    const field =
+      rule && schema && schema.fields ? schema.fields.find((f) => f.name === rule.field) : null;
 
-    return field
-      ? field.context
-      : null;
+    return field ? field.context : null;
   };
 
   return (

--- a/src/RuleGroup.test.js
+++ b/src/RuleGroup.test.js
@@ -168,11 +168,13 @@ describe('<RuleGroup />', () => {
     });
 
     it('has the first rule with the correct values', () => {
-      props.schema.fields = [{
-        name: 'field_1',
-        label: 'label_1',
-        context: { prop: `prop_value` }
-      }];
+      props.schema.fields = [
+        {
+          name: 'field_1',
+          label: 'label_1',
+          context: { prop: `prop_value` }
+        }
+      ];
 
       const dom = shallow(<RuleGroup {...props} />);
       const ruleProps = dom
@@ -387,7 +389,7 @@ describe('<RuleGroup />', () => {
       field: 'field_' + index,
       operator: 'operator_' + index,
       value: 'value_' + index,
-      context: { prop: `prop${index}_value`}
+      context: { prop: `prop${index}_value` }
     };
   }
 

--- a/src/RuleGroup.test.js
+++ b/src/RuleGroup.test.js
@@ -168,6 +168,12 @@ describe('<RuleGroup />', () => {
     });
 
     it('has the first rule with the correct values', () => {
+      props.schema.fields = [{
+        name: 'field_1',
+        label: 'label_1',
+        context: { prop: `prop_value` }
+      }];
+
       const dom = shallow(<RuleGroup {...props} />);
       const ruleProps = dom
         .find('Rule')
@@ -177,6 +183,8 @@ describe('<RuleGroup />', () => {
       expect(ruleProps.field).to.equal('field_1');
       expect(ruleProps.operator).to.equal('operator_1');
       expect(ruleProps.value).to.equal('value_1');
+      expect(ruleProps.context !== null && ruleProps.context !== undefined).to.be.true;
+      expect(ruleProps.context.prop).to.equal('prop_value');
     });
   });
 
@@ -250,7 +258,7 @@ describe('<RuleGroup />', () => {
       const dom = mount(<RuleGroup {...props} />);
       dom.find('.ruleGroup-addRule').simulate('click');
 
-      expect(actualRule).to.include.keys('id', 'field', 'operator', 'value');
+      expect(actualRule).to.include.keys('id', 'field', 'operator', 'value', 'context');
       expect(actualId).to.equal('id');
     });
   });
@@ -378,7 +386,8 @@ describe('<RuleGroup />', () => {
       id: 'rule_id_' + index,
       field: 'field_' + index,
       operator: 'operator_' + index,
-      value: 'value_' + index
+      value: 'value_' + index,
+      context: { prop: `prop${index}_value`}
     };
   }
 


### PR DESCRIPTION
For (partially) [#91](https://github.com/sapientglobalmarkets/react-querybuilder/issues/91)

Added an optional context object for schema fields that will be passed to any CustomValueEditor and CustomOperatorSelector.

Any issues just let me know :)