### PR TITLE
Create 'json_without_ids' format option in formatQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Pass `false` not to reset operator and value for field change.
 
 ### formatQuery
 
-`formatQuery` formats a given query in either JSON or SQL format. Example:
+`formatQuery` formats a given query in either SQL, JSON, or JSON without ids 'json_without_ids' (can be useful if you need to serialize the rules). Example:
 
 ```js
 import { formatQuery } from 'react-querybuilder';
@@ -468,6 +468,47 @@ const valueProcessor = (field, operator, value) => {
 };
 
 console.log(formatQuery(query, 'sql', valueProcessor)); // '(instrument in ("Guitar","Vocals") and lastName = "Vai")'
+```
+
+Or you can pass 'json_without_ids' to get the same query without the IDs, it can be useful if you need to save the query to the url so that it becomes bookmarkable:
+
+```js
+const query = {
+  id: 'g-J5GsbcFmZ6xOJCLPPKIfE',
+  rules: [
+    {
+      id: 'r-KneYcwIPPHDGSogtKhG4g',
+      field: 'instrument',
+      value: ['Guitar', 'Vocals'],
+      operator: 'in'
+    },
+    {
+      id: 'r-wz6AkZbzSyDYbPk1AxgvO',
+      field: 'lastName',
+      value: 'Vai',
+      operator: '='
+    }
+  ],
+  combinator: 'and',
+  not: false
+};
+console.log(formatQuery(query, 'json_without_ids')); 
+// {
+//   rules: [
+//     {
+//       field: 'instrument',
+//       value: ['Guitar', 'Vocals'],
+//       operator: 'in'
+//     },
+//     {
+//       field: 'lastName',
+//       value: 'Vai',
+//       operator: '='
+//     }
+//   ],
+//   combinator: 'and',
+//   not: false
+// };
 ```
 
 ## Development

--- a/index.d.ts
+++ b/index.d.ts
@@ -283,6 +283,6 @@ export default class QueryBuilder extends React.Component<QueryBuilderProps> {}
  */
 export function formatQuery(
   ruleGroup: RuleGroup,
-  format: 'json' | 'sql',
+  format: 'json' | 'sql' | 'json_without_ids',
   valueProcessor?: (field: string, operator: string, value: any) => string
 ): string;

--- a/src/utils/formatQuery.js
+++ b/src/utils/formatQuery.js
@@ -6,12 +6,12 @@ import { isRuleGroup } from '.';
  * based on a given field, operator, and value.  By default, values are
  * processed assuming the default operators are being used.
  * @param {RuleGroup} ruleGroup
- * @param {"json"|"sql"} format
+ * @param {"json"|"sql"|"json_without_ids"} format
  * @param {Function} valueProcessor
  */
 const formatQuery = (ruleGroup, format, valueProcessor) => {
   if (format.toLowerCase() === 'json') {
-    return JSON.stringify(ruleGroup, null, 2);
+    return JSON.stringify(ruleGroup, null, 2)
   } else if (format.toLowerCase() === 'sql') {
     const valueProc =
       valueProcessor ||
@@ -78,9 +78,20 @@ const formatQuery = (ruleGroup, format, valueProcessor) => {
     };
 
     return processRuleGroup(ruleGroup);
+  } else if (format.toLowerCase() === 'json_without_ids') {
+    return JSON.stringify(removeIdsFromRuleGroup(ruleGroup))
   } else {
     return '';
   }
 };
+
+const removeIdsFromRuleGroup = ruleGroup => {
+  const ruleGroupCopy = { ...ruleGroup };
+  delete ruleGroupCopy.id;
+  if (ruleGroupCopy.rules) {
+    ruleGroupCopy.rules = ruleGroupCopy.rules.map(rule => removeIdsFromRuleGroup(rule));
+  }
+  return ruleGroupCopy;
+}
 
 export default formatQuery;

--- a/src/utils/formatQuery.js
+++ b/src/utils/formatQuery.js
@@ -6,7 +6,7 @@ import { isRuleGroup } from '.';
  * based on a given field, operator, and value.  By default, values are
  * processed assuming the default operators are being used.
  * @param {RuleGroup} ruleGroup
- * @param {"json"|"sql"} format
+ * @param {"json"|"sql"|"json_without_ids"} format
  * @param {Function} valueProcessor
  */
 const formatQuery = (ruleGroup, format, valueProcessor) => {
@@ -78,9 +78,20 @@ const formatQuery = (ruleGroup, format, valueProcessor) => {
     };
 
     return processRuleGroup(ruleGroup);
+  } else if (format.toLowerCase() === 'json_without_ids') {
+    return JSON.stringify(removeIdsFromRuleGroup(ruleGroup))
   } else {
     return '';
   }
 };
+
+const removeIdsFromRuleGroup = ruleGroup => {
+  const ruleGroupCopy = { ...ruleGroup };
+  delete ruleGroupCopy.id;
+  if (ruleGroupCopy.rules) {
+    ruleGroupCopy.rules = ruleGroupCopy.rules.map(rule => removeIdsFromRuleGroup(rule));
+  }
+  return ruleGroupCopy;
+}
 
 export default formatQuery;

--- a/src/utils/formatQuery.js
+++ b/src/utils/formatQuery.js
@@ -11,7 +11,7 @@ import { isRuleGroup } from '.';
  */
 const formatQuery = (ruleGroup, format, valueProcessor) => {
   if (format.toLowerCase() === 'json') {
-    return JSON.stringify(ruleGroup, null, 2)
+    return JSON.stringify(ruleGroup, null, 2);
   } else if (format.toLowerCase() === 'sql') {
     const valueProc =
       valueProcessor ||

--- a/src/utils/formatQuery.test.js
+++ b/src/utils/formatQuery.test.js
@@ -155,4 +155,96 @@ describe('formatQuery', () => {
       '(instrument in ("Guitar","Vocals") and lastName = "Vai")'
     );
   });
+
+  it('handles json_without_ids correctly', () => {
+    const example_without_ids = {
+      rules: [
+        {
+          field: 'firstName',
+          value: '',
+          operator: 'null'
+        },
+        {
+          field: 'lastName',
+          value: '',
+          operator: 'notNull'
+        },
+        {
+          field: 'firstName',
+          value: 'Test,This',
+          operator: 'in'
+        },
+        {
+          field: 'lastName',
+          value: 'Test,This',
+          operator: 'notIn'
+        },
+        {
+          field: 'age',
+          value: '26',
+          operator: '='
+        },
+        {
+          field: 'isMusician',
+          value: true,
+          operator: '='
+        },
+        {
+          rules: [
+            {
+              field: 'gender',
+              value: 'M',
+              operator: '='
+            },
+            {
+              field: 'job',
+              value: 'Programmer',
+              operator: '!='
+            },
+            {
+              field: 'email',
+              value: '@',
+              operator: 'contains'
+            }
+          ],
+          combinator: 'or',
+          not: true
+        },
+        {
+          rules: [
+            {
+              field: 'lastName',
+              value: 'ab',
+              operator: 'doesNotContain'
+            },
+            {
+              field: 'job',
+              value: 'Prog',
+              operator: 'beginsWith'
+            },
+            {
+              field: 'email',
+              value: 'com',
+              operator: 'endsWith'
+            },
+            {
+              field: 'job',
+              value: 'Man',
+              operator: 'doesNotBeginWith'
+            },
+            {
+              field: 'email',
+              value: 'fr',
+              operator: 'doesNotEndWith'
+            }
+          ],
+          combinator: 'or',
+          not: false
+        }
+      ],
+      combinator: 'and',
+      not: false
+    };
+    expect(formatQuery(query, 'json_without_ids')).to.equal(JSON.stringify(example_without_ids));
+  })
 });


### PR DESCRIPTION
Hi small addition to the formats available, as I said in issue #124  needed a query that can fit nicely in a URL.

Not sure about 'json_without_ids' name, but looks self explanatory to me.