### PR TITLE
Bugfix/not property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ interface RuleGroup {
   id: string;
   combinator: string;
   rules: (Rule | RuleGroup)[];
+  not?: boolean;
 }
 
 type ValueEditorType = 'text' | 'select' | 'checkbox' | 'radio';

--- a/src/RuleGroup.jsx
+++ b/src/RuleGroup.jsx
@@ -121,6 +121,7 @@ const RuleGroup = ({ id, parentId, combinator, rules, translations, schema, not 
               combinator={r.combinator}
               translations={translations}
               rules={r.rules}
+              not={r.not}
             />
           ) : (
             <Rule

--- a/src/RuleGroup.test.js
+++ b/src/RuleGroup.test.js
@@ -223,6 +223,30 @@ describe('<RuleGroup />', () => {
   });
 
   describe('onNotToggleChange', () => {
+    it('should set NOT property on ruleGroups below root', () => {
+      // given
+      const idOfNestedRuleGroup = "nested"
+      const propsWithNestedRuleGroup = {
+        ...props,
+        id: "root",
+        rules: [
+          {
+            id: idOfNestedRuleGroup,
+            combinator: "and",
+            rules: [],
+            not: true
+          }
+        ]
+      }
+      propsWithNestedRuleGroup.schema.isRuleGroup = () => true
+
+      // when
+      const dom = mount(<RuleGroup {...propsWithNestedRuleGroup}/>);
+
+      // then
+      expect(dom.find(RuleGroup).find({id: idOfNestedRuleGroup}).props().not).to.equal(true);
+    })
+
     it('calls onPropChange from the schema with expected values', () => {
       let actualProperty, actualValue, actualId;
       schema.onPropChange = (prop, value, id) => {


### PR DESCRIPTION
Fix for the issue that currently, the NOT property of a ruleGroup below root is not set, thus always undefined. Can be verified in the live-demo.

Also added the not-property to RuleGroup's type definition.