### PR TITLE
export `RuleGroup` just like `Rule`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
-          # This is important to fetch the changes to the previous commit
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Prettify code
         uses: creyD/prettier_action@v3.1

--- a/packages/react-querybuilder/src/index.ts
+++ b/packages/react-querybuilder/src/index.ts
@@ -3,6 +3,7 @@ export { QueryBuilder };
 export * from './defaults';
 export * from './utils';
 export { Rule } from './Rule';
+import { RuleGroup } from './RuleGroup';
 export { InlineCombinator } from './InlineCombinator';
 export * from './controls/';
 export * from './types';

--- a/packages/react-querybuilder/src/index.ts
+++ b/packages/react-querybuilder/src/index.ts
@@ -3,7 +3,7 @@ export { QueryBuilder };
 export * from './defaults';
 export * from './utils';
 export { Rule } from './Rule';
-import { RuleGroup } from './RuleGroup';
+export { RuleGroup } from './RuleGroup';
 export { InlineCombinator } from './InlineCombinator';
 export * from './controls/';
 export * from './types';


### PR DESCRIPTION
export `RuleGroup` from the query builder just like `Rule`

since `RuleGroup` is customizable through the `controlElements` property, it'd make sense exporting it for reusing purpose.