### PR TITLE
Add `autoSelectOperator` prop

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,10 @@
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
+    ],
     "react/display-name": "off",
     "react/prop-types": "off",
     "react/react-in-jsx-scope": "off"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         uses: creyD/prettier_action@v3.1
         with:
           prettier_options: --write packages/*/src/** ./*.js
-          prettier_version: 2.5.1
+          prettier_version: 2.6.2
           commit_message: 'Prettified code'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/demo/src/constants.ts
+++ b/packages/demo/src/constants.ts
@@ -14,9 +14,6 @@ export const styleNameMap: Record<StyleName, string> = {
   bulma: 'Bulma',
 };
 
-export const styleNameArray: StyleName[] = [
-  'default',
-  ...objectKeys(styleNameMap)
-    .filter(s => s !== 'default')
-    .sort(),
-];
+const { default: _d, ...compatStyles } = styleNameMap;
+
+export const styleNameArray: StyleName[] = ['default', ...objectKeys(compatStyles).sort()];

--- a/packages/react-querybuilder/dev/constants.ts
+++ b/packages/react-querybuilder/dev/constants.ts
@@ -19,6 +19,7 @@ export const defaultOptions: DemoOptions = {
   resetOnFieldChange: true,
   resetOnOperatorChange: false,
   autoSelectField: true,
+  autoSelectOperator: true,
   addRuleToNewGroups: false,
   validateQuery: false,
   independentCombinators: false,
@@ -36,6 +37,7 @@ export const optionOrder: DemoOption[] = [
   'resetOnFieldChange',
   'resetOnOperatorChange',
   'autoSelectField',
+  'autoSelectOperator',
   'addRuleToNewGroups',
   'validateQuery',
   'independentCombinators',
@@ -82,6 +84,11 @@ export const optionsMetadata: Record<
     link: '/docs/api/querybuilder#autoselectfield',
     label: 'Auto-select field',
     title: 'The default field will be automatically selected for new rules',
+  },
+  autoSelectOperator: {
+    link: '/docs/api/querybuilder#autoselectoperator',
+    label: 'Auto-select operator',
+    title: 'The default operator will be automatically selected for new rules',
   },
   addRuleToNewGroups: {
     link: '/docs/api/querybuilder#addruletonewgroups',

--- a/packages/react-querybuilder/dev/types.ts
+++ b/packages/react-querybuilder/dev/types.ts
@@ -8,6 +8,7 @@ export type DemoOption =
   | 'resetOnFieldChange'
   | 'resetOnOperatorChange'
   | 'autoSelectField'
+  | 'autoSelectOperator'
   | 'addRuleToNewGroups'
   | 'validateQuery'
   | 'independentCombinators'

--- a/packages/react-querybuilder/src/QueryBuilder.test.tsx
+++ b/packages/react-querybuilder/src/QueryBuilder.test.tsx
@@ -1,7 +1,13 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { simulateDragDrop, wrapWithTestBackend } from 'react-dnd-test-utils';
-import { defaultTranslations as t, standardClassnames as sc, TestID } from './defaults';
+import {
+  defaultPlaceholderFieldName,
+  defaultPlaceholderOperatorName,
+  defaultTranslations as t,
+  standardClassnames as sc,
+  TestID,
+} from './defaults';
 import {
   QueryBuilder as QueryBuilderOriginal,
   QueryBuilderWithoutDndProvider,
@@ -206,7 +212,7 @@ describe('when fields are provided with optgroups', () => {
       <QueryBuilder defaultQuery={query} fields={fields} autoSelectField={false} />
     );
     await user.click(selectors.getByTestId(TestID.addRule));
-    expect(selectors.getAllByTestId(TestID.fields)[1]).toHaveValue('~');
+    expect(selectors.getAllByTestId(TestID.fields)[1]).toHaveValue(defaultPlaceholderFieldName);
   });
 });
 
@@ -869,19 +875,21 @@ describe('autoSelectField', () => {
     expect(container.querySelectorAll(`.${sc.value}`)).toHaveLength(0);
   });
 
-  it('uses the placeholderFieldLabel', async () => {
-    const placeholderFieldLabel = 'Test placeholder';
+  it('uses the placeholderFieldLabel and placeholderFieldName', async () => {
+    const placeholderFieldName = 'placeholderFieldName';
+    const placeholderLabel = 'Test placeholder';
     const { getByDisplayValue, getByTestId } = render(
       <QueryBuilder
         fields={fields}
         autoSelectField={false}
-        translations={{ fields: { placeholderLabel: placeholderFieldLabel } }}
+        placeholderFieldName={placeholderFieldName}
+        translations={{ fields: { placeholderLabel } }}
       />
     );
 
     await user.click(getByTestId(TestID.addRule));
 
-    expect(getByDisplayValue(placeholderFieldLabel)).toBeInTheDocument();
+    expect(getByDisplayValue(placeholderLabel)).toHaveValue(placeholderFieldName);
   });
 
   it('uses the placeholderFieldGroupLabel', async () => {
@@ -920,29 +928,35 @@ describe('autoSelectOperator', () => {
 
     expect(container.querySelectorAll(`select.${sc.fields}`)).toHaveLength(1);
     expect(container.querySelectorAll(`select.${sc.operators}`)).toHaveLength(1);
+    expect(getByTestId(TestID.operators)).toHaveValue(defaultPlaceholderOperatorName);
     expect(container.querySelectorAll(`.${sc.value}`)).toHaveLength(0);
   });
 
-  it('uses the placeholderOperatorLabel', async () => {
-    const placeholderOperatorLabel = 'Test placeholder';
+  it('uses the placeholderOperatorLabel and placeholderOperatorName', async () => {
+    const placeholderOperatorName = 'placeholderOperatorName';
+    const placeholderLabel = 'Test placeholder';
     const { getByDisplayValue, getByTestId } = render(
       <QueryBuilder
         fields={fields}
         autoSelectOperator={false}
-        translations={{ operators: { placeholderLabel: placeholderOperatorLabel } }}
+        placeholderOperatorName={placeholderOperatorName}
+        translations={{ operators: { placeholderLabel } }}
       />
     );
 
     await user.click(getByTestId(TestID.addRule));
 
-    expect(getByDisplayValue(placeholderOperatorLabel)).toBeInTheDocument();
+    expect(getByDisplayValue(placeholderLabel)).toHaveValue(placeholderOperatorName);
   });
 
   it('uses the placeholderOperatorGroupLabel', async () => {
     const placeholderOperatorGroupLabel = 'Test group placeholder';
     const { container, getByTestId } = render(
       <QueryBuilder
-        fields={[{ label: 'Fields', options: fields }]}
+        fields={fields.map(f => ({
+          ...f,
+          operators: [{ label: 'Operators', options: operators }],
+        }))}
         autoSelectOperator={false}
         translations={{
           operators: { placeholderGroupLabel: placeholderOperatorGroupLabel },
@@ -981,7 +995,7 @@ describe('addRuleToNewGroups', () => {
     await user.click(selectors.getByTestId(TestID.addGroup));
     expect(
       ((onQueryChange.mock.calls[1][0] as RuleGroupType).rules[0] as RuleGroupType).rules[0]
-    ).toHaveProperty('field', '~');
+    ).toHaveProperty('field', defaultPlaceholderFieldName);
   });
 
   it('adds a rule when mounted if no initial query is provided', () => {

--- a/packages/react-querybuilder/src/QueryBuilder.test.tsx
+++ b/packages/react-querybuilder/src/QueryBuilder.test.tsx
@@ -833,9 +833,10 @@ describe('valueEditorType property in field', () => {
 
 describe('operators property in field', () => {
   it('sets the operators options', async () => {
+    const operators = [{ name: '=', label: '=' }];
     const fields: Field[] = [
-      { name: 'field1', label: 'Field 1', operators: [{ name: '=', label: '=' }] },
-      { name: 'field2', label: 'Field 2', operators: [{ name: '=', label: '=' }] },
+      { name: 'field1', label: 'Field 1', operators },
+      { name: 'field2', label: 'Field 2', operators },
     ];
     const onQueryChange = jest.fn();
     const { container, getByTestId } = render(
@@ -850,9 +851,10 @@ describe('operators property in field', () => {
 });
 
 describe('autoSelectField', () => {
+  const operators = [{ name: '=', label: '=' }];
   const fields: Field[] = [
-    { name: 'field1', label: 'Field 1', operators: [{ name: '=', label: '=' }] },
-    { name: 'field2', label: 'Field 2', operators: [{ name: '=', label: '=' }] },
+    { name: 'field1', label: 'Field 1', operators },
+    { name: 'field2', label: 'Field 2', operators },
   ];
 
   it('initially hides the operator selector and value editor', async () => {
@@ -898,6 +900,60 @@ describe('autoSelectField', () => {
 
     expect(
       container.querySelector(`optgroup[label="${placeholderFieldGroupLabel}"]`)
+    ).toBeInTheDocument();
+  });
+});
+
+describe('autoSelectOperator', () => {
+  const operators = [{ name: '=', label: '=' }];
+  const fields: Field[] = [
+    { name: 'field1', label: 'Field 1', operators },
+    { name: 'field2', label: 'Field 2', operators },
+  ];
+
+  it('initially hides the value editor', async () => {
+    const { container, getByTestId } = render(
+      <QueryBuilder fields={fields} autoSelectOperator={false} />
+    );
+
+    await user.click(getByTestId(TestID.addRule));
+
+    expect(container.querySelectorAll(`select.${sc.fields}`)).toHaveLength(1);
+    expect(container.querySelectorAll(`select.${sc.operators}`)).toHaveLength(1);
+    expect(container.querySelectorAll(`.${sc.value}`)).toHaveLength(0);
+  });
+
+  it('uses the placeholderOperatorLabel', async () => {
+    const placeholderOperatorLabel = 'Test placeholder';
+    const { getByDisplayValue, getByTestId } = render(
+      <QueryBuilder
+        fields={fields}
+        autoSelectOperator={false}
+        translations={{ operators: { placeholderLabel: placeholderOperatorLabel } }}
+      />
+    );
+
+    await user.click(getByTestId(TestID.addRule));
+
+    expect(getByDisplayValue(placeholderOperatorLabel)).toBeInTheDocument();
+  });
+
+  it('uses the placeholderOperatorGroupLabel', async () => {
+    const placeholderOperatorGroupLabel = 'Test group placeholder';
+    const { container, getByTestId } = render(
+      <QueryBuilder
+        fields={[{ label: 'Fields', options: fields }]}
+        autoSelectOperator={false}
+        translations={{
+          operators: { placeholderGroupLabel: placeholderOperatorGroupLabel },
+        }}
+      />
+    );
+
+    await user.click(getByTestId(TestID.addRule));
+
+    expect(
+      container.querySelector(`optgroup[label="${placeholderOperatorGroupLabel}"]`)
     ).toBeInTheDocument();
   });
 });

--- a/packages/react-querybuilder/src/QueryBuilder.tsx
+++ b/packages/react-querybuilder/src/QueryBuilder.tsx
@@ -7,6 +7,8 @@ import {
   defaultControlClassnames,
   defaultControlElements,
   defaultOperators,
+  defaultPlaceholderFieldName,
+  defaultPlaceholderOperatorName,
   defaultTranslations,
   standardClassnames,
 } from './defaults';
@@ -71,7 +73,9 @@ export const QueryBuilderWithoutDndProvider = <RG extends RuleGroupType | RuleGr
   resetOnFieldChange = true,
   resetOnOperatorChange = false,
   autoSelectField = true,
+  placeholderFieldName = defaultPlaceholderFieldName,
   autoSelectOperator = true,
+  placeholderOperatorName = defaultPlaceholderOperatorName,
   addRuleToNewGroups = false,
   enableDragAndDrop = false,
   independentCombinators,
@@ -88,11 +92,15 @@ export const QueryBuilderWithoutDndProvider = <RG extends RuleGroupType | RuleGr
     return translationsTemp;
   }, [translationsProp]);
 
-  const defaultFields = useMemo(
-    (): Field[] => [{ id: '~', name: '~', label: translations.fields.placeholderLabel }],
-    [translations.fields.placeholderLabel]
+  const defaultField = useMemo(
+    (): Field => ({
+      id: placeholderFieldName,
+      name: placeholderFieldName,
+      label: translations.fields.placeholderLabel,
+    }),
+    [placeholderFieldName, translations.fields.placeholderLabel]
   );
-  const fieldsProp = fProp ?? defaultFields;
+  const fieldsProp = useMemo(() => fProp ?? [defaultField], [defaultField, fProp]);
 
   const fields = useMemo(() => {
     let f = Array.isArray(fieldsProp)
@@ -102,13 +110,13 @@ export const QueryBuilderWithoutDndProvider = <RG extends RuleGroupType | RuleGr
           .sort((a, b) => a.label.localeCompare(b.label));
     if (!autoSelectField) {
       if (isOptionGroupArray(f)) {
-        f = [{ label: translations.fields.placeholderGroupLabel, options: defaultFields }, ...f];
+        f = [{ label: translations.fields.placeholderGroupLabel, options: [defaultField] }, ...f];
       } else {
-        f = [...defaultFields, ...f];
+        f = [defaultField, ...f];
       }
     }
     return isOptionGroupArray(f) ? uniqOptGroups(f) : uniqByName(f);
-  }, [autoSelectField, defaultFields, fieldsProp, translations.fields.placeholderGroupLabel]);
+  }, [autoSelectField, defaultField, fieldsProp, translations.fields.placeholderGroupLabel]);
 
   const fieldMap = useMemo(() => {
     if (!Array.isArray(fieldsProp)) return fieldsProp;
@@ -128,8 +136,12 @@ export const QueryBuilderWithoutDndProvider = <RG extends RuleGroupType | RuleGr
   const disabledPaths = useMemo(() => (Array.isArray(disabled) && disabled) || [], [disabled]);
 
   const defaultOperator = useMemo(
-    (): NameLabelPair[] => [{ id: '~', name: '~', label: translations.operators.placeholderLabel }],
-    [translations.operators.placeholderLabel]
+    (): NameLabelPair => ({
+      id: placeholderOperatorName,
+      name: placeholderOperatorName,
+      label: translations.operators.placeholderLabel,
+    }),
+    [placeholderOperatorName, translations.operators.placeholderLabel]
   );
 
   const getOperatorsMain = useCallback(
@@ -148,15 +160,25 @@ export const QueryBuilderWithoutDndProvider = <RG extends RuleGroupType | RuleGr
 
       if (!autoSelectOperator) {
         if (isOptionGroupArray(opsFinal)) {
-          opsFinal = [{ label: translations.operators.placeholderGroupLabel, options: defaultOperator }, ...opsFinal]
+          opsFinal = [
+            { label: translations.operators.placeholderGroupLabel, options: [defaultOperator] },
+            ...opsFinal,
+          ];
         } else {
-          opsFinal = [...defaultOperator, ...opsFinal]
+          opsFinal = [defaultOperator, ...opsFinal];
         }
       }
 
       return isOptionGroupArray(opsFinal) ? uniqOptGroups(opsFinal) : uniqByName(opsFinal);
     },
-    [defaultOperator, fieldMap, getOperators, operators, translations.operators.placeholderGroupLabel]
+    [
+      autoSelectOperator,
+      defaultOperator,
+      fieldMap,
+      getOperators,
+      operators,
+      translations.operators.placeholderGroupLabel,
+    ]
   );
 
   const getRuleDefaultOperator = useCallback(
@@ -429,7 +451,9 @@ export const QueryBuilderWithoutDndProvider = <RG extends RuleGroupType | RuleGr
     showCloneButtons,
     showLockButtons,
     autoSelectField,
+    placeholderFieldName,
     autoSelectOperator,
+    placeholderOperatorName,
     addRuleToNewGroups,
     enableDragAndDrop,
     independentCombinators: !!independentCombinators,

--- a/packages/react-querybuilder/src/QueryBuilder.tsx
+++ b/packages/react-querybuilder/src/QueryBuilder.tsx
@@ -12,6 +12,7 @@ import {
 } from './defaults';
 import type {
   Field,
+  NameLabelPair,
   QueryBuilderProps,
   RuleGroupType,
   RuleGroupTypeIC,
@@ -428,6 +429,7 @@ export const QueryBuilderWithoutDndProvider = <RG extends RuleGroupType | RuleGr
     showCloneButtons,
     showLockButtons,
     autoSelectField,
+    autoSelectOperator,
     addRuleToNewGroups,
     enableDragAndDrop,
     independentCombinators: !!independentCombinators,

--- a/packages/react-querybuilder/src/Rule.tsx
+++ b/packages/react-querybuilder/src/Rule.tsx
@@ -38,6 +38,7 @@ export const Rule = ({
     onPropChange,
     onRuleRemove,
     autoSelectField,
+    autoSelectOperator,
     showCloneButtons,
     showLockButtons,
     independentCombinators,
@@ -201,7 +202,7 @@ export const Rule = ({
         context={context}
         validation={validationResult}
       />
-      {(autoSelectField || fieldData.name !== '~') && (
+      {(autoSelectField || field !== '~') && (
         <>
           <controls.operatorSelector
             testID={TestID.operators}
@@ -218,42 +219,46 @@ export const Rule = ({
             context={context}
             validation={validationResult}
           />
-          {!['null', 'notNull'].includes(operator) && valueSources.length > 1 && (
-            <controls.valueSourceSelector
-              testID={TestID.valueSourceSelector}
-              field={field}
-              fieldData={fieldData}
-              title={translations.valueSourceSelector.title}
-              options={vsOptions}
-              value={valueSource ?? 'value'}
-              className={c(standardClassnames.valueSource, classNames.valueSource)}
-              handleOnChange={generateOnChangeHandler('valueSource')}
-              level={level}
-              path={path}
-              disabled={disabled}
-              context={context}
-              validation={validationResult}
-            />
+          {(autoSelectOperator || operator !== '~') && (
+            <>
+              {!['null', 'notNull'].includes(operator) && valueSources.length > 1 && (
+                <controls.valueSourceSelector
+                  testID={TestID.valueSourceSelector}
+                  field={field}
+                  fieldData={fieldData}
+                  title={translations.valueSourceSelector.title}
+                  options={vsOptions}
+                  value={valueSource ?? 'value'}
+                  className={c(standardClassnames.valueSource, classNames.valueSource)}
+                  handleOnChange={generateOnChangeHandler('valueSource')}
+                  level={level}
+                  path={path}
+                  disabled={disabled}
+                  context={context}
+                  validation={validationResult}
+                />
+              )}
+              <controls.valueEditor
+                testID={TestID.valueEditor}
+                field={field}
+                fieldData={fieldData}
+                title={translations.value.title}
+                operator={operator}
+                value={value}
+                valueSource={valueSource ?? 'value'}
+                type={valueEditorType}
+                inputType={inputType}
+                values={values}
+                className={c(standardClassnames.value, classNames.value)}
+                handleOnChange={generateOnChangeHandler('value')}
+                level={level}
+                path={path}
+                disabled={disabled}
+                context={context}
+                validation={validationResult}
+              />
+            </>
           )}
-          <controls.valueEditor
-            testID={TestID.valueEditor}
-            field={field}
-            fieldData={fieldData}
-            title={translations.value.title}
-            operator={operator}
-            value={value}
-            valueSource={valueSource ?? 'value'}
-            type={valueEditorType}
-            inputType={inputType}
-            values={values}
-            className={c(standardClassnames.value, classNames.value)}
-            handleOnChange={generateOnChangeHandler('value')}
-            level={level}
-            path={path}
-            disabled={disabled}
-            context={context}
-            validation={validationResult}
-          />
         </>
       )}
       {showCloneButtons && (

--- a/packages/react-querybuilder/src/Rule.tsx
+++ b/packages/react-querybuilder/src/Rule.tsx
@@ -1,7 +1,7 @@
 import { MouseEvent as ReactMouseEvent, useRef } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import { DNDType, standardClassnames, TestID } from './defaults';
-import type { DraggedItem, Field, RuleProps, RuleType } from './types';
+import type { DraggedItem, RuleProps, RuleType } from './types';
 import {
   c,
   filterFieldsByComparator,
@@ -38,7 +38,9 @@ export const Rule = ({
     onPropChange,
     onRuleRemove,
     autoSelectField,
+    placeholderFieldName,
     autoSelectOperator,
+    placeholderOperatorName,
     showCloneButtons,
     showLockButtons,
     independentCombinators,
@@ -129,9 +131,9 @@ export const Rule = ({
     }
   };
 
-  const fieldData = fieldMap?.[field] ?? ({} as Field);
+  const fieldData = fieldMap?.[field] ?? { name: field, label: field };
   const inputType = fieldData.inputType ?? getInputType(field, operator);
-  const operators = fieldData.operators ?? getOperators(field);
+  const operators = getOperators(field);
   const valueSources =
     typeof fieldData.valueSources === 'function'
       ? fieldData.valueSources(operator)
@@ -202,7 +204,7 @@ export const Rule = ({
         context={context}
         validation={validationResult}
       />
-      {(autoSelectField || field !== '~') && (
+      {(autoSelectField || field !== placeholderFieldName) && (
         <>
           <controls.operatorSelector
             testID={TestID.operators}
@@ -219,7 +221,7 @@ export const Rule = ({
             context={context}
             validation={validationResult}
           />
-          {(autoSelectOperator || operator !== '~') && (
+          {(autoSelectOperator || operator !== placeholderOperatorName) && (
             <>
               {!['null', 'notNull'].includes(operator) && valueSources.length > 1 && (
                 <controls.valueSourceSelector

--- a/packages/react-querybuilder/src/defaults.ts
+++ b/packages/react-querybuilder/src/defaults.ts
@@ -9,9 +9,12 @@ import type {
   TranslationsFull,
 } from './types';
 
+const placeholderName = '~';
 const placeholderLabel = '------';
+export const defaultPlaceholderFieldName = placeholderName;
 export const defaultPlaceholderFieldLabel = placeholderLabel;
 export const defaultPlaceholderFieldGroupLabel = placeholderLabel;
+export const defaultPlaceholderOperatorName = placeholderName;
 export const defaultPlaceholderOperatorLabel = placeholderLabel;
 export const defaultPlaceholderOperatorGroupLabel = placeholderLabel;
 

--- a/packages/react-querybuilder/src/defaults.ts
+++ b/packages/react-querybuilder/src/defaults.ts
@@ -9,8 +9,11 @@ import type {
   TranslationsFull,
 } from './types';
 
-export const defaultPlaceholderFieldLabel = '------';
-export const defaultPlaceholderFieldGroupLabel = defaultPlaceholderFieldLabel;
+const placeholderLabel = '------';
+export const defaultPlaceholderFieldLabel = placeholderLabel;
+export const defaultPlaceholderFieldGroupLabel = placeholderLabel;
+export const defaultPlaceholderOperatorLabel = placeholderLabel;
+export const defaultPlaceholderOperatorGroupLabel = placeholderLabel;
 
 export const defaultTranslations: TranslationsFull = {
   fields: {
@@ -20,6 +23,8 @@ export const defaultTranslations: TranslationsFull = {
   },
   operators: {
     title: 'Operators',
+    placeholderLabel: defaultPlaceholderOperatorLabel,
+    placeholderGroupLabel: defaultPlaceholderOperatorGroupLabel,
   },
   value: {
     title: 'Value',

--- a/packages/react-querybuilder/src/types/basic.ts
+++ b/packages/react-querybuilder/src/types/basic.ts
@@ -27,7 +27,7 @@ export type OptionGroup<O extends NameLabelPair = NameLabelPair> = {
 
 export interface Field extends NameLabelPair {
   id?: string;
-  operators?: NameLabelPair[];
+  operators?: NameLabelPair[] | OptionGroup[];
   valueEditorType?: ValueEditorType | ((operator: string) => ValueEditorType);
   valueSources?: ValueSources | ((operator: string) => ValueSources);
   inputType?: string | null;

--- a/packages/react-querybuilder/src/types/importExport.ts
+++ b/packages/react-querybuilder/src/types/importExport.ts
@@ -57,6 +57,18 @@ export interface FormatQueryOptions {
    * numeric value.
    */
   parseNumbers?: boolean;
+  /**
+   * Any rules where the field is equal to this value will be ignored.
+   *
+   * @default '~'
+   */
+  placeholderFieldName?: string;
+  /**
+   * Any rules where the operator is equal to this value will be ignored.
+   *
+   * @default '~'
+   */
+  placeholderOperatorName?: string;
 }
 
 export type ValueProcessorOptions = Pick<FormatQueryOptions, 'parseNumbers'>;

--- a/packages/react-querybuilder/src/types/props.ts
+++ b/packages/react-querybuilder/src/types/props.ts
@@ -254,7 +254,9 @@ export interface Schema {
   showCloneButtons: boolean;
   showLockButtons: boolean;
   autoSelectField: boolean;
+  placeholderFieldName: string;
   autoSelectOperator: boolean;
+  placeholderOperatorName: string;
   addRuleToNewGroups: boolean;
   enableDragAndDrop: boolean;
   validationMap: ValidationMap;
@@ -483,9 +485,17 @@ export type QueryBuilderProps<RG extends RuleGroupType | RuleGroupTypeIC = RuleG
      */
     autoSelectField?: boolean;
     /**
+     * Value for the placeholder option if autoSelectField is false
+     */
+    placeholderFieldName?: string;
+    /**
      * Select the first operator in the array automatically
      */
-     autoSelectOperator?: boolean;
+    autoSelectOperator?: boolean;
+    /**
+     * Value for the placeholder option if autoSelectOperator is false
+     */
+    placeholderOperatorName?: string;
     /**
      * Adds a new default rule automatically to each new group
      */

--- a/packages/react-querybuilder/src/types/props.ts
+++ b/packages/react-querybuilder/src/types/props.ts
@@ -254,6 +254,7 @@ export interface Schema {
   showCloneButtons: boolean;
   showLockButtons: boolean;
   autoSelectField: boolean;
+  autoSelectOperator: boolean;
   addRuleToNewGroups: boolean;
   enableDragAndDrop: boolean;
   validationMap: ValidationMap;
@@ -273,7 +274,7 @@ interface TranslationWithPlaceholders extends Translation {
 }
 export interface Translations {
   fields: TranslationWithPlaceholders;
-  operators: Translation;
+  operators: TranslationWithPlaceholders;
   value: Translation;
   removeRule: TranslationWithLabel;
   removeGroup: TranslationWithLabel;
@@ -481,6 +482,10 @@ export type QueryBuilderProps<RG extends RuleGroupType | RuleGroupTypeIC = RuleG
      * Select the first field in the array automatically
      */
     autoSelectField?: boolean;
+    /**
+     * Select the first operator in the array automatically
+     */
+     autoSelectOperator?: boolean;
     /**
      * Adds a new default rule automatically to each new group
      */

--- a/packages/react-querybuilder/src/utils/formatQuery.test.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery.test.ts
@@ -1,3 +1,4 @@
+import { defaultPlaceholderFieldName, defaultPlaceholderOperatorName } from '../defaults';
 import type { RuleGroupType, ValueProcessor } from '../types';
 import { convertToIC } from './convertQuery';
 import {
@@ -11,6 +12,21 @@ import { add } from './queryTools';
 const query: RuleGroupType = {
   id: 'g-root',
   rules: [
+    {
+      field: defaultPlaceholderFieldName,
+      operator: defaultPlaceholderOperatorName,
+      value: 'Placeholder',
+    },
+    {
+      field: defaultPlaceholderFieldName,
+      operator: '=',
+      value: 'Placeholder',
+    },
+    {
+      field: 'firstName',
+      operator: defaultPlaceholderOperatorName,
+      value: 'Placeholder',
+    },
     {
       field: 'firstName',
       value: '',
@@ -143,6 +159,21 @@ const mongoQuery: RuleGroupType = {
   id: 'g-root',
   combinator: 'and',
   rules: [
+    {
+      field: '~',
+      operator: '~',
+      value: 'Placeholder',
+    },
+    {
+      field: '~',
+      operator: '=',
+      value: 'Placeholder',
+    },
+    {
+      field: 'firstName',
+      operator: '~',
+      value: 'Placeholder',
+    },
     {
       field: 'invalid',
       value: '',
@@ -1398,5 +1429,30 @@ describe('parseNumbers', () => {
     expect(formatQuery(queryForNumberParsing, { format: 'cel', parseNumbers: true })).toBe(
       'f == "NaN" && f == 0 && f == 0 && f == 0 && (f == 1.5 || f == 1.5) && f in [0, 1, 2] && f in [0, 1, 2] && f in [0, "abc", 2] && (f >= 0 && f <= 1) && (f >= 0 && f <= "abc") && (f >= "[object Object]" && f <= "[object Object]")'
     );
+  });
+});
+
+describe('placeholder names', () => {
+  const placeholderFieldName = 'placeholderFieldName';
+  const placeholderOperatorName = 'placeholderOperatorName';
+
+  const queryForPlaceholders: RuleGroupType = {
+    combinator: 'and',
+    rules: [
+      { field: defaultPlaceholderFieldName, operator: defaultPlaceholderOperatorName, value: 'v1' },
+      { field: placeholderFieldName, operator: '=', value: 'v2' },
+      { field: 'f3', operator: placeholderOperatorName, value: 'v3' },
+      { field: placeholderFieldName, operator: placeholderOperatorName, value: 'v4' },
+    ],
+  };
+
+  it('respects custom placeholder names', () => {
+    expect(
+      formatQuery(queryForPlaceholders, {
+        format: 'sql',
+        placeholderFieldName,
+        placeholderOperatorName,
+      })
+    ).toBe(`(${defaultPlaceholderFieldName} ${defaultPlaceholderOperatorName} 'v1')`);
   });
 });


### PR DESCRIPTION
The `autoSelectOperator` prop should default to `true` like [`autoSelectField`](https://react-querybuilder.js.org/docs/api/querybuilder#autoselectfield). When false, the operators list should begin with `{ name: '~', label: translations.operators.placeholderLabel }` and the value editor should be hidden when the operator is `'~'`.

Fixes #305.