### PR TITLE
createRule giving `name` of undefined when fields are empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-querybuilder",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "The React <QueryBuilder /> component for constructing queries",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-querybuilder",
-  "version": "3.7.1",
+  "version": "3.7.0",
   "description": "The React <QueryBuilder /> component for constructing queries",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/src/QueryBuilder.tsx
+++ b/src/QueryBuilder.tsx
@@ -134,7 +134,10 @@ export const QueryBuilder: React.FC<QueryBuilderProps> = ({
   };
 
   const createRule = (): RuleType => {
-    let field = fields[0].name;
+    let field = '';
+    if (fields && fields[0]) {
+      field = fields[0].name
+    }
     if (getDefaultField) {
       if (typeof getDefaultField === 'string') {
         field = getDefaultField;

--- a/src/__tests__/QueryBuilder.test.tsx
+++ b/src/__tests__/QueryBuilder.test.tsx
@@ -89,6 +89,27 @@ describe('<QueryBuilder />', () => {
     });
   });
 
+  describe('when initial query, without fields, is provided create rule should work', () => {
+    let wrapper: ReactWrapper;
+
+    beforeEach(() => {
+      const newProps = cloneDeep(props);
+      delete newProps.fields;
+      act(() => {
+        wrapper = mount(<QueryBuilder {...newProps} />);
+      });
+    });
+
+    afterEach(() => {
+      wrapper.unmount();
+    });
+
+    it('should be able to create rule on add rule click', () => {
+      wrapper.find('.ruleGroup-addRule').first().simulate('click');
+      expect(wrapper.find(Rule).length).to.eq(1);
+    });
+  });
+
   describe('when initial query, without ID, is provided', () => {
     let wrapper: ReactWrapper;
     const queryWithoutID = {


### PR DESCRIPTION
Resolves #159 

Bugfix for createRule giving `name` of undefined when fields are passed empty.