### PR TITLE
Query tools

### DIFF
--- a/packages/react-querybuilder/src/QueryBuilder.tsx
+++ b/packages/react-querybuilder/src/QueryBuilder.tsx
@@ -27,13 +27,11 @@ import {
   isOptionGroupArray,
   isRuleGroup,
   move,
-  pathsAreEqual,
   prepareRuleGroup,
   remove,
   uniqByName,
   uniqOptGroups,
   update,
-  updateCombinator,
 } from './utils';
 
 enableES5();
@@ -320,9 +318,10 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
   };
 
   const updateIndependentCombinator = (value: string, path: number[]) => {
+    // TODO: merge this into onPropChange
     /* istanbul ignore next */
     if (queryDisabled) return;
-    const newQuery = updateCombinator(root, value, path);
+    const newQuery = update(root, 'combinator', value, path, {});
     dispatch(newQuery);
   };
 
@@ -334,15 +333,12 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
   };
 
   const moveRule = (oldPath: number[], newPath: number[], clone?: boolean) => {
-    // No-op if entire query is disabled or the old and new paths are the same.
-    // Ignore in test coverage since components that call this method
-    // already prevent this case via their respective canDrop tests.
     /* istanbul ignore if */
-    if (queryDisabled || pathsAreEqual(oldPath, newPath)) {
+    if (queryDisabled) {
       return;
     }
 
-    const newQuery = move(root, oldPath, newPath, { clone, combinators, independentCombinators });
+    const newQuery = move(root, oldPath, newPath, { clone, combinators });
     dispatch(newQuery);
   };
 

--- a/packages/react-querybuilder/src/QueryBuilder.tsx
+++ b/packages/react-querybuilder/src/QueryBuilder.tsx
@@ -382,13 +382,14 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
       c(
         standardClassnames.queryBuilder,
         classNames.queryBuilder,
+        queryDisabled ? standardClassnames.disabled : '',
         typeof validationResult === 'boolean'
           ? validationResult
             ? standardClassnames.valid
             : standardClassnames.invalid
           : ''
       ),
-    [classNames.queryBuilder, validationResult]
+    [classNames.queryBuilder, queryDisabled, validationResult]
   );
 
   return (

--- a/packages/react-querybuilder/src/QueryBuilder.tsx
+++ b/packages/react-querybuilder/src/QueryBuilder.tsx
@@ -1,4 +1,4 @@
-import produce, { enableES5 } from 'immer';
+import { enableES5 } from 'immer';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -20,21 +20,20 @@ import {
   Schema,
 } from './types';
 import {
+  add,
   c,
-  findPath,
   generateID,
-  getCommonAncestorPath,
   getFirstOption,
-  getParentPath,
   isOptionGroupArray,
   isRuleGroup,
+  move,
   pathsAreEqual,
-  prepareRule,
   prepareRuleGroup,
-  regenerateID,
-  regenerateIDs,
+  remove,
   uniqByName,
   uniqOptGroups,
+  update,
+  updateCombinator,
 } from './utils';
 
 enableES5();
@@ -259,11 +258,7 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
   // that the query has already been prepared, i.e. the user is just passing back
   // the onQueryChange callback parameter as query. This appears to have a huge
   // performance impact.
-  const root: RG = query
-    ? isFirstRender.current
-      ? (prepareRuleGroup(query) as any)
-      : query
-    : queryState;
+  const root: RG = query ? (isFirstRender.current ? prepareRuleGroup(query) : query) : queryState;
   isFirstRender.current = false;
 
   // Notify a query change on mount
@@ -279,31 +274,23 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
    * Executes the `onQueryChange` function if provided,
    * and sets the state for uncontrolled components
    */
-  const dispatch = (newQuery: RG) => {
-    // State variable only used when component is uncontrolled
-    if (!query) {
-      setQueryState(newQuery);
-    }
-    onQueryChange(newQuery);
-  };
+  const dispatch = useCallback(
+    (newQuery: RG) => {
+      // State variable only used when component is uncontrolled
+      if (!query) {
+        setQueryState(newQuery);
+      }
+      onQueryChange(newQuery);
+    },
+    [onQueryChange, query]
+  );
 
   const onRuleAdd = (rule: RuleType, parentPath: number[]) => {
     /* istanbul ignore next */
     if (queryDisabled) return;
     const newRule = onAddRule(rule, parentPath, root);
     if (!newRule) return;
-    const newQuery = produce(root, draft => {
-      const parent = findPath(parentPath, draft) as RG;
-      if ('combinator' in parent) {
-        parent.rules.push(prepareRule(newRule));
-      } else {
-        if (parent.rules.length > 0) {
-          const prevCombinator = parent.rules[parent.rules.length - 2];
-          parent.rules.push((typeof prevCombinator === 'string' ? prevCombinator : 'and') as any);
-        }
-        parent.rules.push(prepareRule(newRule));
-      }
-    });
+    const newQuery = add(root, newRule, parentPath);
     dispatch(newQuery);
   };
 
@@ -312,47 +299,22 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
     if (queryDisabled) return;
     const newGroup = onAddGroup(group, parentPath, root);
     if (!newGroup) return;
-    const newQuery = produce(root, draft => {
-      const parent = findPath(parentPath, draft) as RG;
-      /* istanbul ignore else */
-      if ('combinator' in parent) {
-        parent.rules.push(prepareRuleGroup(newGroup) as any);
-      } else if (!('combinator' in parent)) {
-        if (parent.rules.length > 0) {
-          const prevCombinator = parent.rules[parent.rules.length - 2];
-          parent.rules.push((typeof prevCombinator === 'string' ? prevCombinator : 'and') as any);
-        }
-        parent.rules.push(prepareRuleGroup(newGroup) as any);
-      }
-    });
+    const newQuery = add(root, newGroup, parentPath);
     dispatch(newQuery);
   };
 
   const onPropChange = (
-    prop: Exclude<keyof RuleType | keyof RuleGroupType, 'id' | 'path'>,
+    prop: Exclude<keyof (RuleType & RuleGroupType), 'id' | 'path' | 'rules'>,
     value: any,
     path: number[]
   ) => {
     /* istanbul ignore next */
     if (queryDisabled) return;
-    const newQuery = produce(root, draft => {
-      const ruleOrGroup = findPath(path, draft);
-      /* istanbul ignore if */
-      if (!ruleOrGroup) return;
-      const isGroup = 'rules' in ruleOrGroup;
-      (ruleOrGroup as any)[prop] = value;
-      if (!isGroup) {
-        // Reset operator and set default value for field change
-        if (resetOnFieldChange && prop === 'field') {
-          ruleOrGroup.operator = getRuleDefaultOperator(value);
-          ruleOrGroup.value = getRuleDefaultValue({ ...ruleOrGroup, field: value });
-        }
-
-        // Set default value for operator change
-        if (resetOnOperatorChange && prop === 'operator') {
-          ruleOrGroup.value = getRuleDefaultValue({ ...ruleOrGroup, operator: value });
-        }
-      }
+    const newQuery = update(root, prop, value, path, {
+      resetOnFieldChange,
+      resetOnOperatorChange,
+      getRuleDefaultOperator,
+      getRuleDefaultValue,
     });
     dispatch(newQuery);
   };
@@ -360,29 +322,14 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
   const updateIndependentCombinator = (value: string, path: number[]) => {
     /* istanbul ignore next */
     if (queryDisabled) return;
-    const parentPath = getParentPath(path);
-    const index = path[path.length - 1];
-    const newQuery = produce(root, draft => {
-      const parentRules = (findPath(parentPath, draft) as RG).rules;
-      parentRules[index] = value;
-    });
+    const newQuery = updateCombinator(root, value, path);
     dispatch(newQuery);
   };
 
   const onRuleOrGroupRemove = (path: number[]) => {
     /* istanbul ignore next */
     if (queryDisabled) return;
-    const parentPath = getParentPath(path);
-    const index = path[path.length - 1];
-    const newQuery = produce(root, draft => {
-      const parent = findPath(parentPath, draft) as RG;
-      if (!('combinator' in parent) && parent.rules.length > 1) {
-        const idxStartDelete = index === 0 ? 0 : index - 1;
-        parent.rules.splice(idxStartDelete, 2);
-      } else {
-        parent.rules.splice(index, 1);
-      }
-    });
+    const newQuery = remove(root, path);
     dispatch(newQuery);
   };
 
@@ -395,81 +342,7 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
       return;
     }
 
-    const parentOldPath = getParentPath(oldPath);
-    const ruleOrGroupOriginal = findPath(oldPath, root);
-    /* istanbul ignore if */
-    if (!ruleOrGroupOriginal) return;
-    const ruleOrGroup = clone
-      ? 'rules' in ruleOrGroupOriginal
-        ? regenerateIDs(ruleOrGroupOriginal)
-        : regenerateID(ruleOrGroupOriginal)
-      : ruleOrGroupOriginal;
-
-    const commonAncestorPath = getCommonAncestorPath(oldPath, newPath);
-    const movingOnUp = newPath[commonAncestorPath.length] <= oldPath[commonAncestorPath.length];
-
-    const newQuery = produce(root, draft => {
-      const parentOfRuleToRemove = findPath(parentOldPath, draft) as RG;
-      const ruleToRemoveIndex = oldPath[oldPath.length - 1];
-      const oldPrevCombinator =
-        independentCombinators && ruleToRemoveIndex > 0
-          ? (parentOfRuleToRemove.rules[ruleToRemoveIndex - 1] as string)
-          : null;
-      const oldNextCombinator =
-        independentCombinators && ruleToRemoveIndex < parentOfRuleToRemove.rules.length - 1
-          ? (parentOfRuleToRemove.rules[ruleToRemoveIndex + 1] as string)
-          : null;
-      /* istanbul ignore else */
-      if (!clone) {
-        const idxStartDelete = independentCombinators
-          ? Math.max(0, ruleToRemoveIndex - 1)
-          : ruleToRemoveIndex;
-        const deleteLength = independentCombinators ? 2 : 1;
-        // Remove the source item
-        parentOfRuleToRemove.rules.splice(idxStartDelete, deleteLength);
-      }
-
-      const newNewPath = [...newPath];
-      /* istanbul ignore else */
-      if (!movingOnUp && !clone) {
-        newNewPath[commonAncestorPath.length] -= independentCombinators ? 2 : 1;
-      }
-      const newNewParentPath = getParentPath(newNewPath);
-      const parentToInsertInto = findPath(newNewParentPath, draft) as RG;
-      const newIndex = newNewPath[newNewPath.length - 1];
-
-      // This function 1) glosses over the need for type assertions to splice directly
-      // into parentToInsertInto.rules, and 2) simplifies the actual insertion code.
-      const insertRuleOrGroup = (...args: any[]) =>
-        parentToInsertInto.rules.splice(newIndex, 0, ...args);
-
-      // Insert the source item at the target path
-      if (parentToInsertInto.rules.length === 0 || !independentCombinators) {
-        insertRuleOrGroup(ruleOrGroup);
-      } else {
-        if (newIndex === 0) {
-          if (ruleToRemoveIndex === 0 && oldNextCombinator) {
-            insertRuleOrGroup(ruleOrGroup, oldNextCombinator);
-          } else {
-            const newNextCombinator =
-              parentToInsertInto.rules[1] ||
-              oldPrevCombinator ||
-              /* istanbul ignore next */ getFirstOption(combinators);
-            insertRuleOrGroup(ruleOrGroup, newNextCombinator);
-          }
-        } else {
-          if (oldPrevCombinator) {
-            insertRuleOrGroup(oldPrevCombinator, ruleOrGroup);
-          } else {
-            const newPrevCombinator =
-              parentToInsertInto.rules[newIndex - 2] ||
-              oldNextCombinator ||
-              getFirstOption(combinators);
-            insertRuleOrGroup(newPrevCombinator, ruleOrGroup);
-          }
-        }
-      }
-    });
+    const newQuery = move(root, oldPath, newPath, { clone, combinators, independentCombinators });
     dispatch(newQuery);
   };
 
@@ -477,7 +350,10 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
     () => (typeof validator === 'function' ? validator(root) : {}),
     [root, validator]
   );
-  const validationMap = typeof validationResult === 'object' ? validationResult : {};
+  const validationMap = useMemo(
+    () => (typeof validationResult === 'object' ? validationResult : {}),
+    [validationResult]
+  );
 
   const classNames = useMemo(
     () => ({ ...defaultControlClassnames, ...controlClassnames }),

--- a/packages/react-querybuilder/src/QueryBuilder.tsx
+++ b/packages/react-querybuilder/src/QueryBuilder.tsx
@@ -18,6 +18,7 @@ import {
   RuleGroupTypeIC,
   RuleType,
   Schema,
+  UpdateableProperties,
 } from './types';
 import {
   add,
@@ -168,7 +169,7 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
   const getRuleDefaultValue = useCallback(
     (rule: RuleType) => {
       const fieldData = fieldMap[rule.field];
-      /* istanbul ignore next */
+      /* istanbul ignore if */
       if (fieldData?.defaultValue !== undefined && fieldData.defaultValue !== null) {
         return fieldData.defaultValue;
       } else if (getDefaultValue) {
@@ -260,7 +261,6 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
   isFirstRender.current = false;
 
   // Notify a query change on mount
-  /* istanbul ignore next */
   useEffect(() => {
     if (enableMountQueryChange) {
       onQueryChange(root);
@@ -284,7 +284,6 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
   );
 
   const onRuleAdd = (rule: RuleType, parentPath: number[]) => {
-    /* istanbul ignore next */
     if (queryDisabled) return;
     const newRule = onAddRule(rule, parentPath, root);
     if (!newRule) return;
@@ -293,7 +292,6 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
   };
 
   const onGroupAdd = (group: RG, parentPath: number[]) => {
-    /* istanbul ignore next */
     if (queryDisabled) return;
     const newGroup = onAddGroup(group, parentPath, root);
     if (!newGroup) return;
@@ -301,12 +299,7 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
     dispatch(newQuery);
   };
 
-  const onPropChange = (
-    prop: Exclude<keyof (RuleType & RuleGroupType), 'id' | 'path' | 'rules'>,
-    value: any,
-    path: number[]
-  ) => {
-    /* istanbul ignore next */
+  const onPropChange = (prop: UpdateableProperties, value: any, path: number[]) => {
     if (queryDisabled) return;
     const newQuery = update(root, prop, value, path, {
       resetOnFieldChange,
@@ -318,26 +311,18 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
   };
 
   const updateIndependentCombinator = (value: string, path: number[]) => {
-    // TODO: merge this into onPropChange
-    /* istanbul ignore next */
-    if (queryDisabled) return;
-    const newQuery = update(root, 'combinator', value, path, {});
-    dispatch(newQuery);
+    // TODO: remove this and just use onPropChange
+    onPropChange('combinator', value, path);
   };
 
   const onRuleOrGroupRemove = (path: number[]) => {
-    /* istanbul ignore next */
     if (queryDisabled) return;
     const newQuery = remove(root, path);
     dispatch(newQuery);
   };
 
   const moveRule = (oldPath: number[], newPath: number[], clone?: boolean) => {
-    /* istanbul ignore if */
-    if (queryDisabled) {
-      return;
-    }
-
+    if (queryDisabled) return;
     const newQuery = move(root, oldPath, newPath, { clone, combinators });
     dispatch(newQuery);
   };

--- a/packages/react-querybuilder/src/Rule.tsx
+++ b/packages/react-querybuilder/src/Rule.tsx
@@ -126,6 +126,7 @@ export const Rule = ({
   const outerClassName = c(
     standardClassnames.rule,
     classNames.rule,
+    disabled ? standardClassnames.disabled : '',
     validationClassName,
     dndDragging,
     dndOver

--- a/packages/react-querybuilder/src/RuleGroup.tsx
+++ b/packages/react-querybuilder/src/RuleGroup.tsx
@@ -147,6 +147,7 @@ export const RuleGroup = ({
   const outerClassName = c(
     standardClassnames.ruleGroup,
     classNames.ruleGroup,
+    disabled ? standardClassnames.disabled : '',
     validationClassName,
     dndDragging
   );

--- a/packages/react-querybuilder/src/__tests__/QueryBuilder.test.tsx
+++ b/packages/react-querybuilder/src/__tests__/QueryBuilder.test.tsx
@@ -1540,6 +1540,10 @@ describe('enableDragAndDrop', () => {
 });
 
 describe('disabled', () => {
+  it('should have the correct classname', () => {
+    const { container } = render(<QueryBuilder disabled />);
+    expect(container.querySelectorAll('div')[0]).toHaveClass(sc.disabled);
+  });
   it('prevents changes when disabled', () => {
     const onQueryChange = jest.fn();
     const { getAllByLabelText, getAllByTestId, getAllByTitle, getAllByDisplayValue } = render(

--- a/packages/react-querybuilder/src/__tests__/QueryBuilder.test.tsx
+++ b/packages/react-querybuilder/src/__tests__/QueryBuilder.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { simulateDragDrop, wrapWithTestBackend } from 'react-dnd-test-utils';
-import { defaultTranslations, standardClassnames, TestID } from '../defaults';
+import { defaultTranslations as t, standardClassnames as sc, TestID } from '../defaults';
 import { QueryBuilder as QueryBuilderOriginal } from '../QueryBuilder';
 import type {
   Field,
@@ -27,7 +27,7 @@ const stripQueryIds = (query: any) => JSON.parse(formatQuery(query, 'json_withou
 describe('when rendered', () => {
   it('should have the correct className', () => {
     const { container } = render(<QueryBuilder />);
-    expect(container.querySelectorAll('div')[0]).toHaveClass(standardClassnames.queryBuilder);
+    expect(container.querySelectorAll('div')[0]).toHaveClass(sc.queryBuilder);
   });
 
   it('should render the root RuleGroup', () => {
@@ -804,7 +804,7 @@ describe('valueEditorType property in field', () => {
 
     userEvent.click(getByTestId(TestID.addRule));
 
-    expect(container.querySelector(`select.${standardClassnames.value}`)).toBeDefined();
+    expect(container.querySelector(`select.${sc.value}`)).toBeDefined();
   });
 });
 
@@ -821,10 +821,8 @@ describe('operators property in field', () => {
 
     userEvent.click(getByTestId(TestID.addRule));
 
-    expect(container.querySelector(`select.${standardClassnames.operators}`)).toBeDefined();
-    expect(
-      container.querySelectorAll(`select.${standardClassnames.operators} option`)
-    ).toHaveLength(1);
+    expect(container.querySelector(`select.${sc.operators}`)).toBeDefined();
+    expect(container.querySelectorAll(`select.${sc.operators} option`)).toHaveLength(1);
   });
 });
 
@@ -841,9 +839,9 @@ describe('autoSelectField', () => {
 
     userEvent.click(getByTestId(TestID.addRule));
 
-    expect(container.querySelectorAll(`select.${standardClassnames.fields}`)).toHaveLength(1);
-    expect(container.querySelectorAll(`select.${standardClassnames.operators}`)).toHaveLength(0);
-    expect(container.querySelectorAll(`.${standardClassnames.value}`)).toHaveLength(0);
+    expect(container.querySelectorAll(`select.${sc.fields}`)).toHaveLength(1);
+    expect(container.querySelectorAll(`select.${sc.operators}`)).toHaveLength(0);
+    expect(container.querySelectorAll(`.${sc.value}`)).toHaveLength(0);
   });
 });
 
@@ -896,7 +894,7 @@ describe('showCloneButtons', () => {
           }}
         />
       );
-      userEvent.click(getAllByText(defaultTranslations.cloneRule.label)[0]);
+      userEvent.click(getAllByText(t.cloneRule.label)[0]);
       expect(stripQueryIds(onQueryChange.mock.calls[1][0])).toEqual({
         combinator: 'and',
         rules: [
@@ -925,7 +923,7 @@ describe('showCloneButtons', () => {
           }}
         />
       );
-      userEvent.click(getAllByText(defaultTranslations.cloneRule.label)[0]);
+      userEvent.click(getAllByText(t.cloneRule.label)[0]);
       expect(stripQueryIds(onQueryChange.mock.calls[1][0])).toEqual({
         combinator: 'and',
         rules: [
@@ -950,7 +948,7 @@ describe('showCloneButtons', () => {
           }}
         />
       );
-      userEvent.click(getByText(defaultTranslations.cloneRule.label));
+      userEvent.click(getByText(t.cloneRule.label));
       expect(stripQueryIds(onQueryChange.mock.calls[1][0])).toEqual({
         rules: [
           { field: 'firstName', operator: '=', value: 'Steve' },
@@ -976,7 +974,7 @@ describe('showCloneButtons', () => {
           }}
         />
       );
-      userEvent.click(getAllByText(defaultTranslations.cloneRule.label)[0]);
+      userEvent.click(getAllByText(t.cloneRule.label)[0]);
       expect(stripQueryIds(onQueryChange.mock.calls[1][0])).toEqual({
         rules: [
           { field: 'firstName', operator: '=', value: 'Steve' },
@@ -1004,7 +1002,7 @@ describe('showCloneButtons', () => {
           }}
         />
       );
-      userEvent.click(getAllByText(defaultTranslations.cloneRule.label)[1]);
+      userEvent.click(getAllByText(t.cloneRule.label)[1]);
       expect(stripQueryIds(onQueryChange.mock.calls[1][0])).toEqual({
         rules: [
           { field: 'firstName', operator: '=', value: 'Steve' },
@@ -1141,49 +1139,33 @@ describe('independent combinators', () => {
 describe('validation', () => {
   it('should not validate if no validator function is provided', () => {
     const { container } = render(<QueryBuilder />);
-    expect(container.querySelector(`div.${standardClassnames.queryBuilder}`)).not.toHaveClass(
-      standardClassnames.valid
-    );
-    expect(container.querySelector(`div.${standardClassnames.queryBuilder}`)).not.toHaveClass(
-      standardClassnames.invalid
-    );
+    expect(container.querySelector(`div.${sc.queryBuilder}`)).not.toHaveClass(sc.valid);
+    expect(container.querySelector(`div.${sc.queryBuilder}`)).not.toHaveClass(sc.invalid);
   });
 
   it('should validate groups if default validator function is provided', () => {
     const { container, getByTestId } = render(<QueryBuilder validator={defaultValidator} />);
     userEvent.click(getByTestId(TestID.addGroup));
     // Expect the root group to be valid (contains the inner group)
-    expect(
-      container.querySelectorAll(`.${standardClassnames.ruleGroup}.${standardClassnames.valid}`)
-    ).toHaveLength(1);
+    expect(container.querySelectorAll(`.${sc.ruleGroup}.${sc.valid}`)).toHaveLength(1);
     // Expect the inner group to be invalid (empty)
-    expect(
-      container.querySelectorAll(`.${standardClassnames.ruleGroup}.${standardClassnames.invalid}`)
-    ).toHaveLength(1);
+    expect(container.querySelectorAll(`.${sc.ruleGroup}.${sc.invalid}`)).toHaveLength(1);
   });
 
   it('should use custom validator function returning false', () => {
     const validator = jest.fn(() => false);
     const { container } = render(<QueryBuilder validator={validator} />);
     expect(validator).toHaveBeenCalled();
-    expect(container.querySelector(`div.${standardClassnames.queryBuilder}`)).not.toHaveClass(
-      standardClassnames.valid
-    );
-    expect(container.querySelector(`div.${standardClassnames.queryBuilder}`)).toHaveClass(
-      standardClassnames.invalid
-    );
+    expect(container.querySelector(`div.${sc.queryBuilder}`)).not.toHaveClass(sc.valid);
+    expect(container.querySelector(`div.${sc.queryBuilder}`)).toHaveClass(sc.invalid);
   });
 
   it('should use custom validator function returning true', () => {
     const validator = jest.fn(() => true);
     const { container } = render(<QueryBuilder validator={validator} />);
     expect(validator).toHaveBeenCalled();
-    expect(container.querySelector(`div.${standardClassnames.queryBuilder}`)).toHaveClass(
-      standardClassnames.valid
-    );
-    expect(container.querySelector(`div.${standardClassnames.queryBuilder}`)).not.toHaveClass(
-      standardClassnames.invalid
-    );
+    expect(container.querySelector(`div.${sc.queryBuilder}`)).toHaveClass(sc.valid);
+    expect(container.querySelector(`div.${sc.queryBuilder}`)).not.toHaveClass(sc.invalid);
   });
 
   it('should pass down validationMap to children', () => {
@@ -1527,11 +1509,11 @@ describe('enableDragAndDrop', () => {
           }}
         />
       );
-      const ruleDrag = getAllByTestId(TestID.rule)[1];
-      const ruleDrop = getAllByTestId(TestID.rule)[3];
+      const dragRule = getAllByTestId(TestID.rule)[1];
+      const dropRule = getAllByTestId(TestID.rule)[3];
       simulateDragDrop(
-        getHandlerId(ruleDrag, 'drag'),
-        getHandlerId(ruleDrop, 'drop'),
+        getHandlerId(dragRule, 'drag'),
+        getHandlerId(dropRule, 'drop'),
         getDndBackend()
       );
       expect(stripQueryIds(onQueryChange.mock.calls[1][0])).toEqual({
@@ -1595,21 +1577,21 @@ describe('disabled', () => {
         }}
       />
     );
-    userEvent.click(getAllByTitle(defaultTranslations.addRule.title)[0]);
-    userEvent.click(getAllByTitle(defaultTranslations.addGroup.title)[0]);
-    userEvent.click(getAllByTitle(defaultTranslations.removeRule.title)[0]);
-    userEvent.click(getAllByTitle(defaultTranslations.removeGroup.title)[0]);
-    userEvent.click(getAllByTitle(defaultTranslations.cloneRule.title)[0]);
-    userEvent.click(getAllByTitle(defaultTranslations.cloneRuleGroup.title)[0]);
-    userEvent.click(getAllByLabelText(defaultTranslations.notToggle.label)[0]);
+    userEvent.click(getAllByTitle(t.addRule.title)[0]);
+    userEvent.click(getAllByTitle(t.addGroup.title)[0]);
+    userEvent.click(getAllByTitle(t.removeRule.title)[0]);
+    userEvent.click(getAllByTitle(t.removeGroup.title)[0]);
+    userEvent.click(getAllByTitle(t.cloneRule.title)[0]);
+    userEvent.click(getAllByTitle(t.cloneRuleGroup.title)[0]);
+    userEvent.click(getAllByLabelText(t.notToggle.label)[0]);
     userEvent.selectOptions(getAllByDisplayValue('Field 0')[0], 'field1');
     userEvent.selectOptions(getAllByDisplayValue('=')[0], '>');
-    userEvent.selectOptions(getAllByDisplayValue('=')[0], '>');
-    const ruleDrag = getAllByTestId(TestID.rule)[1];
-    const ruleDrop = getAllByTestId(TestID.rule)[3];
+    userEvent.type(getAllByDisplayValue('4')[0], 'Not 4');
+    const dragRule = getAllByTestId(TestID.rule)[1];
+    const dropRule = getAllByTestId(TestID.rule)[3];
     simulateDragDrop(
-      getHandlerId(ruleDrag, 'drag'),
-      getHandlerId(ruleDrop, 'drop'),
+      getHandlerId(dragRule, 'drag'),
+      getHandlerId(dropRule, 'drop'),
       getDndBackend()
     );
     expect(onQueryChange).not.toHaveBeenCalled();
@@ -1643,5 +1625,63 @@ describe('disabled', () => {
     expect(getAllByTestId(TestID.fields)[2]).toBeDisabled();
     expect(getAllByTestId(TestID.operators)[2]).toBeDisabled();
     expect(getAllByTestId(TestID.valueEditor)[2]).toBeDisabled();
+  });
+
+  it('prevents changes from custom components when disabled', () => {
+    const onQueryChange = jest.fn();
+    const ruleToAdd: RuleType = { field: 'f1', operator: '=', value: 'v1' };
+    const groupToAdd: RuleGroupTypeIC = { rules: [] };
+    const { getByTestId } = render(
+      <QueryBuilder
+        fields={[
+          { name: 'field0', label: 'Field 0' },
+          { name: 'field1', label: 'Field 1' },
+          { name: 'field2', label: 'Field 2' },
+          { name: 'field3', label: 'Field 3' },
+          { name: 'field4', label: 'Field 4' },
+        ]}
+        enableMountQueryChange={false}
+        independentCombinators
+        onQueryChange={onQueryChange}
+        enableDragAndDrop
+        showCloneButtons
+        showNotToggle
+        disabled
+        controlElements={{
+          ruleGroup: ({ schema }) => (
+            <div data-testid={TestID.ruleGroup}>
+              <button onClick={() => schema.onRuleAdd(ruleToAdd, [])} />
+              <button onClick={() => schema.onGroupAdd(groupToAdd, [])} />
+              <button onClick={() => schema.onPropChange('field', 'f2', [0])} />
+              <button onClick={() => schema.updateIndependentCombinator('or', [1])} />
+              <button onClick={() => schema.onRuleRemove([0])} />
+              <button onClick={() => schema.onGroupRemove([6])} />
+              <button onClick={() => schema.moveRule([6], [0])} />
+              <button onClick={() => schema.moveRule([6], [0], true)} />
+            </div>
+          ),
+        }}
+        query={{
+          rules: [
+            { field: 'field0', operator: '=', value: '0' },
+            'and',
+            { field: 'field1', operator: '=', value: '1' },
+            'and',
+            { field: 'field2', operator: '=', value: '2' },
+            'and',
+            {
+              rules: [
+                { field: 'field3', operator: '=', value: '3' },
+                'and',
+                { field: 'field4', operator: '=', value: '4' },
+              ],
+            },
+          ],
+        }}
+      />
+    );
+    const rg = getByTestId(TestID.ruleGroup);
+    rg.querySelectorAll('button').forEach(b => userEvent.click(b));
+    expect(onQueryChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-querybuilder/src/__tests__/Rule.test.tsx
+++ b/packages/react-querybuilder/src/__tests__/Rule.test.tsx
@@ -8,7 +8,7 @@ import {
   wrapWithTestBackend,
 } from 'react-dnd-test-utils';
 import { act } from 'react-dom/test-utils';
-import { defaultTranslations, standardClassnames, TestID } from '../defaults';
+import { defaultTranslations as t, standardClassnames as sc, TestID } from '../defaults';
 import { Rule as RuleOriginal } from '../Rule';
 import type {
   ActionProps,
@@ -123,12 +123,12 @@ const getProps = (mergeIntoSchema?: Partial<Schema>): RuleProps => ({
   operator: 'operator',
   schema: { ...schema, ...mergeIntoSchema } as Schema,
   path: [0],
-  translations: defaultTranslations,
+  translations: t,
 });
 
 it('should have correct classNames', () => {
   const { getByTestId } = render(<Rule {...getProps()} />);
-  expect(getByTestId(TestID.rule)).toHaveClass(standardClassnames.rule, 'custom-rule-class');
+  expect(getByTestId(TestID.rule)).toHaveClass(sc.rule, 'custom-rule-class');
 });
 
 describe('onElementChanged methods', () => {
@@ -138,7 +138,7 @@ describe('onElementChanged methods', () => {
       const props = { ...getProps({ onPropChange }) };
       const { getByTestId } = render(<Rule {...props} />);
       userEvent.selectOptions(
-        getByTestId(TestID.rule).querySelector(`select.${standardClassnames.fields}`)!,
+        getByTestId(TestID.rule).querySelector(`select.${sc.fields}`)!,
         'any_field'
       );
       expect(onPropChange).toHaveBeenCalledWith('field', 'any_field', [0]);
@@ -151,7 +151,7 @@ describe('onElementChanged methods', () => {
       const props = { ...getProps({ onPropChange }) };
       const { getByTestId } = render(<Rule {...props} />);
       userEvent.selectOptions(
-        getByTestId(TestID.rule).querySelector(`select.${standardClassnames.operators}`)!,
+        getByTestId(TestID.rule).querySelector(`select.${sc.operators}`)!,
         'any_operator'
       );
       expect(onPropChange).toHaveBeenCalledWith('operator', 'any_operator', [0]);
@@ -163,10 +163,7 @@ describe('onElementChanged methods', () => {
       const onPropChange = jest.fn();
       const props = { ...getProps({ onPropChange }) };
       const { getByTestId } = render(<Rule {...props} />);
-      userEvent.type(
-        getByTestId(TestID.rule).querySelector(`input.${standardClassnames.value}`)!,
-        'any_value'
-      );
+      userEvent.type(getByTestId(TestID.rule).querySelector(`input.${sc.value}`)!, 'any_value');
       expect(onPropChange).toHaveBeenCalledWith('value', 'any_value', [0]);
     });
   });
@@ -176,7 +173,7 @@ describe('cloneRule', () => {
   it('should call moveRule with the right paths', () => {
     const moveRule = jest.fn();
     const { getByText } = render(<Rule {...getProps({ moveRule, showCloneButtons: true })} />);
-    userEvent.click(getByText(defaultTranslations.cloneRule.label));
+    userEvent.click(getByText(t.cloneRule.label));
     expect(moveRule).toHaveBeenCalledWith([0], [1], true);
   });
 });
@@ -185,7 +182,7 @@ describe('removeRule', () => {
   it('should call onRuleRemove with the rule and path', () => {
     const onRuleRemove = jest.fn();
     const { getByText } = render(<Rule {...getProps({ onRuleRemove })} />);
-    userEvent.click(getByText(defaultTranslations.removeRule.label));
+    userEvent.click(getByText(t.removeRule.label));
     expect(onRuleRemove).toHaveBeenCalledWith([0]);
   });
 });
@@ -193,8 +190,8 @@ describe('removeRule', () => {
 describe('validation', () => {
   it('should not validate if no validationMap[id] value exists and no validator function is provided', () => {
     const { getByTestId } = render(<Rule {...getProps()} />);
-    expect(getByTestId(TestID.rule)).not.toHaveClass(standardClassnames.valid);
-    expect(getByTestId(TestID.rule)).not.toHaveClass(standardClassnames.invalid);
+    expect(getByTestId(TestID.rule)).not.toHaveClass(sc.valid);
+    expect(getByTestId(TestID.rule)).not.toHaveClass(sc.invalid);
   });
 
   it('should validate to false if validationMap[id] = false even if a validator function is provided', () => {
@@ -202,24 +199,24 @@ describe('validation', () => {
     const fieldMap = { field1: { name: 'field1', label: 'Field 1', validator } };
     const validationMap = { id: false };
     const { getByTestId } = render(<Rule {...getProps({ fieldMap, validationMap })} />);
-    expect(getByTestId(TestID.rule)).not.toHaveClass(standardClassnames.valid);
-    expect(getByTestId(TestID.rule)).toHaveClass(standardClassnames.invalid);
+    expect(getByTestId(TestID.rule)).not.toHaveClass(sc.valid);
+    expect(getByTestId(TestID.rule)).toHaveClass(sc.invalid);
     expect(validator).not.toHaveBeenCalled();
   });
 
   it('should validate to true if validationMap[id] = true', () => {
     const validationMap = { id: true };
     const { getByTestId } = render(<Rule {...getProps({ validationMap })} />);
-    expect(getByTestId(TestID.rule)).toHaveClass(standardClassnames.valid);
-    expect(getByTestId(TestID.rule)).not.toHaveClass(standardClassnames.invalid);
+    expect(getByTestId(TestID.rule)).toHaveClass(sc.valid);
+    expect(getByTestId(TestID.rule)).not.toHaveClass(sc.invalid);
   });
 
   it('should validate if validationMap[id] does not exist and a validator function is provided', () => {
     const validator = jest.fn(() => true);
     const fieldMap = { field1: { name: 'field1', label: 'Field 1', validator } };
     const { getByTestId } = render(<Rule {...getProps({ fieldMap })} field="field1" />);
-    expect(getByTestId(TestID.rule)).toHaveClass(standardClassnames.valid);
-    expect(getByTestId(TestID.rule)).not.toHaveClass(standardClassnames.invalid);
+    expect(getByTestId(TestID.rule)).toHaveClass(sc.valid);
+    expect(getByTestId(TestID.rule)).not.toHaveClass(sc.invalid);
     expect(validator).toHaveBeenCalled();
   });
 
@@ -246,14 +243,14 @@ describe('enableDragAndDrop', () => {
   it('should not have the drag class if not dragging', () => {
     const { getByTestId } = render(<Rule {...getProps()} />);
     const rule = getByTestId(TestID.rule);
-    expect(rule).not.toHaveClass(standardClassnames.dndDragging);
+    expect(rule).not.toHaveClass(sc.dndDragging);
   });
 
   it('should have the drag class if dragging', () => {
     const { getByTestId } = render(<Rule {...getProps()} />);
     const rule = getByTestId(TestID.rule);
     simulateDrag(getHandlerId(rule, 'drag'), getDndBackend());
-    expect(rule).toHaveClass(standardClassnames.dndDragging);
+    expect(rule).toHaveClass(sc.dndDragging);
     act(() => {
       getDndBackend().simulateEndDrag();
     });
@@ -272,7 +269,7 @@ describe('enableDragAndDrop', () => {
       getHandlerId(rules[1], 'drop'),
       getDndBackend()
     );
-    expect(rules[1]).toHaveClass(standardClassnames.dndOver);
+    expect(rules[1]).toHaveClass(sc.dndOver);
     act(() => {
       getDndBackend().simulateEndDrag();
     });
@@ -292,8 +289,8 @@ describe('enableDragAndDrop', () => {
       getHandlerId(rules[1], 'drop'),
       getDndBackend()
     );
-    expect(rules[0]).not.toHaveClass(standardClassnames.dndDragging);
-    expect(rules[1]).not.toHaveClass(standardClassnames.dndOver);
+    expect(rules[0]).not.toHaveClass(sc.dndDragging);
+    expect(rules[1]).not.toHaveClass(sc.dndOver);
     expect(moveRule).toHaveBeenCalledWith([0], [2]);
   });
 
@@ -302,8 +299,8 @@ describe('enableDragAndDrop', () => {
     const { getByTestId } = render(<Rule {...getProps({ moveRule })} />);
     const rule = getByTestId(TestID.rule);
     simulateDragDrop(getHandlerId(rule, 'drag'), getHandlerId(rule, 'drop'), getDndBackend());
-    expect(rule).not.toHaveClass(standardClassnames.dndDragging);
-    expect(rule).not.toHaveClass(standardClassnames.dndOver);
+    expect(rule).not.toHaveClass(sc.dndDragging);
+    expect(rule).not.toHaveClass(sc.dndOver);
     expect(moveRule).not.toHaveBeenCalled();
   });
 
@@ -326,6 +323,10 @@ describe('enableDragAndDrop', () => {
 });
 
 describe('disabled', () => {
+  it('should have the correct classname', () => {
+    const { getByTestId } = render(<Rule {...getProps()} disabled />);
+    expect(getByTestId(TestID.rule)).toHaveClass(sc.disabled);
+  });
   it('does not try to update the query', () => {
     const onRuleRemove = jest.fn();
     const onPropChange = jest.fn();

--- a/packages/react-querybuilder/src/__tests__/RuleGroup.test.tsx
+++ b/packages/react-querybuilder/src/__tests__/RuleGroup.test.tsx
@@ -3,7 +3,12 @@ import userEvent from '@testing-library/user-event';
 import { forwardRef } from 'react';
 import { simulateDrag, simulateDragDrop, wrapWithTestBackend } from 'react-dnd-test-utils';
 import { act } from 'react-dom/test-utils';
-import { defaultCombinators, defaultTranslations, standardClassnames, TestID } from '../defaults';
+import {
+  defaultCombinators,
+  defaultTranslations as t,
+  standardClassnames as sc,
+  TestID,
+} from '../defaults';
 import { Rule } from '../Rule';
 import { RuleGroup as RuleGroupOriginal } from '../RuleGroup';
 import type {
@@ -190,20 +195,19 @@ const getProps = (mergeIntoSchema?: Partial<Schema>): RuleGroupProps => ({
   rules: [],
   combinator: 'and',
   schema: { ...schema, ...mergeIntoSchema } as Schema,
-  translations: defaultTranslations,
+  translations: t,
   disabled: false,
 });
 
 it('should have correct classNames', () => {
   const { getByTestId } = render(<RuleGroup {...getProps()} />);
-  expect(getByTestId(TestID.ruleGroup)).toHaveClass(standardClassnames.ruleGroup);
-  expect(getByTestId(TestID.ruleGroup)).toHaveClass('custom-ruleGroup-class');
-  expect(
-    getByTestId(TestID.ruleGroup).querySelector(`.${standardClassnames.header}`)!.classList
-  ).toContain(classNames.header);
-  expect(
-    getByTestId(TestID.ruleGroup).querySelector(`.${standardClassnames.body}`)!.classList
-  ).toContain(classNames.body);
+  expect(getByTestId(TestID.ruleGroup)).toHaveClass(sc.ruleGroup, 'custom-ruleGroup-class');
+  expect(getByTestId(TestID.ruleGroup).querySelector(`.${sc.header}`)!.classList).toContain(
+    classNames.header
+  );
+  expect(getByTestId(TestID.ruleGroup).querySelector(`.${sc.body}`)!.classList).toContain(
+    classNames.body
+  );
 });
 
 describe('when 2 rules exist', () => {
@@ -220,9 +224,9 @@ describe('when 2 rules exist', () => {
     );
     const firstRule = getAllByTestId(TestID.rule)[0];
     expect(firstRule.dataset.ruleId).toBe('rule_id_1');
-    expect(firstRule.querySelector(`.${standardClassnames.fields}`)).toHaveValue('field1');
-    expect(firstRule.querySelector(`.${standardClassnames.operators}`)).toHaveValue('operator1');
-    expect(firstRule.querySelector(`.${standardClassnames.value}`)).toHaveValue('value_1');
+    expect(firstRule.querySelector(`.${sc.fields}`)).toHaveValue('field1');
+    expect(firstRule.querySelector(`.${sc.operators}`)).toHaveValue('operator1');
+    expect(firstRule.querySelector(`.${sc.value}`)).toHaveValue('value_1');
   });
 });
 
@@ -230,10 +234,7 @@ describe('onCombinatorChange', () => {
   it('calls onPropChange from the schema with expected values', () => {
     const onPropChange = jest.fn();
     const { container } = render(<RuleGroup {...getProps({ onPropChange })} />);
-    userEvent.selectOptions(
-      container.querySelector(`.${standardClassnames.combinators}`)!,
-      'any_combinator_value'
-    );
+    userEvent.selectOptions(container.querySelector(`.${sc.combinators}`)!, 'any_combinator_value');
     expect(onPropChange).toHaveBeenCalledWith('combinator', 'any_combinator_value', [0]);
   });
 });
@@ -253,7 +254,7 @@ describe('addRule', () => {
   it('calls onRuleAdd from the schema with expected values', () => {
     const onRuleAdd = jest.fn();
     const { getByText } = render(<RuleGroup {...getProps({ onRuleAdd })} />);
-    userEvent.click(getByText(defaultTranslations.addRule.label));
+    userEvent.click(getByText(t.addRule.label));
     const call0 = onRuleAdd.mock.calls[0];
     expect(call0[0]).toHaveProperty('id');
     expect(call0[0]).toHaveProperty('field', 'field_0');
@@ -267,7 +268,7 @@ describe('addGroup', () => {
   it('calls onGroupAdd from the schema with expected values', () => {
     const onGroupAdd = jest.fn();
     const { getByText } = render(<RuleGroup {...getProps({ onGroupAdd })} />);
-    userEvent.click(getByText(defaultTranslations.addGroup.label));
+    userEvent.click(getByText(t.addGroup.label));
     const call0 = onGroupAdd.mock.calls[0];
     expect(call0[0]).toHaveProperty('id');
     expect(call0[0]).toHaveProperty('rules', []);
@@ -279,7 +280,7 @@ describe('cloneGroup', () => {
   it('calls moveRule from the schema with expected values', () => {
     const moveRule = jest.fn();
     const { getByText } = render(<RuleGroup {...getProps({ moveRule, showCloneButtons: true })} />);
-    userEvent.click(getByText(defaultTranslations.cloneRuleGroup.label));
+    userEvent.click(getByText(t.cloneRuleGroup.label));
     expect(moveRule).toHaveBeenCalledWith([0], [1], true);
   });
 });
@@ -288,7 +289,7 @@ describe('removeGroup', () => {
   it('calls onGroupRemove from the schema with expected values', () => {
     const onGroupRemove = jest.fn();
     const { getByText } = render(<RuleGroup {...getProps({ onGroupRemove })} />);
-    userEvent.click(getByText(defaultTranslations.removeGroup.label));
+    userEvent.click(getByText(t.removeGroup.label));
     expect(onGroupRemove).toHaveBeenCalledWith([0]);
   });
 });
@@ -301,7 +302,7 @@ describe('showCombinatorsBetweenRules', () => {
         rules={[{ field: 'test', value: 'Test', operator: '=' }]}
       />
     );
-    expect(container.querySelectorAll(`.${standardClassnames.combinators}`)).toHaveLength(0);
+    expect(container.querySelectorAll(`.${sc.combinators}`)).toHaveLength(0);
   });
 
   it('displays combinators when there is more than one rule', () => {
@@ -315,37 +316,31 @@ describe('showCombinatorsBetweenRules', () => {
         ]}
       />
     );
-    expect(container.querySelectorAll(`.${standardClassnames.combinators}`)).toHaveLength(2);
+    expect(container.querySelectorAll(`.${sc.combinators}`)).toHaveLength(2);
   });
 });
 
 describe('showNotToggle', () => {
   it('does not display "not" toggle by default', () => {
     const { container } = render(<RuleGroup {...getProps({ showNotToggle: false })} />);
-    expect(container.querySelectorAll(`.${standardClassnames.notToggle}`)).toHaveLength(0);
+    expect(container.querySelectorAll(`.${sc.notToggle}`)).toHaveLength(0);
   });
 
   it('has the correct classNames', () => {
     const { getByTestId } = render(<RuleGroup {...getProps({ showNotToggle: true })} />);
-    expect(getByTestId(TestID.notToggle)).toHaveClass(
-      standardClassnames.notToggle,
-      'custom-notToggle-class'
-    );
+    expect(getByTestId(TestID.notToggle)).toHaveClass(sc.notToggle, 'custom-notToggle-class');
   });
 });
 
 describe('showCloneButtons', () => {
   it('does not display clone buttons by default', () => {
     const { container } = render(<RuleGroup {...getProps({ showCloneButtons: false })} />);
-    expect(container.querySelectorAll(`.${standardClassnames.cloneGroup}`)).toHaveLength(0);
+    expect(container.querySelectorAll(`.${sc.cloneGroup}`)).toHaveLength(0);
   });
 
   it('has the correct classNames', () => {
     const { getByTestId } = render(<RuleGroup {...getProps({ showCloneButtons: true })} />);
-    expect(getByTestId(TestID.cloneGroup)).toHaveClass(
-      standardClassnames.cloneGroup,
-      'custom-cloneGroup-class'
-    );
+    expect(getByTestId(TestID.cloneGroup)).toHaveClass(sc.cloneGroup, 'custom-cloneGroup-class');
   });
 });
 
@@ -361,7 +356,7 @@ describe('independent combinators', () => {
     );
     const inlineCombinator = getByTestId(TestID.inlineCombinator);
     const combinatorSelector = getByTestId(TestID.combinators);
-    expect(inlineCombinator).toHaveClass(standardClassnames.betweenRules);
+    expect(inlineCombinator).toHaveClass(sc.betweenRules);
     expect(combinatorSelector).toHaveValue('and');
   });
 
@@ -378,7 +373,7 @@ describe('independent combinators', () => {
         rules={rules}
       />
     );
-    userEvent.selectOptions(getByTitle(defaultTranslations.combinators.title), [getByText('OR')]);
+    userEvent.selectOptions(getByTitle(t.combinators.title), [getByText('OR')]);
     expect(updateIndependentCombinator).toHaveBeenCalledWith('or', [0, 1]);
   });
 
@@ -389,7 +384,7 @@ describe('independent combinators', () => {
         {...getProps({ independentCombinators: true, moveRule, showCloneButtons: true })}
       />
     );
-    userEvent.click(getByText(defaultTranslations.cloneRuleGroup.label));
+    userEvent.click(getByText(t.cloneRuleGroup.label));
     expect(moveRule).toHaveBeenCalledWith([0], [1], true);
   });
 });
@@ -397,20 +392,20 @@ describe('independent combinators', () => {
 describe('validation', () => {
   it('should not validate if no validationMap[id] value exists', () => {
     const { getByTestId } = render(<RuleGroup {...getProps()} />);
-    expect(getByTestId(TestID.ruleGroup)).not.toHaveClass(standardClassnames.valid);
-    expect(getByTestId(TestID.ruleGroup)).not.toHaveClass(standardClassnames.invalid);
+    expect(getByTestId(TestID.ruleGroup)).not.toHaveClass(sc.valid);
+    expect(getByTestId(TestID.ruleGroup)).not.toHaveClass(sc.invalid);
   });
 
   it('should validate to false if validationMap[id] = false', () => {
     const { getByTestId } = render(<RuleGroup {...getProps({ validationMap: { id: false } })} />);
-    expect(getByTestId(TestID.ruleGroup)).not.toHaveClass(standardClassnames.valid);
-    expect(getByTestId(TestID.ruleGroup)).toHaveClass(standardClassnames.invalid);
+    expect(getByTestId(TestID.ruleGroup)).not.toHaveClass(sc.valid);
+    expect(getByTestId(TestID.ruleGroup)).toHaveClass(sc.invalid);
   });
 
   it('should validate to true if validationMap[id] = true', () => {
     const { getByTestId } = render(<RuleGroup {...getProps({ validationMap: { id: true } })} />);
-    expect(getByTestId(TestID.ruleGroup)).toHaveClass(standardClassnames.valid);
-    expect(getByTestId(TestID.ruleGroup)).not.toHaveClass(standardClassnames.invalid);
+    expect(getByTestId(TestID.ruleGroup)).toHaveClass(sc.valid);
+    expect(getByTestId(TestID.ruleGroup)).not.toHaveClass(sc.invalid);
   });
 
   it('should pass down validationResult as validation to children', () => {
@@ -437,14 +432,14 @@ describe('enableDragAndDrop', () => {
   it('should not have the drag class if not dragging', () => {
     const { getByTestId } = render(<RuleGroup {...getProps()} />);
     const ruleGroup = getByTestId(TestID.ruleGroup);
-    expect(ruleGroup).not.toHaveClass(standardClassnames.dndDragging);
+    expect(ruleGroup).not.toHaveClass(sc.dndDragging);
   });
 
   it('should have the drag class if dragging', () => {
     const { getByTestId } = render(<RuleGroup {...getProps()} />);
     const ruleGroup = getByTestId(TestID.ruleGroup);
     simulateDrag(getHandlerId(ruleGroup, 'drag'), getDndBackend());
-    expect(ruleGroup).toHaveClass(standardClassnames.dndDragging);
+    expect(ruleGroup).toHaveClass(sc.dndDragging);
     act(() => {
       getDndBackend().simulateEndDrag();
     });
@@ -464,8 +459,8 @@ describe('enableDragAndDrop', () => {
       getHandlerId(ruleGroups[0], 'drop'),
       getDndBackend()
     );
-    expect(ruleGroups[0]).not.toHaveClass(standardClassnames.dndDragging);
-    expect(ruleGroups[1]).not.toHaveClass(standardClassnames.dndOver);
+    expect(ruleGroups[0]).not.toHaveClass(sc.dndDragging);
+    expect(ruleGroups[1]).not.toHaveClass(sc.dndOver);
     expect(moveRule).toHaveBeenCalledWith([1], [0, 0]);
   });
 
@@ -478,8 +473,8 @@ describe('enableDragAndDrop', () => {
       getHandlerId(ruleGroup, 'drop'),
       getDndBackend()
     );
-    expect(ruleGroup).not.toHaveClass(standardClassnames.dndDragging);
-    expect(ruleGroup).not.toHaveClass(standardClassnames.dndOver);
+    expect(ruleGroup).not.toHaveClass(sc.dndDragging);
+    expect(ruleGroup).not.toHaveClass(sc.dndOver);
     expect(moveRule).not.toHaveBeenCalled();
   });
 
@@ -551,8 +546,8 @@ describe('enableDragAndDrop', () => {
       getHandlerId(combinatorEl, 'drop'),
       getDndBackend()
     );
-    expect(ruleGroups[1]).not.toHaveClass(standardClassnames.dndDragging);
-    expect(combinatorEl).not.toHaveClass(standardClassnames.dndOver);
+    expect(ruleGroups[1]).not.toHaveClass(sc.dndDragging);
+    expect(combinatorEl).not.toHaveClass(sc.dndOver);
     expect(moveRule).toHaveBeenCalledWith([1], [0, 1]);
   });
 
@@ -583,6 +578,11 @@ describe('enableDragAndDrop', () => {
 });
 
 describe('disabled', () => {
+  it('should have the correct classname', () => {
+    const { getByTestId } = render(<RuleGroup {...getProps()} disabled />);
+    expect(getByTestId(TestID.ruleGroup)).toHaveClass(sc.disabled);
+  });
+
   it('does not try to update the query', () => {
     const onRuleAdd = jest.fn();
     const onRuleRemove = jest.fn();

--- a/packages/react-querybuilder/src/defaults.ts
+++ b/packages/react-querybuilder/src/defaults.ts
@@ -108,6 +108,7 @@ export const standardClassnames = {
   dndDragging: 'dndDragging',
   dndOver: 'dndOver',
   dragHandle: 'queryBuilder-dragHandle',
+  disabled: 'queryBuilder-disabled',
 } as const;
 
 export const defaultControlClassnames: Classnames = {

--- a/packages/react-querybuilder/src/types/ruleGroups.ts
+++ b/packages/react-querybuilder/src/types/ruleGroups.ts
@@ -21,6 +21,11 @@ export type RuleGroupArray<
   R extends RuleType = RuleType
 > = (R | RG)[];
 
+export type UpdateableProperties = Exclude<
+  keyof (RuleType & RuleGroupType),
+  'id' | 'path' | 'rules'
+>;
+
 export type DefaultRuleGroupArray = RuleGroupArray<DefaultRuleGroupType, DefaultRuleType>;
 
 export type DefaultRuleGroupType = RuleGroupType<DefaultRuleType, DefaultCombinatorName> & {

--- a/packages/react-querybuilder/src/utils/__tests__/queryTools.test.ts
+++ b/packages/react-querybuilder/src/utils/__tests__/queryTools.test.ts
@@ -114,7 +114,7 @@ describe('remove', () => {
 describe('update', () => {
   describe('standard rule groups', () => {
     it('updates rules', () => {
-      expect(stripIDs(update(rg3, 'field', 'fu', [0], {}))).toEqual({
+      expect(stripIDs(update(rg3, 'field', 'fu', [0]))).toEqual({
         combinator: 'and',
         rules: [{ ...r1, field: 'fu', value: '' }, r2, r3],
       });
@@ -136,7 +136,7 @@ describe('update', () => {
         combinator: 'and',
         rules: [{ ...r1, field: 'fu' }, r2, r3],
       });
-      expect(stripIDs(update(rg3, 'operator', 'ou', [1], {}))).toEqual({
+      expect(stripIDs(update(rg3, 'operator', 'ou', [1]))).toEqual({
         combinator: 'and',
         rules: [r1, { ...r2, operator: 'ou' }, r3],
       });
@@ -146,7 +146,7 @@ describe('update', () => {
           rules: [r1, { ...r2, operator: 'ou', value: '' }, r3],
         }
       );
-      expect(stripIDs(update(rg3, 'value', 'vu', [2], {}))).toEqual({
+      expect(stripIDs(update(rg3, 'value', 'vu', [2]))).toEqual({
         combinator: 'and',
         rules: [r1, r2, { ...r3, value: 'vu' }],
       });
@@ -154,16 +154,16 @@ describe('update', () => {
 
     it('updates groups', () => {
       // Root group
-      expect(stripIDs(update(rg1, 'combinator', 'or', [], {}))).toEqual(rg2);
-      expect(stripIDs(update(rg1, 'not', true, [], {}))).toEqual({ ...rg1, not: true });
+      expect(stripIDs(update(rg1, 'combinator', 'or', []))).toEqual(rg2);
+      expect(stripIDs(update(rg1, 'not', true, []))).toEqual({ ...rg1, not: true });
       // Nested groups
       expect(
-        stripIDs(update({ combinator: 'and', rules: [rg1] }, 'combinator', 'or', [0], {}))
+        stripIDs(update({ combinator: 'and', rules: [rg1] }, 'combinator', 'or', [0]))
       ).toEqual({
         combinator: 'and',
         rules: [rg2],
       });
-      expect(stripIDs(update({ combinator: 'and', rules: [rg1] }, 'not', true, [0], {}))).toEqual({
+      expect(stripIDs(update({ combinator: 'and', rules: [rg1] }, 'not', true, [0]))).toEqual({
         combinator: 'and',
         rules: [{ ...rg1, not: true }],
       });
@@ -178,7 +178,7 @@ describe('update', () => {
   describe('independent combinators', () => {
     // TODO: more tests
     it('does not alter the query if the path ends in an even number', () => {
-      expect(update(rgic2, 'combinator', 'or', [2], {})).toBe(rgic2);
+      expect(update(rgic2, 'combinator', 'or', [2])).toBe(rgic2);
     });
   });
 });
@@ -187,7 +187,7 @@ describe('move', () => {
   describe('standard rule groups', () => {
     // TODO: more tests
     it('does not alter the query if the old and new paths are the same', () => {
-      expect(move(rg3, [1], [1], {})).toBe(rg3);
+      expect(move(rg3, [1], [1])).toBe(rg3);
     });
   });
 

--- a/packages/react-querybuilder/src/utils/__tests__/queryTools.test.ts
+++ b/packages/react-querybuilder/src/utils/__tests__/queryTools.test.ts
@@ -1,0 +1,197 @@
+import { RuleGroupType, RuleGroupTypeAny, RuleGroupTypeIC, RuleType } from '../../types';
+import { formatQuery } from '../formatQuery';
+import { add, move, remove, update } from '../queryTools';
+
+const stripIDs = (query: RuleGroupTypeAny) => JSON.parse(formatQuery(query, 'json_without_ids'));
+
+const r1: RuleType = { field: 'f1', operator: '=', value: 'v1' };
+const r2: RuleType = { field: 'f2', operator: '=', value: 'v2' };
+const r3: RuleType = { field: 'f3', operator: '=', value: 'v3' };
+const rg1: RuleGroupType = { combinator: 'and', rules: [] };
+const rg2: RuleGroupType = { combinator: 'or', rules: [] };
+const rg3: RuleGroupType = { combinator: 'and', rules: [r1, r2, r3] };
+const rgic1: RuleGroupTypeIC = { rules: [] };
+const rgic2: RuleGroupTypeIC = { rules: [r1, 'and', r2] };
+
+describe('add', () => {
+  describe('standard rule groups', () => {
+    it('adds rules', () => {
+      expect(stripIDs(add(rg1, r1, []))).toEqual({
+        combinator: 'and',
+        rules: [r1],
+      });
+      expect(stripIDs(add({ combinator: 'and', rules: [r1] }, r2, []))).toEqual({
+        combinator: 'and',
+        rules: [r1, r2],
+      });
+    });
+
+    it('adds groups', () => {
+      expect(stripIDs(add(rg1, rg2, []))).toEqual({
+        combinator: 'and',
+        rules: [{ ...rg2, not: false }],
+      });
+    });
+  });
+
+  describe('independent combinators', () => {
+    it('adds rules', () => {
+      expect(stripIDs(add(rgic1, r1, []))).toEqual({
+        rules: [r1],
+      });
+      expect(stripIDs(add({ rules: [r1] }, r2, []))).toEqual({
+        rules: [r1, 'and', r2],
+      });
+      expect(stripIDs(add({ rules: [r1, 'or', r2] }, r3, []))).toEqual({
+        rules: [r1, 'or', r2, 'or', r3],
+      });
+    });
+
+    it('adds groups', () => {
+      expect(stripIDs(add(rgic1, rgic2, []))).toEqual({ rules: [{ ...rgic2, not: false }] });
+    });
+  });
+});
+
+describe('remove', () => {
+  describe('standard rule groups', () => {
+    it('removes rules', () => {
+      expect(stripIDs(remove({ combinator: 'and', rules: [r1, r2] }, [0]))).toEqual({
+        combinator: 'and',
+        rules: [r2],
+      });
+      expect(stripIDs(remove({ combinator: 'and', rules: [r1, r2, r3] }, [1]))).toEqual({
+        combinator: 'and',
+        rules: [r1, r3],
+      });
+    });
+
+    it('removes groups', () => {
+      expect(stripIDs(remove({ combinator: 'and', rules: [r1, rg1] }, [1]))).toEqual({
+        combinator: 'and',
+        rules: [r1],
+      });
+    });
+
+    it('does not remove the root group', () => {
+      expect(remove(rg1, [])).toBe(rg1);
+    });
+  });
+
+  describe('independent combinators', () => {
+    it('removes rules', () => {
+      expect(stripIDs(remove({ rules: [r1] }, [0]))).toEqual(rgic1);
+      expect(stripIDs(remove(rgic2, [2]))).toEqual({
+        rules: [r1],
+      });
+      expect(stripIDs(remove({ rules: [r1, 'and', r2, 'or', r3] }, [0]))).toEqual({
+        rules: [r2, 'or', r3],
+      });
+      expect(stripIDs(remove({ rules: [r1, 'and', r2, 'or', r3] }, [2]))).toEqual({
+        rules: [r1, 'or', r3],
+      });
+      expect(stripIDs(remove({ rules: [r1, 'and', r2, 'or', r3] }, [4]))).toEqual({
+        rules: [r1, 'and', r2],
+      });
+    });
+
+    it('removes groups', () => {
+      expect(stripIDs(remove({ rules: [rgic1, 'and', rgic2] }, [0]))).toEqual({
+        rules: [rgic2],
+      });
+    });
+
+    it('does not remove the root group', () => {
+      expect(remove(rgic1, [])).toBe(rgic1);
+    });
+
+    it('does not remove independent combinators', () => {
+      expect(remove(rgic2, [1])).toBe(rgic2);
+    });
+  });
+});
+
+describe('update', () => {
+  describe('standard rule groups', () => {
+    it('updates rules', () => {
+      expect(stripIDs(update(rg3, 'field', 'fu', [0], {}))).toEqual({
+        combinator: 'and',
+        rules: [{ ...r1, field: 'fu', value: '' }, r2, r3],
+      });
+      expect(
+        stripIDs(
+          update(
+            { combinator: 'and', rules: [{ field: 'f1', operator: '<', value: 'v1' }] },
+            'field',
+            'fu',
+            [0],
+            {}
+          )
+        )
+      ).toEqual({
+        combinator: 'and',
+        rules: [{ ...r1, field: 'fu', value: '' }],
+      });
+      expect(stripIDs(update(rg3, 'field', 'fu', [0], { resetOnFieldChange: false }))).toEqual({
+        combinator: 'and',
+        rules: [{ ...r1, field: 'fu' }, r2, r3],
+      });
+      expect(stripIDs(update(rg3, 'operator', 'ou', [1], {}))).toEqual({
+        combinator: 'and',
+        rules: [r1, { ...r2, operator: 'ou' }, r3],
+      });
+      expect(stripIDs(update(rg3, 'operator', 'ou', [1], { resetOnOperatorChange: true }))).toEqual(
+        {
+          combinator: 'and',
+          rules: [r1, { ...r2, operator: 'ou', value: '' }, r3],
+        }
+      );
+      expect(stripIDs(update(rg3, 'value', 'vu', [2], {}))).toEqual({
+        combinator: 'and',
+        rules: [r1, r2, { ...r3, value: 'vu' }],
+      });
+    });
+
+    it('updates groups', () => {
+      // Root group
+      expect(stripIDs(update(rg1, 'combinator', 'or', [], {}))).toEqual(rg2);
+      expect(stripIDs(update(rg1, 'not', true, [], {}))).toEqual({ ...rg1, not: true });
+      // Nested groups
+      expect(
+        stripIDs(update({ combinator: 'and', rules: [rg1] }, 'combinator', 'or', [0], {}))
+      ).toEqual({
+        combinator: 'and',
+        rules: [rg2],
+      });
+      expect(stripIDs(update({ combinator: 'and', rules: [rg1] }, 'not', true, [0], {}))).toEqual({
+        combinator: 'and',
+        rules: [{ ...rg1, not: true }],
+      });
+    });
+
+    it('does not reset operator or value when the value is the same', () => {
+      expect(update(rg3, 'field', 'f1', [0], { resetOnFieldChange: true })).toBe(rg3);
+      expect(update(rg3, 'operator', '=', [0], { resetOnOperatorChange: true })).toBe(rg3);
+    });
+  });
+
+  describe('independent combinators', () => {
+    // TODO: more tests
+    it('does not alter the query if the path ends in an even number', () => {
+      expect(update(rgic2, 'combinator', 'or', [2], {})).toBe(rgic2);
+    });
+  });
+});
+
+describe('move', () => {
+  describe('standard rule groups', () => {
+    // TODO: more tests
+    it('does not alter the query if the old and new paths are the same', () => {
+      expect(move(rg3, [1], [1], {})).toBe(rg3);
+    });
+  });
+
+  describe('independent combinators', () => {
+    // TODO: more tests
+  });
+});

--- a/packages/react-querybuilder/src/utils/__tests__/queryTools.test.ts
+++ b/packages/react-querybuilder/src/utils/__tests__/queryTools.test.ts
@@ -1,344 +1,331 @@
-import { RuleGroupType, RuleGroupTypeAny, RuleGroupTypeIC, RuleType } from '../../types';
+import { defaultCombinators } from '../../defaults';
+import {
+  DefaultRuleGroupType,
+  DefaultRuleGroupTypeAny,
+  DefaultRuleGroupTypeIC,
+  DefaultRuleType,
+} from '../../types';
 import { formatQuery } from '../formatQuery';
 import { add, move, remove, update } from '../queryTools';
 
-const stripIDs = (query: RuleGroupTypeAny) => JSON.parse(formatQuery(query, 'json_without_ids'));
+const [and, or] = defaultCombinators.map(c => c.name);
 
-const [r1, r2, r3, r4, r5] = ['=', '<', '>', '<=', '>='].map<RuleType>((operator, i) => ({
-  field: `f${i + 1}`,
-  operator,
-  value: `v${i + 1}`,
-}));
-const [rg1, rg2] = ['and', 'or'].map<RuleGroupType>(combinator => ({ combinator, rules: [] }));
-const rg3: RuleGroupType = { combinator: 'and', rules: [r1, r2, r3] };
-const rgic1: RuleGroupTypeIC = { rules: [] };
-const rgic2: RuleGroupTypeIC = { rules: [r1, 'and', r2] };
+const stripIDs = (query: DefaultRuleGroupTypeAny) =>
+  JSON.parse(formatQuery(query, 'json_without_ids'));
+
+const [r1, r2, r3, r4, r5] = (['=', '<', '>', '<=', '>='] as const).map<DefaultRuleType>(
+  (operator, i) => ({
+    field: `f${i + 1}`,
+    operator,
+    value: `v${i + 1}`,
+  })
+);
+const [rg1, rg2] = [and, or].map(combinator => ({ combinator, rules: [] }));
+const rg3: DefaultRuleGroupType = { combinator: and, rules: [r1, r2, r3] };
+const rgic1: DefaultRuleGroupTypeIC = { rules: [] };
+const rgic2: DefaultRuleGroupTypeIC = { rules: [r1, and, r2] };
+
+const testQT = (
+  title: string,
+  ruleGroup: DefaultRuleGroupTypeAny,
+  expectation: DefaultRuleGroupTypeAny,
+  exact?: boolean
+) => {
+  it(title, () => {
+    if (exact) {
+      expect(ruleGroup).toBe(expectation);
+    } else {
+      expect(stripIDs(ruleGroup)).toEqual(expectation);
+    }
+  });
+};
 
 describe('add', () => {
   describe('standard rule groups', () => {
-    it('adds rules', () => {
-      expect(stripIDs(add(rg1, r1, []))).toEqual({
-        combinator: 'and',
-        rules: [r1],
-      });
-      expect(stripIDs(add({ combinator: 'and', rules: [r1] }, r2, []))).toEqual({
-        combinator: 'and',
-        rules: [r1, r2],
-      });
+    testQT('adds a rule', add(rg1, r1, []), { combinator: and, rules: [r1] });
+    testQT('adds another rule', add({ combinator: and, rules: [r1] }, r2, []), {
+      combinator: and,
+      rules: [r1, r2],
     });
-
-    it('adds groups', () => {
-      expect(stripIDs(add(rg1, rg2, []))).toEqual({
-        combinator: 'and',
-        rules: [{ ...rg2, not: false }],
-      });
-    });
+    testQT('adds a group', add(rg1, rg2, []), { combinator: and, rules: [{ ...rg2, not: false }] });
   });
 
   describe('independent combinators', () => {
-    it('adds rules', () => {
-      expect(stripIDs(add(rgic1, r1, []))).toEqual({
-        rules: [r1],
-      });
-      expect(stripIDs(add({ rules: [r1] }, r2, []))).toEqual({
-        rules: [r1, 'and', r2],
-      });
-      expect(stripIDs(add({ rules: [r1, 'or', r2] }, r3, []))).toEqual({
-        rules: [r1, 'or', r2, 'or', r3],
-      });
+    testQT('adds a rule', add(rgic1, r1, []), { rules: [r1] });
+    testQT('adds a rule and the default combinator', add({ rules: [r1] }, r2, []), {
+      rules: [r1, and, r2],
     });
-
-    it('adds groups', () => {
-      expect(stripIDs(add(rgic1, rgic2, []))).toEqual({ rules: [{ ...rgic2, not: false }] });
+    testQT('adds a rule and copies existing combinator', add({ rules: [r1, or, r2] }, r3, []), {
+      rules: [r1, or, r2, or, r3],
     });
+    testQT('adds a group', add(rgic1, rgic2, []), { rules: [{ ...rgic2, not: false }] });
   });
 });
 
 describe('remove', () => {
   describe('standard rule groups', () => {
-    it('removes rules', () => {
-      expect(stripIDs(remove({ combinator: 'and', rules: [r1, r2] }, [0]))).toEqual({
-        combinator: 'and',
-        rules: [r2],
-      });
-      expect(stripIDs(remove({ combinator: 'and', rules: [r1, r2, r3] }, [1]))).toEqual({
-        combinator: 'and',
+    testQT('removes the first of two rules', remove({ combinator: and, rules: [r1, r2] }, [0]), {
+      combinator: and,
+      rules: [r2],
+    });
+    testQT(
+      'removes the second of three rules',
+      remove({ combinator: and, rules: [r1, r2, r3] }, [1]),
+      {
+        combinator: and,
         rules: [r1, r3],
-      });
+      }
+    );
+    testQT('removes a group', remove({ combinator: and, rules: [r1, rg1] }, [1]), {
+      combinator: and,
+      rules: [r1],
     });
-
-    it('removes groups', () => {
-      expect(stripIDs(remove({ combinator: 'and', rules: [r1, rg1] }, [1]))).toEqual({
-        combinator: 'and',
-        rules: [r1],
-      });
-    });
-
-    it('does not remove the root group', () => {
-      expect(remove(rg1, [])).toBe(rg1);
-    });
+    testQT('does not remove the root group', remove(rg1, []), rg1, true);
   });
 
   describe('independent combinators', () => {
-    it('removes rules', () => {
-      expect(stripIDs(remove({ rules: [r1] }, [0]))).toEqual(rgic1);
-      expect(stripIDs(remove(rgic2, [2]))).toEqual({
-        rules: [r1],
-      });
-      expect(stripIDs(remove({ rules: [r1, 'and', r2, 'or', r3] }, [0]))).toEqual({
-        rules: [r2, 'or', r3],
-      });
-      expect(stripIDs(remove({ rules: [r1, 'and', r2, 'or', r3] }, [2]))).toEqual({
-        rules: [r1, 'or', r3],
-      });
-      expect(stripIDs(remove({ rules: [r1, 'and', r2, 'or', r3] }, [4]))).toEqual({
-        rules: [r1, 'and', r2],
-      });
+    testQT('removes a lonely rule', remove({ rules: [r1] }, [0]), rgic1);
+    testQT('removes the second of two rules', remove(rgic2, [2]), { rules: [r1] });
+    testQT('removes the first of three rules', remove({ rules: [r1, and, r2, or, r3] }, [0]), {
+      rules: [r2, or, r3],
     });
-
-    it('removes groups', () => {
-      expect(stripIDs(remove({ rules: [rgic1, 'and', rgic2] }, [0]))).toEqual({
-        rules: [rgic2],
-      });
+    testQT('removes the second of three rules', remove({ rules: [r1, and, r2, or, r3] }, [2]), {
+      rules: [r1, or, r3],
     });
-
-    it('does not remove the root group', () => {
-      expect(remove(rgic1, [])).toBe(rgic1);
+    testQT('removes the third of three rules', remove({ rules: [r1, and, r2, or, r3] }, [4]), {
+      rules: [r1, and, r2],
     });
-
-    it('does not remove independent combinators', () => {
-      expect(remove(rgic2, [1])).toBe(rgic2);
-    });
+    testQT('removes a group', remove({ rules: [rgic1, and, rgic2] }, [0]), { rules: [rgic2] });
+    testQT('does not remove the root group', remove(rgic1, []), rgic1, true);
+    testQT('does not remove independent combinators', remove(rgic2, [1]), rgic2, true);
   });
 });
 
 describe('update', () => {
   describe('standard rule groups', () => {
-    it('updates rules', () => {
-      expect(stripIDs(update(rg3, 'field', 'fu', [0]))).toEqual({
-        combinator: 'and',
-        rules: [{ ...r1, field: 'fu', value: '' }, r2, r3],
-      });
-      expect(
-        stripIDs(
-          update(
-            { combinator: 'and', rules: [{ field: 'f1', operator: '<', value: 'v1' }] },
-            'field',
-            'fu',
-            [0],
-            {}
-          )
-        )
-      ).toEqual({
-        combinator: 'and',
+    testQT('updates a rule', update(rg3, 'field', 'fu', [0]), {
+      combinator: and,
+      rules: [{ ...r1, field: 'fu', value: '' }, r2, r3],
+    });
+    testQT(
+      'updates a rule and resets the value by default',
+      update(
+        { combinator: and, rules: [{ field: 'f1', operator: '<', value: 'v1' }] },
+        'field',
+        'fu',
+        [0]
+      ),
+      {
+        combinator: and,
         rules: [{ ...r1, field: 'fu', value: '' }],
-      });
-      expect(stripIDs(update(rg3, 'field', 'fu', [0], { resetOnFieldChange: false }))).toEqual({
-        combinator: 'and',
+      }
+    );
+    testQT(
+      'updates a rule and does not reset the value',
+      update(rg3, 'field', 'fu', [0], { resetOnFieldChange: false }),
+      {
+        combinator: and,
         rules: [{ ...r1, field: 'fu' }, r2, r3],
-      });
-      expect(stripIDs(update(rg3, 'operator', 'ou', [1]))).toEqual({
-        combinator: 'and',
-        rules: [r1, { ...r2, operator: 'ou' }, r3],
-      });
-      expect(stripIDs(update(rg3, 'operator', 'ou', [1], { resetOnOperatorChange: true }))).toEqual(
-        {
-          combinator: 'and',
-          rules: [r1, { ...r2, operator: 'ou', value: '' }, r3],
-        }
-      );
-      expect(stripIDs(update(rg3, 'value', 'vu', [2]))).toEqual({
-        combinator: 'and',
-        rules: [r1, r2, { ...r3, value: 'vu' }],
-      });
+      }
+    );
+    testQT(
+      'updates a rule operator and does not reset the value',
+      update(rg3, 'operator', 'between', [1]),
+      {
+        combinator: and,
+        rules: [r1, { ...r2, operator: 'between' }, r3],
+      }
+    );
+    testQT(
+      'updates a rule operator and resets the value',
+      update(rg3, 'operator', 'between', [1], { resetOnOperatorChange: true }),
+      {
+        combinator: and,
+        rules: [r1, { ...r2, operator: 'between', value: '' }, r3],
+      }
+    );
+    testQT('updates a rule value', update(rg3, 'value', 'vu', [2]), {
+      combinator: and,
+      rules: [r1, r2, { ...r3, value: 'vu' }],
     });
-
-    it('updates groups', () => {
-      expect(stripIDs(update(rg1, 'combinator', 'or', []))).toEqual(rg2);
-      expect(stripIDs(update(rg1, 'not', true, []))).toEqual({ ...rg1, not: true });
-      expect(
-        stripIDs(update({ combinator: 'and', rules: [rg1] }, 'combinator', 'or', [0]))
-      ).toEqual({
-        combinator: 'and',
+    testQT('updates a group combinator', update(rg1, 'combinator', or, []), rg2);
+    testQT('updates a group "not" value', update(rg1, 'not', true, []), { ...rg1, not: true });
+    testQT(
+      'updates a child group combinator',
+      update({ combinator: and, rules: [rg1] }, 'combinator', or, [0]),
+      {
+        combinator: and,
         rules: [rg2],
-      });
-      expect(stripIDs(update({ combinator: 'and', rules: [rg1] }, 'not', true, [0]))).toEqual({
-        combinator: 'and',
+      }
+    );
+    testQT(
+      'updates a child group "not" value',
+      update({ combinator: and, rules: [rg1] }, 'not', true, [0]),
+      {
+        combinator: and,
         rules: [{ ...rg1, not: true }],
-      });
-    });
-
-    it('does not reset operator or value when the value is the same', () => {
-      expect(update(rg3, 'field', 'f1', [0], { resetOnFieldChange: true })).toBe(rg3);
-      expect(update(rg3, 'operator', '=', [0], { resetOnOperatorChange: true })).toBe(rg3);
-    });
+      }
+    );
+    testQT(
+      'does not reset operator or value when the field is the same',
+      update(rg3, 'field', 'f1', [0], { resetOnFieldChange: true }),
+      rg3,
+      true
+    );
+    testQT(
+      'does not reset value when the operator is the same',
+      update(rg3, 'operator', '=', [0], { resetOnOperatorChange: true }),
+      rg3,
+      true
+    );
   });
 
   describe('independent combinators', () => {
-    it('updates combinators', () => {
-      expect(stripIDs(update(rgic2, 'combinator', 'or', [1]))).toEqual({ rules: [r1, 'or', r2] });
-    });
-
-    it('does not alter the query if the path ends in an even number', () => {
-      expect(update(rgic2, 'combinator', 'or', [2])).toBe(rgic2);
-    });
+    testQT('updates a combinator', update(rgic2, 'combinator', or, [1]), { rules: [r1, or, r2] });
+    testQT(
+      'does not alter the query if the path ends in an even number',
+      update(rgic2, 'combinator', or, [2]),
+      rgic2,
+      true
+    );
   });
 });
 
 describe('move', () => {
   describe('standard rule groups', () => {
-    it('moves a rule down within the same group', () => {
-      expect(
-        stripIDs(
-          move(
-            {
-              combinator: 'and',
-              rules: [r1, r2],
-            },
-            [0],
-            [2]
-          )
-        )
-      ).toEqual({ combinator: 'and', rules: [r2, r1] });
-    });
-
-    it('moves a rule to a different group with a common ancestor', () => {
-      expect(stripIDs(move({ combinator: 'and', rules: [r1, r2, rg1] }, [1], [2, 0]))).toEqual({
-        combinator: 'and',
+    testQT(
+      'moves a rule down within the same group',
+      move(
+        {
+          combinator: and,
+          rules: [r1, r2],
+        },
+        [0],
+        [2]
+      ),
+      { combinator: and, rules: [r2, r1] }
+    );
+    testQT(
+      'moves a rule to a different group with a common ancestor',
+      move({ combinator: and, rules: [r1, r2, rg1] }, [1], [2, 0]),
+      {
+        combinator: and,
         rules: [r1, { ...rg1, rules: [r2] }],
-      });
-    });
-
-    it("moves a rule up to its parent group's parent group", () => {
-      expect(stripIDs(move({ combinator: 'and', rules: [rg3] }, [0, 1], [0]))).toEqual({
-        combinator: 'and',
-        rules: [r2, { combinator: 'and', rules: [r1, r3] }],
-      });
-    });
-
-    it('moves a rule up to another group', () => {
-      expect(
-        stripIDs(
-          move(
-            {
-              combinator: 'and',
-              rules: [
-                { combinator: 'and', rules: [r1] },
-                { combinator: 'and', rules: [r2, r3] },
-              ],
-            },
-            [1, 1],
-            [0, 1]
-          )
-        )
-      ).toEqual({
-        combinator: 'and',
+      }
+    );
+    testQT(
+      "moves a rule up to its parent group's parent group",
+      move({ combinator: and, rules: [rg3] }, [0, 1], [0]),
+      {
+        combinator: and,
+        rules: [r2, { combinator: and, rules: [r1, r3] }],
+      }
+    );
+    testQT(
+      'moves a rule up to another group',
+      move(
+        {
+          combinator: and,
+          rules: [
+            { combinator: and, rules: [r1] },
+            { combinator: and, rules: [r2, r3] },
+          ],
+        },
+        [1, 1],
+        [0, 1]
+      ),
+      {
+        combinator: and,
         rules: [
-          { combinator: 'and', rules: [r1, r3] },
-          { combinator: 'and', rules: [r2] },
+          { combinator: and, rules: [r1, r3] },
+          { combinator: and, rules: [r2] },
         ],
-      });
+      }
+    );
+    testQT('clones a rule', move(rg3, [1], [0], { clone: true }), {
+      combinator: and,
+      rules: [r2, r1, r2, r3],
     });
-
-    it('clones rules', () => {
-      expect(stripIDs(move(rg3, [1], [0], { clone: true }))).toEqual({
-        combinator: 'and',
-        rules: [r2, r1, r2, r3],
-      });
-    });
-
-    it('clones groups', () => {
-      expect(
-        stripIDs(move({ combinator: 'and', rules: [r1, rg3, r2] }, [1], [0], { clone: true }))
-      ).toEqual({
-        combinator: 'and',
+    testQT(
+      'clones a group',
+      move({ combinator: and, rules: [r1, rg3, r2] }, [1], [0], { clone: true }),
+      {
+        combinator: and,
         rules: [rg3, r1, rg3, r2],
-      });
-    });
-
-    it('does not alter the query if the old and new paths are the same', () => {
-      expect(move(rg3, [1], [1])).toBe(rg3);
-    });
+      }
+    );
+    testQT(
+      'does not alter the query if the old and new paths are the same',
+      move(rg3, [1], [1]),
+      rg3,
+      true
+    );
   });
 
   describe('independent combinators', () => {
-    it('swaps the first rule with the last within the same group', () => {
-      expect(stripIDs(move(rgic2, [0], [3]))).toEqual({ rules: [r2, 'and', r1] });
+    testQT('swaps the first rule with the last within the same group', move(rgic2, [0], [3]), {
+      rules: [r2, and, r1],
     });
-
-    it('swaps the last rule with the first within the same group', () => {
-      expect(stripIDs(move(rgic2, [2], [0]))).toEqual({ rules: [r2, 'and', r1] });
+    testQT('swaps the last rule with the first within the same group', move(rgic2, [2], [0]), {
+      rules: [r2, and, r1],
     });
-
-    it('moves a rule from first to last within the same group', () => {
-      expect(stripIDs(move({ rules: [r1, 'and', r2, 'or', r3] }, [0], [5]))).toEqual({
-        rules: [r2, 'or', r3, 'or', r1],
-      });
+    testQT(
+      'moves a rule from first to last within the same group',
+      move({ rules: [r1, and, r2, or, r3] }, [0], [5]),
+      {
+        rules: [r2, or, r3, or, r1],
+      }
+    );
+    testQT(
+      'moves a rule from last to first within the same group',
+      move({ rules: [r1, and, r2, or, r3] }, [4], [0]),
+      {
+        rules: [r3, and, r1, and, r2],
+      }
+    );
+    testQT(
+      'moves a rule from last to middle by dropping on inline combinator',
+      move({ rules: [r1, and, r2, or, r3] }, [4], [1]),
+      {
+        rules: [r1, or, r3, and, r2],
+      }
+    );
+    testQT(
+      'moves a first-child rule to a different group as the first child',
+      move({ rules: [r1, and, { rules: [r2, and, r3] }] }, [0], [2, 0]),
+      {
+        rules: [{ rules: [r1, and, r2, and, r3] }],
+      }
+    );
+    testQT(
+      'moves a middle-child rule to a different group as a middle child',
+      move({ rules: [r1, and, r2, and, r3, and, { rules: [r4, and, r5] }] }, [2], [6, 1]),
+      {
+        rules: [r1, and, r3, and, { rules: [r4, and, r2, and, r5] }],
+      }
+    );
+    testQT(
+      'moves an only-child rule up to a different group with only one existing child',
+      move({ rules: [{ rules: [r1] }, and, { rules: [r2] }] }, [2, 0], [0, 1]),
+      {
+        rules: [{ rules: [r1, and, r2] }, and, { rules: [] }],
+      }
+    );
+    testQT('', move({ rules: [{ rules: [r1] }, and, { rules: [r2] }] }, [2, 0], [0, 0]), {
+      rules: [{ rules: [r2, and, r1] }, and, { rules: [] }],
     });
-
-    it('moves a rule from last to first within the same group', () => {
-      expect(stripIDs(move({ rules: [r1, 'and', r2, 'or', r3] }, [4], [0]))).toEqual({
-        rules: [r3, 'and', r1, 'and', r2],
-      });
-    });
-
-    it('moves a rule from last to middle by dropping on inline combinator', () => {
-      expect(stripIDs(move({ rules: [r1, 'and', r2, 'or', r3] }, [4], [1]))).toEqual({
-        rules: [r1, 'or', r3, 'and', r2],
-      });
-    });
-
-    it('moves a first-child rule to a different group as the first child', () => {
-      expect(
-        stripIDs(move({ rules: [r1, 'and', { rules: [r2, 'and', r3] }] }, [0], [2, 0]))
-      ).toEqual({
-        rules: [{ rules: [r1, 'and', r2, 'and', r3] }],
-      });
-    });
-
-    it('moves a middle-child rule to a different group as a middle child', () => {
-      expect(
-        stripIDs(
-          move(
-            { rules: [r1, 'and', r2, 'and', r3, 'and', { rules: [r4, 'and', r5] }] },
-            [2],
-            [6, 1]
-          )
-        )
-      ).toEqual({
-        rules: [r1, 'and', r3, 'and', { rules: [r4, 'and', r2, 'and', r5] }],
-      });
-    });
-
-    it('moves an only-child rule up to a different group with only one existing child', () => {
-      expect(
-        stripIDs(move({ rules: [{ rules: [r1] }, 'and', { rules: [r2] }] }, [2, 0], [0, 1]))
-      ).toEqual({
-        rules: [{ rules: [r1, 'and', r2] }, 'and', { rules: [] }],
-      });
-      expect(
-        stripIDs(move({ rules: [{ rules: [r1] }, 'and', { rules: [r2] }] }, [2, 0], [0, 0]))
-      ).toEqual({
-        rules: [{ rules: [r2, 'and', r1] }, 'and', { rules: [] }],
-      });
-    });
-
-    it('moves a middle-child rule up to a different group with only one existing child', () => {
-      expect(
-        stripIDs(
-          move(
-            { rules: [{ rules: [r1] }, 'and', { rules: [r2, 'and', r3, 'and', r4] }] },
-            [2, 2],
-            [0, 1]
-          )
-        )
-      ).toEqual({
-        rules: [{ rules: [r1, 'and', r3] }, 'and', { rules: [r2, 'and', r4] }],
-      });
-    });
-
-    it('does not alter the query if the old path is to a combinator', () => {
-      expect(move(rgic2, [1], [0])).toBe(rgic2);
-    });
+    testQT(
+      'moves a middle-child rule up to a different group with only one existing child',
+      move({ rules: [{ rules: [r1] }, and, { rules: [r2, and, r3, and, r4] }] }, [2, 2], [0, 1]),
+      {
+        rules: [{ rules: [r1, and, r3] }, and, { rules: [r2, and, r4] }],
+      }
+    );
+    testQT(
+      'does not alter the query if the old path is to a combinator',
+      move(rgic2, [1], [0]),
+      rgic2,
+      true
+    );
   });
 });

--- a/packages/react-querybuilder/src/utils/index.ts
+++ b/packages/react-querybuilder/src/utils/index.ts
@@ -10,5 +10,6 @@ export * from './optGroupUtils';
 export * from './parseSQL';
 export * from './pathUtils';
 export * from './prepareQueryObjects';
+export * from './queryTools';
 export * from './regenerateIDs';
 export * from './uniq';

--- a/packages/react-querybuilder/src/utils/prepareQueryObjects.ts
+++ b/packages/react-querybuilder/src/utils/prepareQueryObjects.ts
@@ -25,3 +25,9 @@ export const prepareRuleGroup = <RG extends RuleGroupTypeAny>(queryObject: RG): 
     ) as RuleGroupArray | RuleGroupICArray;
     draft.not = !!draft.not;
   });
+
+/**
+ * Generates a valid rule or group
+ */
+export const prepareRuleOrGroup = <RG extends RuleGroupTypeAny>(rg: RG | RuleType) =>
+  'rules' in rg ? prepareRuleGroup(rg) : prepareRule(rg);

--- a/packages/react-querybuilder/src/utils/queryTools.ts
+++ b/packages/react-querybuilder/src/utils/queryTools.ts
@@ -38,7 +38,7 @@ export const update = <RG extends RuleGroupType | RuleGroupTypeIC>(
     resetOnOperatorChange = false,
     getRuleDefaultOperator = () => '=',
     getRuleDefaultValue = () => '',
-  }: Partial<UpdateOptions>
+  }: Partial<UpdateOptions> = {}
 ) =>
   produce(query, draft => {
     if (prop === 'combinator' && !('combinator' in draft)) {
@@ -86,17 +86,15 @@ export const remove = <RG extends RuleGroupType | RuleGroupTypeIC>(query: RG, pa
   });
 };
 
+interface MoveOptions {
+  clone: boolean;
+  combinators: NameLabelPair[] | OptionGroup[];
+}
 export const move = <RG extends RuleGroupType | RuleGroupTypeIC>(
   query: RG,
   oldPath: number[],
   newPath: number[],
-  {
-    clone = false,
-    combinators = defaultCombinators,
-  }: {
-    clone?: boolean;
-    combinators?: NameLabelPair[] | OptionGroup[];
-  }
+  { clone = false, combinators = defaultCombinators }: Partial<MoveOptions> = {}
 ) => {
   if (pathsAreEqual(oldPath, newPath)) {
     return query;

--- a/packages/react-querybuilder/src/utils/queryTools.ts
+++ b/packages/react-querybuilder/src/utils/queryTools.ts
@@ -1,12 +1,18 @@
 import produce from 'immer';
 import { defaultCombinators } from '../defaults';
-import { NameLabelPair, OptionGroup, RuleGroupType, RuleGroupTypeIC, RuleType } from '../types';
+import {
+  NameLabelPair,
+  OptionGroup,
+  RuleGroupTypeAny,
+  RuleType,
+  UpdateableProperties,
+} from '../types';
 import { getFirstOption } from './optGroupUtils';
 import { findPath, getCommonAncestorPath, getParentPath, pathsAreEqual } from './pathUtils';
 import { prepareRuleOrGroup } from './prepareQueryObjects';
 import { regenerateID, regenerateIDs } from './regenerateIDs';
 
-export const add = <RG extends RuleGroupType | RuleGroupTypeIC>(
+export const add = <RG extends RuleGroupTypeAny>(
   query: RG,
   ruleOrGroup: RG | RuleType,
   parentPath: number[]
@@ -28,9 +34,9 @@ interface UpdateOptions {
   getRuleDefaultOperator: (field: string) => string;
   getRuleDefaultValue: (rule: RuleType) => any;
 }
-export const update = <RG extends RuleGroupType | RuleGroupTypeIC>(
+export const update = <RG extends RuleGroupTypeAny>(
   query: RG,
-  prop: Exclude<keyof (RuleType & RuleGroupType), 'id' | 'path' | 'rules'>,
+  prop: UpdateableProperties,
   value: any,
   path: number[],
   {
@@ -70,7 +76,7 @@ export const update = <RG extends RuleGroupType | RuleGroupTypeIC>(
     }
   });
 
-export const remove = <RG extends RuleGroupType | RuleGroupTypeIC>(query: RG, path: number[]) => {
+export const remove = <RG extends RuleGroupTypeAny>(query: RG, path: number[]) => {
   if (path.length === 0 || (!('combinator' in query) && !findPath(path, query))) {
     return query;
   }
@@ -90,7 +96,7 @@ interface MoveOptions {
   clone: boolean;
   combinators: NameLabelPair[] | OptionGroup[];
 }
-export const move = <RG extends RuleGroupType | RuleGroupTypeIC>(
+export const move = <RG extends RuleGroupTypeAny>(
   query: RG,
   oldPath: number[],
   newPath: number[],

--- a/packages/react-querybuilder/src/utils/queryTools.ts
+++ b/packages/react-querybuilder/src/utils/queryTools.ts
@@ -124,7 +124,6 @@ export const move = <RG extends RuleGroupType | RuleGroupTypeIC>(
       independentCombinators && ruleToRemoveIndex < parentOfRuleToRemove.rules.length - 1
         ? (parentOfRuleToRemove.rules[ruleToRemoveIndex + 1] as string)
         : null;
-    /* istanbul ignore else */
     if (!clone) {
       const idxStartDelete = independentCombinators
         ? Math.max(0, ruleToRemoveIndex - 1)
@@ -135,7 +134,6 @@ export const move = <RG extends RuleGroupType | RuleGroupTypeIC>(
     }
 
     const newNewPath = [...newPath];
-    /* istanbul ignore else */
     if (!movingOnUp && !clone) {
       newNewPath[commonAncestorPath.length] -= independentCombinators ? 2 : 1;
     }
@@ -157,9 +155,7 @@ export const move = <RG extends RuleGroupType | RuleGroupTypeIC>(
           insertRuleOrGroup(ruleOrGroup, oldNextCombinator);
         } else {
           const newNextCombinator =
-            parentToInsertInto.rules[1] ||
-            oldPrevCombinator ||
-            /* istanbul ignore next */ getFirstOption(combinators);
+            parentToInsertInto.rules[1] || oldPrevCombinator || getFirstOption(combinators);
           insertRuleOrGroup(ruleOrGroup, newNextCombinator);
         }
       } else {

--- a/packages/react-querybuilder/src/utils/queryTools.ts
+++ b/packages/react-querybuilder/src/utils/queryTools.ts
@@ -1,0 +1,169 @@
+import produce from 'immer';
+import { defaultCombinators } from '../defaults';
+import { NameLabelPair, OptionGroup, RuleGroupType, RuleGroupTypeIC, RuleType } from '../types';
+import { getFirstOption } from './optGroupUtils';
+import { findPath, getCommonAncestorPath, getParentPath } from './pathUtils';
+import { prepareRuleOrGroup } from './prepareQueryObjects';
+import { regenerateID, regenerateIDs } from './regenerateIDs';
+
+export const add = <RG extends RuleGroupType | RuleGroupTypeIC>(
+  query: RG,
+  ruleOrGroup: RG | RuleType,
+  parentPath: number[]
+) =>
+  produce(query, draft => {
+    const parent = findPath(parentPath, draft) as RG;
+    if (!('combinator' in parent) && parent.rules.length > 0) {
+      const prevCombinator = parent.rules[parent.rules.length - 2];
+      parent.rules.push((typeof prevCombinator === 'string' ? prevCombinator : 'and') as any);
+    }
+    parent.rules.push(prepareRuleOrGroup(ruleOrGroup) as RuleType);
+  });
+
+type UpdateOptions = Partial<{
+  resetOnFieldChange: boolean;
+  resetOnOperatorChange: boolean;
+  getRuleDefaultOperator: (field: string) => string;
+  getRuleDefaultValue: (rule: RuleType) => any;
+}>;
+export const update = <RG extends RuleGroupType | RuleGroupTypeIC>(
+  query: RG,
+  prop: Exclude<keyof (RuleType & RuleGroupType), 'id' | 'path' | 'rules'>,
+  value: any,
+  path: number[],
+  {
+    resetOnFieldChange = true,
+    resetOnOperatorChange = false,
+    getRuleDefaultOperator = () => '=',
+    getRuleDefaultValue = () => '',
+  }: UpdateOptions
+) =>
+  produce(query, draft => {
+    const ruleOrGroup = findPath(path, draft)!;
+    const isGroup = 'rules' in ruleOrGroup;
+    (ruleOrGroup as any)[prop] = value;
+    if (!isGroup) {
+      // Reset operator and set default value for field change
+      if (resetOnFieldChange && prop === 'field') {
+        ruleOrGroup.operator = getRuleDefaultOperator(value);
+        ruleOrGroup.value = getRuleDefaultValue({ ...ruleOrGroup, field: value });
+      }
+
+      // Set default value for operator change
+      if (resetOnOperatorChange && prop === 'operator') {
+        ruleOrGroup.value = getRuleDefaultValue({ ...ruleOrGroup, operator: value });
+      }
+    }
+  });
+
+export const updateCombinator = <RG extends RuleGroupType | RuleGroupTypeIC>(
+  query: RG,
+  value: string,
+  path: number[]
+) =>
+  produce(query, draft => {
+    const parentRules = (findPath(getParentPath(path), draft) as RG).rules;
+    parentRules[path[path.length - 1]] = value;
+  });
+
+export const remove = <RG extends RuleGroupType | RuleGroupTypeIC>(query: RG, path: number[]) =>
+  produce(query, draft => {
+    const index = path[path.length - 1];
+    const parent = findPath(getParentPath(path), draft) as RG;
+    if (!('combinator' in parent) && parent.rules.length > 1) {
+      const idxStartDelete = index === 0 ? 0 : index - 1;
+      parent.rules.splice(idxStartDelete, 2);
+    } else {
+      parent.rules.splice(index, 1);
+    }
+  });
+
+export const move = <RG extends RuleGroupType | RuleGroupTypeIC>(
+  query: RG,
+  oldPath: number[],
+  newPath: number[],
+  {
+    clone,
+    combinators = defaultCombinators,
+    independentCombinators,
+  }: {
+    clone?: boolean;
+    combinators?: NameLabelPair[] | OptionGroup<NameLabelPair>[];
+    independentCombinators?: boolean;
+  }
+) => {
+  const ruleOrGroupOriginal = findPath(oldPath, query);
+  /* istanbul ignore if */
+  if (!ruleOrGroupOriginal) return query;
+  const ruleOrGroup = clone
+    ? 'rules' in ruleOrGroupOriginal
+      ? regenerateIDs(ruleOrGroupOriginal)
+      : regenerateID(ruleOrGroupOriginal)
+    : ruleOrGroupOriginal;
+
+  const commonAncestorPath = getCommonAncestorPath(oldPath, newPath);
+  const movingOnUp = newPath[commonAncestorPath.length] <= oldPath[commonAncestorPath.length];
+
+  return produce(query, draft => {
+    const parentOfRuleToRemove = findPath(getParentPath(oldPath), draft) as RG;
+    const ruleToRemoveIndex = oldPath[oldPath.length - 1];
+    const oldPrevCombinator =
+      independentCombinators && ruleToRemoveIndex > 0
+        ? (parentOfRuleToRemove.rules[ruleToRemoveIndex - 1] as string)
+        : null;
+    const oldNextCombinator =
+      independentCombinators && ruleToRemoveIndex < parentOfRuleToRemove.rules.length - 1
+        ? (parentOfRuleToRemove.rules[ruleToRemoveIndex + 1] as string)
+        : null;
+    /* istanbul ignore else */
+    if (!clone) {
+      const idxStartDelete = independentCombinators
+        ? Math.max(0, ruleToRemoveIndex - 1)
+        : ruleToRemoveIndex;
+      const deleteLength = independentCombinators ? 2 : 1;
+      // Remove the source item
+      parentOfRuleToRemove.rules.splice(idxStartDelete, deleteLength);
+    }
+
+    const newNewPath = [...newPath];
+    /* istanbul ignore else */
+    if (!movingOnUp && !clone) {
+      newNewPath[commonAncestorPath.length] -= independentCombinators ? 2 : 1;
+    }
+    const newNewParentPath = getParentPath(newNewPath);
+    const parentToInsertInto = findPath(newNewParentPath, draft) as RG;
+    const newIndex = newNewPath[newNewPath.length - 1];
+
+    // This function 1) glosses over the need for type assertions to splice directly
+    // into parentToInsertInto.rules, and 2) simplifies the actual insertion code.
+    const insertRuleOrGroup = (...args: any[]) =>
+      parentToInsertInto.rules.splice(newIndex, 0, ...args);
+
+    // Insert the source item at the target path
+    if (parentToInsertInto.rules.length === 0 || !independentCombinators) {
+      insertRuleOrGroup(ruleOrGroup);
+    } else {
+      if (newIndex === 0) {
+        if (ruleToRemoveIndex === 0 && oldNextCombinator) {
+          insertRuleOrGroup(ruleOrGroup, oldNextCombinator);
+        } else {
+          const newNextCombinator =
+            parentToInsertInto.rules[1] ||
+            oldPrevCombinator ||
+            /* istanbul ignore next */ getFirstOption(combinators);
+          insertRuleOrGroup(ruleOrGroup, newNextCombinator);
+        }
+      } else {
+        if (oldPrevCombinator) {
+          insertRuleOrGroup(oldPrevCombinator, ruleOrGroup);
+        } else {
+          const newPrevCombinator =
+            parentToInsertInto.rules[newIndex - 2] ||
+            oldNextCombinator ||
+            getFirstOption(combinators);
+          insertRuleOrGroup(newPrevCombinator, ruleOrGroup);
+        }
+      }
+    }
+  });
+};

--- a/packages/react-querybuilder/src/utils/queryTools.ts
+++ b/packages/react-querybuilder/src/utils/queryTools.ts
@@ -100,7 +100,6 @@ export const move = <RG extends RuleGroupType | RuleGroupTypeIC>(
     return query;
   }
   const ruleOrGroupOriginal = findPath(oldPath, query);
-  /* istanbul ignore if */
   if (!ruleOrGroupOriginal) {
     return query;
   }


### PR DESCRIPTION
Fixes #244.

- Expose internal query manipulation methods:
  - `add` - adds a rule or group (and an independent combinator if necessary)
  - `remove` - removes a rule or group (and the previous independent combinator if one exists)
  - `update` - updates a property of a rule or group, or updates an independent combinator
  - `move` - moves (or clones with a new `id`) a rule or group to a new location in the query tree
- Add `"queryBuilder-disabled"` class to disabled queries, groups, and rules