### PR TITLE
Add library-specific props to compatibility components

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,10 +1,10 @@
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   schedule:
     - cron: '45 5 * * 1'
 
@@ -20,32 +20,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ['javascript']
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/packages/antd/src/AntDActionElement.tsx
+++ b/packages/antd/src/AntDActionElement.tsx
@@ -1,5 +1,8 @@
 import { Button } from 'antd';
-import type { ActionProps } from 'react-querybuilder';
+import { ComponentPropsWithoutRef } from 'react';
+import type { ActionWithRulesProps } from 'react-querybuilder';
+
+type AntDActionProps = ActionWithRulesProps & ComponentPropsWithoutRef<typeof Button>;
 
 export const AntDActionElement = ({
   className,
@@ -8,13 +11,22 @@ export const AntDActionElement = ({
   title,
   disabled,
   disabledTranslation,
-}: ActionProps) => (
+  // Props that should not be in extraProps
+  testID: _testID,
+  rules: _rules,
+  level: _level,
+  path: _path,
+  context: _context,
+  validation: _validation,
+  ...extraProps
+}: AntDActionProps) => (
   <Button
     type="primary"
     className={className}
     title={disabledTranslation && disabled ? disabledTranslation.title : title}
     onClick={e => handleOnClick(e)}
-    disabled={disabled && !disabledTranslation}>
+    disabled={disabled && !disabledTranslation}
+    {...extraProps}>
     {disabledTranslation && disabled ? disabledTranslation.label : label}
   </Button>
 );

--- a/packages/antd/src/AntDDragHandle.tsx
+++ b/packages/antd/src/AntDDragHandle.tsx
@@ -1,13 +1,27 @@
 import { HolderOutlined } from '@ant-design/icons';
-import { forwardRef } from 'react';
+import { forwardRef, type ComponentPropsWithRef } from 'react';
 import type { DragHandleProps } from 'react-querybuilder';
 
-export const AntDDragHandle = forwardRef<HTMLSpanElement, DragHandleProps>(
-  ({ className, title }, dragRef) => (
-    <span ref={dragRef} className={className} title={title}>
-      <HolderOutlined />
-    </span>
-  )
+type AntDDragHandleProps = DragHandleProps & ComponentPropsWithRef<typeof HolderOutlined>;
+
+export const AntDDragHandle = forwardRef<HTMLSpanElement, AntDDragHandleProps>(
+  (
+    {
+      className,
+      title,
+      // Props that should not be in extraProps
+      testID: _testID,
+      ref: _ref,
+      level: _level,
+      path: _path,
+      label: _label,
+      disabled: _disabled,
+      context: _context,
+      validation: _validation,
+      ...extraProps
+    },
+    dragRef
+  ) => <HolderOutlined ref={dragRef} className={className} title={title} {...extraProps} />
 );
 
 AntDDragHandle.displayName = 'AntDDragHandle';

--- a/packages/antd/src/AntDNotToggle.tsx
+++ b/packages/antd/src/AntDNotToggle.tsx
@@ -1,5 +1,8 @@
 import { Switch } from 'antd';
+import type { ComponentPropsWithoutRef } from 'react';
 import type { NotToggleProps } from 'react-querybuilder';
+
+type AntDNotToggleProps = NotToggleProps & ComponentPropsWithoutRef<typeof Switch>;
 
 export const AntDNotToggle = ({
   className,
@@ -8,7 +11,8 @@ export const AntDNotToggle = ({
   checked,
   title,
   disabled,
-}: NotToggleProps) => (
+  ...extraProps
+}: AntDNotToggleProps) => (
   <Switch
     title={title}
     className={className}
@@ -17,6 +21,7 @@ export const AntDNotToggle = ({
     disabled={disabled}
     checkedChildren={label}
     unCheckedChildren="="
+    {...extraProps}
   />
 );
 

--- a/packages/antd/src/AntDValueEditor.tsx
+++ b/packages/antd/src/AntDValueEditor.tsx
@@ -14,6 +14,7 @@ export const AntDValueEditor = ({
   type,
   inputType,
   values,
+  valueSource: _vs,
   disabled,
   ...props
 }: ValueEditorProps) => {

--- a/packages/antd/src/AntDValueSelector.tsx
+++ b/packages/antd/src/AntDValueSelector.tsx
@@ -1,7 +1,10 @@
 import { Select } from 'antd';
-import { useMemo } from 'react';
-import type { ValueSelectorProps } from 'react-querybuilder';
+import { useMemo, type ComponentPropsWithoutRef } from 'react';
+import type { VersatileSelectorProps } from 'react-querybuilder';
 import { toOptions } from './utils';
+
+type AntDValueSelectorProps = VersatileSelectorProps &
+  Omit<ComponentPropsWithoutRef<typeof Select>, 'onChange' | 'defaultValue'>;
 
 export const AntDValueSelector = ({
   className,
@@ -11,7 +14,18 @@ export const AntDValueSelector = ({
   title,
   disabled,
   multiple,
-}: ValueSelectorProps) => {
+  // Props that should not be in extraProps
+  testID: _testID,
+  rules: _rules,
+  level: _level,
+  path: _path,
+  context: _context,
+  validation: _validation,
+  operator: _operator,
+  field: _field,
+  fieldData: _fieldData,
+  ...extraProps
+}: AntDValueSelectorProps) => {
   const onChange = useMemo(() => {
     if (multiple) {
       return (v: string | string[]) =>
@@ -35,7 +49,8 @@ export const AntDValueSelector = ({
         dropdownMatchSelectWidth={false}
         disabled={disabled}
         value={val as any}
-        onChange={onChange}>
+        onChange={onChange}
+        {...extraProps}>
         {toOptions(options)}
       </Select>
     </span>

--- a/packages/bulma/src/BulmaActionElement.tsx
+++ b/packages/bulma/src/BulmaActionElement.tsx
@@ -10,7 +10,7 @@ export const BulmaActionElement = ({
 }: ActionProps) => (
   <button
     type="button"
-    className={`${className} button is-small`}
+    className={`button is-small ${className}`}
     title={disabledTranslation && disabled ? disabledTranslation.title : title}
     onClick={e => handleOnClick(e)}
     disabled={disabled && !disabledTranslation}>

--- a/packages/chakra/src/ChakraActionElement.tsx
+++ b/packages/chakra/src/ChakraActionElement.tsx
@@ -1,5 +1,8 @@
 import { Button } from '@chakra-ui/react';
-import type { ActionProps } from 'react-querybuilder';
+import type { ComponentPropsWithoutRef } from 'react';
+import type { ActionWithRulesProps } from 'react-querybuilder';
+
+type ChakraActionProps = ActionWithRulesProps & ComponentPropsWithoutRef<typeof Button>;
 
 export const ChakraActionElement = ({
   className,
@@ -8,7 +11,15 @@ export const ChakraActionElement = ({
   title,
   disabled,
   disabledTranslation,
-}: ActionProps) => (
+  // Props that should not be in extraProps
+  testID: _testID,
+  rules: _rules,
+  level: _level,
+  path: _path,
+  context: _context,
+  validation: _validation,
+  ...extraProps
+}: ChakraActionProps) => (
   <Button
     className={className}
     title={disabledTranslation && disabled ? disabledTranslation.title : title}
@@ -16,7 +27,8 @@ export const ChakraActionElement = ({
     variant="solid"
     onClick={e => handleOnClick(e)}
     size="xs"
-    isDisabled={disabled && !disabledTranslation}>
+    isDisabled={disabled && !disabledTranslation}
+    {...extraProps}>
     {disabledTranslation && disabled ? disabledTranslation.label : label}
   </Button>
 );

--- a/packages/chakra/src/ChakraDragHandle.tsx
+++ b/packages/chakra/src/ChakraDragHandle.tsx
@@ -1,16 +1,39 @@
 import { DragHandleIcon } from '@chakra-ui/icons';
 import { IconButton } from '@chakra-ui/react';
-import { forwardRef } from 'react';
+import { forwardRef, type ComponentPropsWithRef } from 'react';
 import type { DragHandleProps } from 'react-querybuilder';
 
-export const ChakraDragHandle = forwardRef<HTMLSpanElement, DragHandleProps>(
-  ({ className, title, disabled }, dragRef) => (
+type IBP = ComponentPropsWithRef<typeof IconButton>;
+
+type ChakraDragHandleProps = DragHandleProps &
+  Omit<IBP, 'aria-label'> &
+  Partial<Pick<IBP, 'aria-label'>>;
+
+export const ChakraDragHandle = forwardRef<HTMLSpanElement, ChakraDragHandleProps>(
+  (
+    {
+      className,
+      title,
+      disabled,
+      // Props that should not be in extraProps
+      testID: _testID,
+      ref: _ref,
+      level: _level,
+      path: _path,
+      label: _label,
+      context: _context,
+      validation: _validation,
+      ...extraProps
+    },
+    dragRef
+  ) => (
     <span ref={dragRef} className={className} title={title}>
       <IconButton
         isDisabled={disabled}
-        aria-label={title ?? /* istanbul ignore next */ ''}
         size="xs"
         icon={<DragHandleIcon />}
+        aria-label={title ?? /* istanbul ignore next */ ''}
+        {...extraProps}
       />
     </span>
   )

--- a/packages/chakra/src/ChakraNotToggle.tsx
+++ b/packages/chakra/src/ChakraNotToggle.tsx
@@ -1,6 +1,8 @@
 import { FormControl, FormLabel, Switch } from '@chakra-ui/react';
-import { useRef } from 'react';
+import { useRef, type ComponentPropsWithoutRef } from 'react';
 import type { NotToggleProps } from 'react-querybuilder';
+
+type ChakraNotToggleProps = NotToggleProps & ComponentPropsWithoutRef<typeof Switch>;
 
 export const ChakraNotToggle = ({
   className,
@@ -9,7 +11,8 @@ export const ChakraNotToggle = ({
   checked,
   title,
   disabled,
-}: NotToggleProps) => {
+  ...extraProps
+}: ChakraNotToggleProps) => {
   const id = useRef(`notToggle-${Math.random()}`);
 
   return (
@@ -27,6 +30,7 @@ export const ChakraNotToggle = ({
           isChecked={checked}
           isDisabled={disabled}
           onChange={e => handleOnChange(e.target.checked)}
+          {...extraProps}
         />
         <FormLabel htmlFor={id.current}>{label}</FormLabel>
       </FormControl>

--- a/packages/chakra/src/ChakraValueEditor.tsx
+++ b/packages/chakra/src/ChakraValueEditor.tsx
@@ -1,6 +1,6 @@
 import { Checkbox, Input, Radio, RadioGroup, Stack, Switch, Textarea } from '@chakra-ui/react';
 import { useEffect } from 'react';
-import { ValueEditorProps, ValueSelector } from 'react-querybuilder';
+import { type ValueEditorProps, ValueSelector } from 'react-querybuilder';
 import { ChakraValueSelector } from './ChakraValueSelector';
 
 export const ChakraValueEditor = ({
@@ -13,6 +13,8 @@ export const ChakraValueEditor = ({
   type,
   inputType,
   values,
+  valueSource: _vs,
+  testID: _t,
   disabled,
   ...props
 }: ValueEditorProps) => {

--- a/packages/chakra/src/ChakraValueSelector.tsx
+++ b/packages/chakra/src/ChakraValueSelector.tsx
@@ -1,6 +1,9 @@
 import { Select } from '@chakra-ui/react';
-import type { ValueSelectorProps } from 'react-querybuilder';
+import type { ComponentPropsWithoutRef } from 'react';
+import type { VersatileSelectorProps } from 'react-querybuilder';
 import { toOptions } from './utils';
+
+type ChakraValueSelectorProps = VersatileSelectorProps & ComponentPropsWithoutRef<typeof Select>;
 
 export const ChakraValueSelector = ({
   className,
@@ -9,7 +12,19 @@ export const ChakraValueSelector = ({
   value,
   title,
   disabled,
-}: ValueSelectorProps) => (
+  // Props that should not be in extraProps
+  testID: _testID,
+  rules: _rules,
+  level: _level,
+  path: _path,
+  context: _context,
+  validation: _validation,
+  operator: _operator,
+  field: _field,
+  fieldData: _fieldData,
+  multiple: _multiple,
+  ...extraProps
+}: ChakraValueSelectorProps) => (
   <Select
     className={className}
     title={title}
@@ -17,7 +32,8 @@ export const ChakraValueSelector = ({
     size="xs"
     variant="filled"
     disabled={disabled}
-    onChange={e => handleOnChange(e.target.value)}>
+    onChange={e => handleOnChange(e.target.value)}
+    {...extraProps}>
     {toOptions(options)}
   </Select>
 );

--- a/packages/material/src/MaterialActionElement.tsx
+++ b/packages/material/src/MaterialActionElement.tsx
@@ -1,5 +1,8 @@
 import Button from '@mui/material/Button';
-import type { ActionProps } from 'react-querybuilder';
+import type { ComponentPropsWithoutRef } from 'react';
+import type { ActionWithRulesProps } from 'react-querybuilder';
+
+type MaterialActionProps = ActionWithRulesProps & ComponentPropsWithoutRef<typeof Button>;
 
 export const MaterialActionElement = ({
   className,
@@ -8,7 +11,15 @@ export const MaterialActionElement = ({
   title,
   disabled,
   disabledTranslation,
-}: ActionProps) => (
+  // Props that should not be in extraProps
+  testID: _testID,
+  rules: _rules,
+  level: _level,
+  path: _path,
+  context: _context,
+  validation: _validation,
+  ...extraProps
+}: MaterialActionProps) => (
   <Button
     variant="contained"
     color="primary"
@@ -16,7 +27,8 @@ export const MaterialActionElement = ({
     title={disabledTranslation && disabled ? disabledTranslation.title : title}
     size="small"
     disabled={disabled && !disabledTranslation}
-    onClick={e => handleOnClick(e)}>
+    onClick={e => handleOnClick(e)}
+    {...extraProps}>
     {disabledTranslation && disabled ? disabledTranslation.label : label}
   </Button>
 );

--- a/packages/material/src/MaterialDragHandle.tsx
+++ b/packages/material/src/MaterialDragHandle.tsx
@@ -1,11 +1,30 @@
 import DragIndicator from '@mui/icons-material/DragIndicator';
-import { forwardRef } from 'react';
+import { forwardRef, type ComponentPropsWithRef } from 'react';
 import type { DragHandleProps } from 'react-querybuilder';
 
-export const MaterialDragHandle = forwardRef<HTMLSpanElement, DragHandleProps>(
-  ({ className, title }, dragRef) => (
+type MaterialDragHandleProps = DragHandleProps &
+  Omit<ComponentPropsWithRef<typeof DragIndicator>, 'path'>;
+
+export const MaterialDragHandle = forwardRef<HTMLSpanElement, MaterialDragHandleProps>(
+  (
+    {
+      className,
+      title,
+      path: _path,
+      // Props that should not be in extraProps
+      testID: _testID,
+      ref: _ref,
+      level: _level,
+      label: _label,
+      disabled: _disabled,
+      context: _context,
+      validation: _validation,
+      ...extraProps
+    },
+    dragRef
+  ) => (
     <span ref={dragRef} className={className} title={title}>
-      <DragIndicator />
+      <DragIndicator {...extraProps} />
     </span>
   )
 );

--- a/packages/material/src/MaterialNotToggle.tsx
+++ b/packages/material/src/MaterialNotToggle.tsx
@@ -1,6 +1,9 @@
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
+import type { ComponentPropsWithoutRef } from 'react';
 import type { NotToggleProps } from 'react-querybuilder';
+
+type MaterialNotToggleProps = NotToggleProps & ComponentPropsWithoutRef<typeof Switch>;
 
 export const MaterialNotToggle = ({
   className,
@@ -9,12 +12,19 @@ export const MaterialNotToggle = ({
   checked,
   title,
   disabled,
-}: NotToggleProps) => (
+  ...extraProps
+}: MaterialNotToggleProps) => (
   <FormControlLabel
     className={className}
     title={title}
     disabled={disabled}
-    control={<Switch checked={!!checked} onChange={e => handleOnChange(e.target.checked)} />}
+    control={
+      <Switch
+        checked={!!checked}
+        onChange={e => handleOnChange(e.target.checked)}
+        {...extraProps}
+      />
+    }
     label={label ?? /* istanbul ignore next */ ''}
   />
 );

--- a/packages/material/src/MaterialValueEditor.tsx
+++ b/packages/material/src/MaterialValueEditor.tsx
@@ -20,6 +20,7 @@ export const MaterialValueEditor = ({
   type,
   inputType,
   values,
+  valueSource: _vs,
   disabled,
   ...props
 }: ValueEditorProps) => {

--- a/packages/material/src/MaterialValueSelector.tsx
+++ b/packages/material/src/MaterialValueSelector.tsx
@@ -1,8 +1,10 @@
 import FormControl from '@mui/material/FormControl';
 import Select, { type SelectChangeEvent } from '@mui/material/Select';
-import { useMemo } from 'react';
-import type { ValueSelectorProps } from 'react-querybuilder';
+import { useMemo, type ComponentPropsWithoutRef } from 'react';
+import type { VersatileSelectorProps } from 'react-querybuilder';
 import { toOptions } from './utils';
+
+type MaterialValueSelectorProps = VersatileSelectorProps & ComponentPropsWithoutRef<typeof Select>;
 
 export const MaterialValueSelector = ({
   className,
@@ -12,7 +14,18 @@ export const MaterialValueSelector = ({
   disabled,
   title,
   multiple,
-}: ValueSelectorProps) => {
+  // Props that should not be in extraProps
+  testID: _testID,
+  rules: _rules,
+  level: _level,
+  path: _path,
+  context: _context,
+  validation: _validation,
+  operator: _operator,
+  field: _field,
+  fieldData: _fieldData,
+  ...extraProps
+}: MaterialValueSelectorProps) => {
   const onChange = useMemo(() => {
     if (multiple) {
       return ({ target: { value: v } }: SelectChangeEvent<string | string[]>) =>
@@ -25,7 +38,7 @@ export const MaterialValueSelector = ({
 
   return (
     <FormControl variant="standard" className={className} title={title} disabled={disabled}>
-      <Select value={val as any} onChange={onChange} multiple={!!multiple}>
+      <Select value={val as any} onChange={onChange} multiple={!!multiple} {...extraProps}>
         {toOptions(options)}
       </Select>
     </FormControl>

--- a/packages/react-querybuilder/src/types/basic.ts
+++ b/packages/react-querybuilder/src/types/basic.ts
@@ -20,9 +20,9 @@ export interface NameLabelPair {
   [x: string]: any;
 }
 
-export type OptionGroup<O extends NameLabelPair = NameLabelPair> = {
+export type OptionGroup<Opt extends NameLabelPair = NameLabelPair> = {
   label: string;
-  options: O[];
+  options: Opt[];
 };
 
 export interface Field extends NameLabelPair {

--- a/packages/react-querybuilder/src/types/importExport.ts
+++ b/packages/react-querybuilder/src/types/importExport.ts
@@ -1,6 +1,6 @@
 import type { Field, OptionGroup, ValueSource, ValueSources } from './basic';
 import type { RuleType } from './ruleGroups';
-import type { QueryValidator, RuleValidator } from './validation';
+import type { QueryValidator } from './validation';
 
 export type ExportFormat =
   | 'json'
@@ -37,7 +37,7 @@ export interface FormatQueryOptions {
    * This can be the same Field[] passed to <QueryBuilder />, but really
    * all you need to provide is the name and validator for each field.
    */
-  fields?: { name: string; validator?: RuleValidator; [k: string]: any }[];
+  fields?: (Pick<Field, 'name' | 'validator'> & Record<string, any>)[];
   /**
    * This string will be inserted in place of invalid groups for "sql",
    * "parameterized", "parameterized_named", and "mongodb" formats.
@@ -77,13 +77,13 @@ export interface ParameterizedSQL {
 
 export interface ParameterizedNamedSQL {
   sql: string;
-  params: { [p: string]: any };
+  params: Record<string, any>;
 }
 
 export interface ParseSQLOptions {
   independentCombinators?: boolean;
   paramPrefix?: string;
-  params?: any[] | { [p: string]: any };
+  params?: any[] | Record<string, any>;
   listsAsArrays?: boolean;
   fields?: Field[] | OptionGroup<Field>[] | Record<string, Field>;
   getValueSources?: (field: string, operator: string) => ValueSources;

--- a/packages/react-querybuilder/src/types/props.ts
+++ b/packages/react-querybuilder/src/types/props.ts
@@ -232,7 +232,7 @@ export interface Classnames {
 
 export interface Schema {
   fields: Field[] | OptionGroup<Field>[];
-  fieldMap: { [k: string]: Field };
+  fieldMap: Record<string, Field>;
   classNames: Classnames;
   combinators: NameLabelPair[] | OptionGroup[];
   controls: Controls;

--- a/packages/react-querybuilder/src/types/props.ts
+++ b/packages/react-querybuilder/src/types/props.ts
@@ -107,6 +107,11 @@ export interface ValueSourceSelectorProps extends BaseSelectorProps {
   options: ValueSourceOption[] | OptionGroup<ValueSourceOption>[];
 }
 
+export type VersatileSelectorProps = ValueSelectorProps &
+  Partial<FieldSelectorProps> &
+  Partial<OperatorSelectorProps> &
+  Partial<CombinatorSelectorProps>;
+
 export interface ValueEditorProps extends SelectorEditorProps {
   field: string;
   operator: string;

--- a/packages/react-querybuilder/src/types/validation.ts
+++ b/packages/react-querybuilder/src/types/validation.ts
@@ -6,9 +6,7 @@ export interface ValidationResult {
   reasons?: any[];
 }
 
-export interface ValidationMap {
-  [id: string]: boolean | ValidationResult;
-}
+export type ValidationMap = Record<string, boolean | ValidationResult>;
 
 export type QueryValidator = (query: RuleGroupTypeAny) => boolean | ValidationMap;
 


### PR DESCRIPTION
Fixes #289.

To use the extra props, spread the default props to the component and add any library specific props, like this:

```tsx
import { AntDActionElement } from '@react-querybuilder/antd';
import { QueryBuilder, type ActionWithRulesProps } from 'react-querybuilder';

const MyActionElement = (props: ActionWithRulesProps) => (
  <AntDActionElement {...props} size="large" /> // `size` is from the 'antd' `Button` component
);

export const App = () => {
  return (
    <QueryBuilder
      controlElements={{
        addRuleAction: MyActionElement,
        addGroupAction: MyActionElement,
        cloneRuleAction: MyActionElement,
        cloneGroupAction: MyActionElement,
        lockRuleAction: MyActionElement,
        lockGroupAction: MyActionElement,
        removeRuleAction: MyActionElement,
        removeGroupAction: MyActionElement,
      }}
    />
  )
}
```