### PR TITLE
Added ability to disable inital queryChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,12 @@ Pass `false` not to reset operator and value for field change.
 
 Pass `true` to reset value on operator change.
 
+#### `enableMountQueryChange` _(Optional)_
+
+`boolean`
+
+Pass `false` to disable the `onQueryChange` on mount of component which will set default value.
+
 ### formatQuery
 
 `formatQuery` formats a given query in either SQL, parameterized SQL, JSON, or JSON without IDs (which can be useful if you need to serialize the rules). Example:

--- a/src/QueryBuilder.tsx
+++ b/src/QueryBuilder.tsx
@@ -112,6 +112,7 @@ export const QueryBuilder = ({
   operators = defaultOperators,
   combinators = defaultCombinators,
   translations = defaultTranslations,
+  enableMountQueryChange = true,
   controlElements,
   getDefaultField,
   getDefaultValue,
@@ -389,7 +390,9 @@ export const QueryBuilder = ({
 
   // Notify a query change on mount
   useEffect(() => {
-    _notifyQueryChange(root);
+    if (enableMountQueryChange) {
+      _notifyQueryChange(root);
+    }
   }, []);
 
   return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -287,6 +287,7 @@ export interface QueryBuilderProps {
    */
   combinators?: NameLabelPair[];
   controlElements?: Partial<Controls>;
+  enableMountQueryChange: boolean;
   /**
    * The default field for new rules.  This can be a string identifying the
    * default field, or a function that returns a field name.

--- a/src/types.ts
+++ b/src/types.ts
@@ -287,7 +287,7 @@ export interface QueryBuilderProps {
    */
   combinators?: NameLabelPair[];
   controlElements?: Partial<Controls>;
-  enableMountQueryChange: boolean;
+  enableMountQueryChange?: boolean;
   /**
    * The default field for new rules.  This can be a string identifying the
    * default field, or a function that returns a field name.


### PR DESCRIPTION
- Added ability to disable default callback on component mount.

Useful if someone (me 😄 ) wants to have `null | RuleGroupType` as a value, with current implementation its hard since it automatically invokes the callback on mount.