### PR TITLE
Add XOR support to parseSQL

### DIFF
--- a/packages/react-querybuilder/src/Rule.test.tsx
+++ b/packages/react-querybuilder/src/Rule.test.tsx
@@ -6,6 +6,7 @@ import type {
 } from '@react-querybuilder/ts';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { clsx } from 'clsx';
 import { getFieldMapFromArray, getRuleProps as getProps, ruleClassnames } from '../genericTests';
 import { defaultTranslations as t, standardClassnames as sc, TestID } from './defaults';
 import { errorDeprecatedRuleProps, errorEnabledDndWithoutReactDnD } from './messages';
@@ -22,7 +23,7 @@ afterEach(() => {
 
 it('should have correct classNames', () => {
   render(<Rule {...getProps()} />);
-  expect(screen.getByTestId(TestID.rule)).toHaveClass(sc.rule, ruleClassnames.rule!);
+  expect(screen.getByTestId(TestID.rule)).toHaveClass(sc.rule, clsx(ruleClassnames.rule));
 });
 
 describe('onElementChanged methods', () => {

--- a/packages/react-querybuilder/src/defaults.ts
+++ b/packages/react-querybuilder/src/defaults.ts
@@ -1,6 +1,7 @@
 import type {
   Classnames,
   DefaultCombinator,
+  DefaultCombinatorExtended,
   DefaultOperator,
   DefaultOperatorName,
   TranslationsFull,
@@ -134,6 +135,11 @@ export const defaultOperatorNegationMap: Record<DefaultOperatorName, DefaultOper
 export const defaultCombinators: DefaultCombinator[] = [
   { name: 'and', label: 'AND' },
   { name: 'or', label: 'OR' },
+];
+
+export const defaultCombinatorsExtended: DefaultCombinatorExtended[] = [
+  ...defaultCombinators,
+  { name: 'xor', label: 'XOR' },
 ];
 
 export const standardClassnames = {

--- a/packages/react-querybuilder/src/utils/parseSQL/parseSQL.test.ts
+++ b/packages/react-querybuilder/src/utils/parseSQL/parseSQL.test.ts
@@ -211,6 +211,22 @@ describe('options', () => {
         { field: 'middleName', operator: 'null', value: null },
       ],
     });
+    expect(
+      parseSQL(
+        `firstName = 'Steve' AND lastName = 'Vai' XOR age = 26 OR middleName IS NULL`,
+        icOpts
+      )
+    ).toEqual({
+      rules: [
+        { field: 'firstName', operator: '=', value: 'Steve' },
+        'and',
+        { field: 'lastName', operator: '=', value: 'Vai' },
+        'xor',
+        { field: 'age', operator: '=', value: 26 },
+        'or',
+        { field: 'middleName', operator: 'null', value: null },
+      ],
+    });
   });
 
   describe('fields and getValueSources', () => {
@@ -483,7 +499,7 @@ describe('options', () => {
   });
 });
 
-describe('AND/OR expressions', () => {
+describe('AND/OR/XOR expressions', () => {
   it('AND', () => {
     expect(parseSQL(`firstName = 'Steve' AND lastName = 'Vai' AND middleName IS NULL`)).toEqual({
       combinator: 'and',
@@ -513,6 +529,47 @@ describe('AND/OR expressions', () => {
         { field: 'firstName', operator: '=', value: 'Steve' },
         { field: 'lastName', operator: '=', value: 'Vai' },
         { field: 'middleName', operator: 'null', value: null },
+      ],
+    });
+  });
+
+  it('order of precedence is AND -> XOR -> OR', () => {
+    expect(parseSQL(`f1 = 'v1' AND f2 = 'v2' XOR f3 = 'v3' OR f4 = 'v4'`)).toEqual({
+      combinator: 'or',
+      rules: [
+        {
+          combinator: 'xor',
+          rules: [
+            {
+              combinator: 'and',
+              rules: [
+                { field: 'f1', operator: '=', value: 'v1' },
+                { field: 'f2', operator: '=', value: 'v2' },
+              ],
+            },
+            { field: 'f3', operator: '=', value: 'v3' },
+          ],
+        },
+        { field: 'f4', operator: '=', value: 'v4' },
+      ],
+    });
+    expect(parseSQL(`f1 = 'v1' OR f2 = 'v2' XOR f3 = 'v3' AND f4 = 'v4'`)).toEqual({
+      combinator: 'or',
+      rules: [
+        { field: 'f1', operator: '=', value: 'v1' },
+        {
+          combinator: 'xor',
+          rules: [
+            { field: 'f2', operator: '=', value: 'v2' },
+            {
+              combinator: 'and',
+              rules: [
+                { field: 'f3', operator: '=', value: 'v3' },
+                { field: 'f4', operator: '=', value: 'v4' },
+              ],
+            },
+          ],
+        },
       ],
     });
   });

--- a/packages/react-querybuilder/src/utils/parseSQL/parseSQL.test.ts
+++ b/packages/react-querybuilder/src/utils/parseSQL/parseSQL.test.ts
@@ -506,6 +506,17 @@ describe('AND/OR expressions', () => {
     });
   });
 
+  it('XOR', () => {
+    expect(parseSQL(`firstName = 'Steve' XOR lastName = 'Vai' XOR middleName IS NULL`)).toEqual({
+      combinator: 'xor',
+      rules: [
+        { field: 'firstName', operator: '=', value: 'Steve' },
+        { field: 'lastName', operator: '=', value: 'Vai' },
+        { field: 'middleName', operator: 'null', value: null },
+      ],
+    });
+  });
+
   it('mixed AND/OR', () => {
     expect(parseSQL(`firstName = 'Steve' AND lastName = 'Vai' OR middleName IS NULL`)).toEqual({
       combinator: 'or',

--- a/packages/react-querybuilder/src/utils/parseSQL/sql.jison
+++ b/packages/react-querybuilder/src/utils/parseSQL/sql.jison
@@ -429,7 +429,7 @@ expr
   | NOT expr -> { type: 'NotExpression', value: $2 }
   | expr OR expr -> { type: 'OrExpression', operator: $2, left: $1, right: $3 }
   | expr AND expr -> { type: 'AndExpression', operator: $2, left: $1, right: $3 }
-  | expr XOR expr -> { type: 'XORExpression', left: $1, right: $3 }
+  | expr XOR expr -> { type: 'XorExpression', operator: $2, left: $1, right: $3 }
   ;
 expr_list
   : expr -> { type: 'ExpressionList', value: [ $1 ] }

--- a/packages/react-querybuilder/src/utils/parseSQL/sqlParser.js
+++ b/packages/react-querybuilder/src/utils/parseSQL/sqlParser.js
@@ -311,7 +311,7 @@ case 136:
 this.$ = { type: 'AndExpression', operator: $$[$0-1], left: $$[$0-2], right: $$[$0] };
 break;
 case 137:
-this.$ = { type: 'XORExpression', left: $$[$0-2], right: $$[$0] };
+this.$ = { type: 'XorExpression', operator: $$[$0-1], left: $$[$0-2], right: $$[$0] };
 break;
 case 138:
 this.$ = { type: 'ExpressionList', value: [ $$[$0] ] };

--- a/packages/react-querybuilder/src/utils/parseSQL/types.ts
+++ b/packages/react-querybuilder/src/utils/parseSQL/types.ts
@@ -1,3 +1,5 @@
+import type { DefaultCombinatorNameExtended } from '@react-querybuilder/ts';
+
 type AnyCase<T extends string> = string extends T
   ? string
   : T extends `${infer F1}${infer F2}${infer R}`
@@ -269,3 +271,9 @@ export interface ParsedSQL {
   };
   hasSemicolon: boolean;
 }
+
+export type MaybeWithCombinator = { combinator?: DefaultCombinatorNameExtended };
+export type AndList = SQLExpression[] & MaybeWithCombinator;
+export type MixedAndXorList = (SQLExpression | AndList)[] & MaybeWithCombinator;
+export type MixedAndXorOrList = (SQLExpression | MixedAndXorList | AndList)[] & MaybeWithCombinator;
+export type GenerateMixedAndXorOrListReturn = MixedAndXorOrList & MaybeWithCombinator;

--- a/packages/react-querybuilder/src/utils/parseSQL/types.ts
+++ b/packages/react-querybuilder/src/utils/parseSQL/types.ts
@@ -272,8 +272,7 @@ export interface ParsedSQL {
   hasSemicolon: boolean;
 }
 
-export type MaybeWithCombinator = { combinator?: DefaultCombinatorNameExtended };
-export type AndList = SQLExpression[] & MaybeWithCombinator;
-export type MixedAndXorList = (SQLExpression | AndList)[] & MaybeWithCombinator;
-export type MixedAndXorOrList = (SQLExpression | MixedAndXorList | AndList)[] & MaybeWithCombinator;
-export type GenerateMixedAndXorOrListReturn = MixedAndXorOrList & MaybeWithCombinator;
+export type GenerateMixedAndXorOrListReturn = {
+  combinator: DefaultCombinatorNameExtended;
+  expressions: (GenerateMixedAndXorOrListReturn | SQLExpression)[];
+};

--- a/packages/react-querybuilder/src/utils/parseSQL/types.ts
+++ b/packages/react-querybuilder/src/utils/parseSQL/types.ts
@@ -272,7 +272,7 @@ export interface ParsedSQL {
   hasSemicolon: boolean;
 }
 
-export type GenerateMixedAndXorOrListReturn = {
+export type MixedAndXorOrList = {
   combinator: DefaultCombinatorNameExtended;
-  expressions: (GenerateMixedAndXorOrListReturn | SQLExpression)[];
+  expressions: (MixedAndXorOrList | SQLExpression)[];
 };

--- a/packages/react-querybuilder/src/utils/parseSQL/types.ts
+++ b/packages/react-querybuilder/src/utils/parseSQL/types.ts
@@ -65,12 +65,13 @@ type TokenType =
   | 'UseIndexHint'
   | 'UsingJoinCondition'
   | 'WhenThenList'
-  | 'XORExpression';
+  | 'XorExpression';
 
 export type ComparisonOperator = '=' | '>=' | '>' | '<=' | '<' | '<>' | '!=';
 export type NotOpt = AnyCase<'NOT'> | null;
 export type AndOperator = AnyCase<'AND'>;
 export type OrOperator = AnyCase<'OR'>;
+export type XorOperator = AnyCase<'XOR'>;
 
 export interface SQLWhereObject {
   type: TokenType;
@@ -170,11 +171,14 @@ export interface SQLOrExpression extends SQLWhereObject {
   left: SQLExpression;
   right: SQLExpression;
 }
+export interface SQLXorExpression extends SQLWhereObject {
+  type: 'XorExpression';
+  operator: XorOperator;
+  left: SQLExpression;
+  right: SQLExpression;
+}
 
 // Interfaces that might show up but will be ignored
-export interface SQLXORExpression extends SQLWhereObjectAny {
-  type: 'XORExpression';
-}
 export interface SQLFunctionCall extends SQLWhereObjectAny {
   type: 'FunctionCall';
 }
@@ -237,7 +241,7 @@ export type SQLExpression =
   | SQLNotExpression
   | SQLAndExpression
   | SQLOrExpression
-  | SQLXORExpression;
+  | SQLXorExpression;
 
 export interface ParsedSQL {
   nodeType: 'Main';

--- a/packages/react-querybuilder/src/utils/parseSQL/utils.test.ts
+++ b/packages/react-querybuilder/src/utils/parseSQL/utils.test.ts
@@ -1,0 +1,147 @@
+import type { AndList, GenerateMixedAndXorOrListReturn, SQLExpression } from './types';
+import { generateMixedAndXorOrList } from './utils';
+
+const isNullExpr: SQLExpression = {
+  type: 'IsNullBooleanPrimary',
+  value: { type: 'Identifier', value: 'f1' },
+  hasNot: null,
+};
+const isNotNullExpr: SQLExpression = {
+  type: 'IsNullBooleanPrimary',
+  value: { type: 'Identifier', value: 'f1' },
+  hasNot: 'NOT',
+};
+
+it('simple AND operator', () => {
+  const expectation: GenerateMixedAndXorOrListReturn = [isNullExpr, isNullExpr];
+  expectation.combinator = 'and';
+  expect(
+    generateMixedAndXorOrList({
+      type: 'AndExpression',
+      operator: 'AND',
+      left: isNullExpr,
+      right: isNullExpr,
+    })
+  ).toEqual(expectation);
+});
+
+it('simple XOR operator', () => {
+  const expectation: GenerateMixedAndXorOrListReturn = [isNullExpr, isNullExpr];
+  expectation.combinator = 'xor';
+  expect(
+    generateMixedAndXorOrList({
+      type: 'XorExpression',
+      operator: 'XOR',
+      left: isNullExpr,
+      right: isNullExpr,
+    })
+  ).toEqual(expectation);
+});
+
+it('simple OR operator', () => {
+  const expectation: GenerateMixedAndXorOrListReturn = [isNullExpr, isNullExpr];
+  expectation.combinator = 'or';
+  expect(
+    generateMixedAndXorOrList({
+      type: 'OrExpression',
+      operator: 'OR',
+      left: isNullExpr,
+      right: isNullExpr,
+    })
+  ).toEqual(expectation);
+});
+
+it('chained AND operators', () => {
+  const expectation: GenerateMixedAndXorOrListReturn = [isNullExpr, isNullExpr, isNullExpr];
+  expectation.combinator = 'and';
+  expect(
+    generateMixedAndXorOrList({
+      type: 'AndExpression',
+      operator: 'AND',
+      left: {
+        type: 'AndExpression',
+        operator: 'AND',
+        left: isNullExpr,
+        right: isNullExpr,
+      },
+      right: isNullExpr,
+    })
+  ).toEqual(expectation);
+});
+
+it('chained XOR operators', () => {
+  const expectation: GenerateMixedAndXorOrListReturn = [isNullExpr, isNullExpr, isNullExpr];
+  expectation.combinator = 'xor';
+  expect(
+    generateMixedAndXorOrList({
+      type: 'XorExpression',
+      operator: 'XOR',
+      left: {
+        type: 'XorExpression',
+        operator: 'XOR',
+        left: isNullExpr,
+        right: isNullExpr,
+      },
+      right: isNullExpr,
+    })
+  ).toEqual(expectation);
+});
+
+it('chained OR operators', () => {
+  const expectation: GenerateMixedAndXorOrListReturn = [isNullExpr, isNullExpr, isNullExpr];
+  expectation.combinator = 'or';
+  expect(
+    generateMixedAndXorOrList({
+      type: 'OrExpression',
+      operator: 'OR',
+      left: {
+        type: 'OrExpression',
+        operator: 'OR',
+        left: isNullExpr,
+        right: isNullExpr,
+      },
+      right: isNullExpr,
+    })
+  ).toEqual(expectation);
+});
+
+describe('complex AND/XOR/OR chains', () => {
+  it('a AND b OR c', () => {
+    const expectation: GenerateMixedAndXorOrListReturn = [[isNullExpr, isNullExpr], isNotNullExpr];
+    (expectation[0] as AndList).combinator = 'and';
+    expectation.combinator = 'or';
+    const testResult = generateMixedAndXorOrList({
+      type: 'OrExpression',
+      operator: 'OR',
+      left: {
+        type: 'AndExpression',
+        operator: 'AND',
+        left: isNullExpr,
+        right: isNullExpr,
+      },
+      right: isNotNullExpr,
+    });
+    expect(testResult).toEqual(expectation);
+  });
+
+  it('a OR b AND c', () => {
+    const expectation: GenerateMixedAndXorOrListReturn = [
+      isNotNullExpr,
+      [isNullExpr, isNotNullExpr],
+    ];
+    (expectation[1] as AndList).combinator = 'and';
+    expectation.combinator = 'or';
+    const testResult = generateMixedAndXorOrList({
+      type: 'AndExpression',
+      operator: 'AND',
+      left: {
+        type: 'OrExpression',
+        operator: 'OR',
+        left: isNotNullExpr,
+        right: isNullExpr,
+      },
+      right: isNotNullExpr,
+    });
+    expect(testResult).toEqual(expectation);
+  });
+});

--- a/packages/react-querybuilder/src/utils/parseSQL/utils.test.ts
+++ b/packages/react-querybuilder/src/utils/parseSQL/utils.test.ts
@@ -1,4 +1,4 @@
-import type { AndList, GenerateMixedAndXorOrListReturn, SQLExpression } from './types';
+import type { GenerateMixedAndXorOrListReturn, SQLExpression } from './types';
 import { generateMixedAndXorOrList } from './utils';
 
 const isNullExpr: SQLExpression = {
@@ -11,10 +11,22 @@ const isNotNullExpr: SQLExpression = {
   value: { type: 'Identifier', value: 'f1' },
   hasNot: 'NOT',
 };
+const isNullExpr2: SQLExpression = {
+  type: 'IsNullBooleanPrimary',
+  value: { type: 'Identifier', value: 'f2' },
+  hasNot: null,
+};
+const isNotNullExpr2: SQLExpression = {
+  type: 'IsNullBooleanPrimary',
+  value: { type: 'Identifier', value: 'f2' },
+  hasNot: 'NOT',
+};
 
 it('simple AND operator', () => {
-  const expectation: GenerateMixedAndXorOrListReturn = [isNullExpr, isNullExpr];
-  expectation.combinator = 'and';
+  const expectation: GenerateMixedAndXorOrListReturn = {
+    combinator: 'and',
+    expressions: [isNullExpr, isNullExpr],
+  };
   expect(
     generateMixedAndXorOrList({
       type: 'AndExpression',
@@ -26,8 +38,10 @@ it('simple AND operator', () => {
 });
 
 it('simple XOR operator', () => {
-  const expectation: GenerateMixedAndXorOrListReturn = [isNullExpr, isNullExpr];
-  expectation.combinator = 'xor';
+  const expectation: GenerateMixedAndXorOrListReturn = {
+    combinator: 'xor',
+    expressions: [isNullExpr, isNullExpr],
+  };
   expect(
     generateMixedAndXorOrList({
       type: 'XorExpression',
@@ -39,8 +53,10 @@ it('simple XOR operator', () => {
 });
 
 it('simple OR operator', () => {
-  const expectation: GenerateMixedAndXorOrListReturn = [isNullExpr, isNullExpr];
-  expectation.combinator = 'or';
+  const expectation: GenerateMixedAndXorOrListReturn = {
+    combinator: 'or',
+    expressions: [isNullExpr, isNullExpr],
+  };
   expect(
     generateMixedAndXorOrList({
       type: 'OrExpression',
@@ -52,8 +68,10 @@ it('simple OR operator', () => {
 });
 
 it('chained AND operators', () => {
-  const expectation: GenerateMixedAndXorOrListReturn = [isNullExpr, isNullExpr, isNullExpr];
-  expectation.combinator = 'and';
+  const expectation: GenerateMixedAndXorOrListReturn = {
+    combinator: 'and',
+    expressions: [isNullExpr, isNullExpr, isNullExpr, isNullExpr],
+  };
   expect(
     generateMixedAndXorOrList({
       type: 'AndExpression',
@@ -61,7 +79,12 @@ it('chained AND operators', () => {
       left: {
         type: 'AndExpression',
         operator: 'AND',
-        left: isNullExpr,
+        left: {
+          type: 'AndExpression',
+          operator: 'AND',
+          left: isNullExpr,
+          right: isNullExpr,
+        },
         right: isNullExpr,
       },
       right: isNullExpr,
@@ -70,8 +93,10 @@ it('chained AND operators', () => {
 });
 
 it('chained XOR operators', () => {
-  const expectation: GenerateMixedAndXorOrListReturn = [isNullExpr, isNullExpr, isNullExpr];
-  expectation.combinator = 'xor';
+  const expectation: GenerateMixedAndXorOrListReturn = {
+    combinator: 'xor',
+    expressions: [isNullExpr, isNullExpr, isNullExpr, isNullExpr],
+  };
   expect(
     generateMixedAndXorOrList({
       type: 'XorExpression',
@@ -79,7 +104,12 @@ it('chained XOR operators', () => {
       left: {
         type: 'XorExpression',
         operator: 'XOR',
-        left: isNullExpr,
+        left: {
+          type: 'XorExpression',
+          operator: 'XOR',
+          left: isNullExpr,
+          right: isNullExpr,
+        },
         right: isNullExpr,
       },
       right: isNullExpr,
@@ -88,8 +118,10 @@ it('chained XOR operators', () => {
 });
 
 it('chained OR operators', () => {
-  const expectation: GenerateMixedAndXorOrListReturn = [isNullExpr, isNullExpr, isNullExpr];
-  expectation.combinator = 'or';
+  const expectation: GenerateMixedAndXorOrListReturn = {
+    combinator: 'or',
+    expressions: [isNullExpr, isNullExpr, isNullExpr, isNullExpr],
+  };
   expect(
     generateMixedAndXorOrList({
       type: 'OrExpression',
@@ -97,7 +129,12 @@ it('chained OR operators', () => {
       left: {
         type: 'OrExpression',
         operator: 'OR',
-        left: isNullExpr,
+        left: {
+          type: 'OrExpression',
+          operator: 'OR',
+          left: isNullExpr,
+          right: isNullExpr,
+        },
         right: isNullExpr,
       },
       right: isNullExpr,
@@ -107,9 +144,10 @@ it('chained OR operators', () => {
 
 describe('complex AND/XOR/OR chains', () => {
   it('a AND b OR c', () => {
-    const expectation: GenerateMixedAndXorOrListReturn = [[isNullExpr, isNullExpr], isNotNullExpr];
-    (expectation[0] as AndList).combinator = 'and';
-    expectation.combinator = 'or';
+    const expectation: GenerateMixedAndXorOrListReturn = {
+      combinator: 'or',
+      expressions: [{ combinator: 'and', expressions: [isNullExpr, isNullExpr] }, isNotNullExpr],
+    };
     const testResult = generateMixedAndXorOrList({
       type: 'OrExpression',
       operator: 'OR',
@@ -125,12 +163,10 @@ describe('complex AND/XOR/OR chains', () => {
   });
 
   it('a OR b AND c', () => {
-    const expectation: GenerateMixedAndXorOrListReturn = [
-      isNotNullExpr,
-      [isNullExpr, isNotNullExpr],
-    ];
-    (expectation[1] as AndList).combinator = 'and';
-    expectation.combinator = 'or';
+    const expectation: GenerateMixedAndXorOrListReturn = {
+      combinator: 'or',
+      expressions: [isNotNullExpr, { combinator: 'and', expressions: [isNullExpr, isNotNullExpr] }],
+    };
     const testResult = generateMixedAndXorOrList({
       type: 'AndExpression',
       operator: 'AND',
@@ -141,6 +177,104 @@ describe('complex AND/XOR/OR chains', () => {
         right: isNullExpr,
       },
       right: isNotNullExpr,
+    });
+    expect(testResult).toEqual(expectation);
+  });
+
+  it('a AND b XOR c OR d', () => {
+    const expectation: GenerateMixedAndXorOrListReturn = {
+      combinator: 'or',
+      expressions: [
+        {
+          combinator: 'xor',
+          expressions: [
+            { combinator: 'and', expressions: [isNullExpr, isNotNullExpr] },
+            isNullExpr,
+          ],
+        },
+        isNotNullExpr,
+      ],
+    };
+    expect(
+      generateMixedAndXorOrList({
+        type: 'OrExpression',
+        operator: 'OR',
+        left: {
+          type: 'XorExpression',
+          operator: 'XOR',
+          left: {
+            type: 'AndExpression',
+            operator: 'AND',
+            left: isNullExpr,
+            right: isNotNullExpr,
+          },
+          right: isNullExpr,
+        },
+        right: isNotNullExpr,
+      })
+    ).toEqual(expectation);
+  });
+
+  it('a OR b XOR c AND d', () => {
+    const expectation: GenerateMixedAndXorOrListReturn = {
+      combinator: 'or',
+      expressions: [
+        isNotNullExpr,
+        {
+          combinator: 'xor',
+          expressions: [
+            isNullExpr,
+            { combinator: 'and', expressions: [isNotNullExpr, isNullExpr] },
+          ],
+        },
+      ],
+    };
+    expect(
+      generateMixedAndXorOrList({
+        type: 'AndExpression',
+        operator: 'AND',
+        left: {
+          type: 'XorExpression',
+          operator: 'XOR',
+          left: {
+            type: 'OrExpression',
+            operator: 'OR',
+            left: isNotNullExpr,
+            right: isNullExpr,
+          },
+          right: isNotNullExpr,
+        },
+        right: isNullExpr,
+      })
+    ).toEqual(expectation);
+  });
+
+  it('a AND b OR c XOR d', () => {
+    const expectation: GenerateMixedAndXorOrListReturn = {
+      combinator: 'or',
+      expressions: [
+        { combinator: 'and', expressions: [isNullExpr, isNotNullExpr] },
+        {
+          combinator: 'xor',
+          expressions: [isNullExpr2, isNotNullExpr2],
+        },
+      ],
+    };
+    const testResult = generateMixedAndXorOrList({
+      type: 'XorExpression',
+      operator: 'XOR',
+      left: {
+        type: 'OrExpression',
+        operator: 'OR',
+        left: {
+          type: 'AndExpression',
+          operator: 'AND',
+          left: isNullExpr,
+          right: isNotNullExpr,
+        },
+        right: isNullExpr2,
+      },
+      right: isNotNullExpr2,
     });
     expect(testResult).toEqual(expectation);
   });

--- a/packages/react-querybuilder/src/utils/parseSQL/utils.test.ts
+++ b/packages/react-querybuilder/src/utils/parseSQL/utils.test.ts
@@ -1,4 +1,4 @@
-import type { GenerateMixedAndXorOrListReturn, SQLExpression } from './types';
+import type { MixedAndXorOrList, SQLExpression } from './types';
 import { generateMixedAndXorOrList } from './utils';
 
 const isNullExpr: SQLExpression = {
@@ -23,7 +23,7 @@ const isNotNullExpr2: SQLExpression = {
 };
 
 it('simple AND operator', () => {
-  const expectation: GenerateMixedAndXorOrListReturn = {
+  const expectation: MixedAndXorOrList = {
     combinator: 'and',
     expressions: [isNullExpr, isNullExpr],
   };
@@ -38,7 +38,7 @@ it('simple AND operator', () => {
 });
 
 it('simple XOR operator', () => {
-  const expectation: GenerateMixedAndXorOrListReturn = {
+  const expectation: MixedAndXorOrList = {
     combinator: 'xor',
     expressions: [isNullExpr, isNullExpr],
   };
@@ -53,7 +53,7 @@ it('simple XOR operator', () => {
 });
 
 it('simple OR operator', () => {
-  const expectation: GenerateMixedAndXorOrListReturn = {
+  const expectation: MixedAndXorOrList = {
     combinator: 'or',
     expressions: [isNullExpr, isNullExpr],
   };
@@ -68,7 +68,7 @@ it('simple OR operator', () => {
 });
 
 it('chained AND operators', () => {
-  const expectation: GenerateMixedAndXorOrListReturn = {
+  const expectation: MixedAndXorOrList = {
     combinator: 'and',
     expressions: [isNullExpr, isNullExpr, isNullExpr, isNullExpr],
   };
@@ -93,7 +93,7 @@ it('chained AND operators', () => {
 });
 
 it('chained XOR operators', () => {
-  const expectation: GenerateMixedAndXorOrListReturn = {
+  const expectation: MixedAndXorOrList = {
     combinator: 'xor',
     expressions: [isNullExpr, isNullExpr, isNullExpr, isNullExpr],
   };
@@ -118,7 +118,7 @@ it('chained XOR operators', () => {
 });
 
 it('chained OR operators', () => {
-  const expectation: GenerateMixedAndXorOrListReturn = {
+  const expectation: MixedAndXorOrList = {
     combinator: 'or',
     expressions: [isNullExpr, isNullExpr, isNullExpr, isNullExpr],
   };
@@ -144,7 +144,7 @@ it('chained OR operators', () => {
 
 describe('complex AND/XOR/OR chains', () => {
   it('a AND b OR c', () => {
-    const expectation: GenerateMixedAndXorOrListReturn = {
+    const expectation: MixedAndXorOrList = {
       combinator: 'or',
       expressions: [{ combinator: 'and', expressions: [isNullExpr, isNullExpr] }, isNotNullExpr],
     };
@@ -163,7 +163,7 @@ describe('complex AND/XOR/OR chains', () => {
   });
 
   it('a OR b AND c', () => {
-    const expectation: GenerateMixedAndXorOrListReturn = {
+    const expectation: MixedAndXorOrList = {
       combinator: 'or',
       expressions: [isNotNullExpr, { combinator: 'and', expressions: [isNullExpr, isNotNullExpr] }],
     };
@@ -182,7 +182,7 @@ describe('complex AND/XOR/OR chains', () => {
   });
 
   it('a AND b XOR c OR d', () => {
-    const expectation: GenerateMixedAndXorOrListReturn = {
+    const expectation: MixedAndXorOrList = {
       combinator: 'or',
       expressions: [
         {
@@ -216,7 +216,7 @@ describe('complex AND/XOR/OR chains', () => {
   });
 
   it('a OR b XOR c AND d', () => {
-    const expectation: GenerateMixedAndXorOrListReturn = {
+    const expectation: MixedAndXorOrList = {
       combinator: 'or',
       expressions: [
         isNotNullExpr,
@@ -250,7 +250,7 @@ describe('complex AND/XOR/OR chains', () => {
   });
 
   it('a AND b OR c XOR d', () => {
-    const expectation: GenerateMixedAndXorOrListReturn = {
+    const expectation: MixedAndXorOrList = {
       combinator: 'or',
       expressions: [
         { combinator: 'and', expressions: [isNullExpr, isNotNullExpr] },
@@ -263,6 +263,89 @@ describe('complex AND/XOR/OR chains', () => {
     const testResult = generateMixedAndXorOrList({
       type: 'XorExpression',
       operator: 'XOR',
+      left: {
+        type: 'OrExpression',
+        operator: 'OR',
+        left: {
+          type: 'AndExpression',
+          operator: 'AND',
+          left: isNullExpr,
+          right: isNotNullExpr,
+        },
+        right: isNullExpr2,
+      },
+      right: isNotNullExpr2,
+    });
+    expect(testResult).toEqual(expectation);
+  });
+
+  it('a AND b OR c OR d', () => {
+    const expectation: MixedAndXorOrList = {
+      combinator: 'or',
+      expressions: [
+        { combinator: 'and', expressions: [isNullExpr, isNotNullExpr] },
+        isNullExpr2,
+        isNotNullExpr2,
+      ],
+    };
+    const testResult = generateMixedAndXorOrList({
+      type: 'OrExpression',
+      operator: 'OR',
+      left: {
+        type: 'OrExpression',
+        operator: 'OR',
+        left: {
+          type: 'AndExpression',
+          operator: 'AND',
+          left: isNullExpr,
+          right: isNotNullExpr,
+        },
+        right: isNullExpr2,
+      },
+      right: isNotNullExpr2,
+    });
+    expect(testResult).toEqual(expectation);
+  });
+
+  it('a AND b XOR c XOR d', () => {
+    const expectation: MixedAndXorOrList = {
+      combinator: 'xor',
+      expressions: [
+        { combinator: 'and', expressions: [isNullExpr, isNotNullExpr] },
+        isNullExpr2,
+        isNotNullExpr2,
+      ],
+    };
+    const testResult = generateMixedAndXorOrList({
+      type: 'XorExpression',
+      operator: 'XOR',
+      left: {
+        type: 'XorExpression',
+        operator: 'XOR',
+        left: {
+          type: 'AndExpression',
+          operator: 'AND',
+          left: isNullExpr,
+          right: isNotNullExpr,
+        },
+        right: isNullExpr2,
+      },
+      right: isNotNullExpr2,
+    });
+    expect(testResult).toEqual(expectation);
+  });
+
+  it('a AND b OR c AND d', () => {
+    const expectation: MixedAndXorOrList = {
+      combinator: 'or',
+      expressions: [
+        { combinator: 'and', expressions: [isNullExpr, isNotNullExpr] },
+        { combinator: 'and', expressions: [isNullExpr2, isNotNullExpr2] },
+      ],
+    };
+    const testResult = generateMixedAndXorOrList({
+      type: 'AndExpression',
+      operator: 'AND',
       left: {
         type: 'OrExpression',
         operator: 'OR',

--- a/packages/ts/src/ruleGroups.ts
+++ b/packages/ts/src/ruleGroups.ts
@@ -38,13 +38,14 @@ export type UpdateableProperties = Exclude<
 
 export type DefaultRuleGroupArray = RuleGroupArray<DefaultRuleGroupType, DefaultRuleType>;
 
-export type DefaultRuleGroupType = RuleGroupType<DefaultRuleType, DefaultCombinatorName> & {
+export type DefaultRuleGroupType = RuleGroupType<DefaultRuleType, DefaultCombinatorNameExtended> & {
   rules: DefaultRuleGroupArray;
 };
 
 export type DefaultRuleType = RuleType<string, DefaultOperatorName>;
 
 export type DefaultCombinatorName = 'and' | 'or';
+export type DefaultCombinatorNameExtended = DefaultCombinatorName | 'xor';
 
 export type DefaultOperatorName =
   | '='

--- a/packages/ts/src/ruleGroups.ts
+++ b/packages/ts/src/ruleGroups.ts
@@ -71,6 +71,10 @@ export interface DefaultCombinator extends NameLabelPair {
   name: DefaultCombinatorName;
 }
 
+export interface DefaultCombinatorExtended extends NameLabelPair {
+  name: DefaultCombinatorNameExtended;
+}
+
 export interface DefaultOperator extends NameLabelPair {
   name: DefaultOperatorName;
 }

--- a/website/docs/api/export.mdx
+++ b/website/docs/api/export.mdx
@@ -256,6 +256,24 @@ Output:
 { "and": [{ "==": [{ "var": "firstName" }, "Steve"] }, { "==": [{ "var": "lastName" }, "Vai"] }] }
 ```
 
+:::info
+
+Before using `jsonLogic.apply()` to apply the result of `formatQuery(query, 'jsonlogic')`, register the additional operators `startsWith` and `endsWith`. These are not [standard JsonLogic operations](https://jsonlogic.com/operations.html), but they correspond to the "beginsWith" and "endsWith" operators, respectively, from `react-querybuilder`.
+
+The most future-proof way is to loop through the `jsonLogicAdditionalOperators` entries like below. This way if any more operators are added in the future, they will be automatically available.
+
+```ts
+import { jsonLogicAdditionalOperators } from 'react-querybuilder';
+
+for (const [op, func] of Object.entries(jsonLogicAdditionalOperators)) {
+  jsonLogic.add_operation(op, func);
+}
+
+jsonLogic.apply({ startsWith: [{ var: 'firstName' }, 'Stev'] }, data);
+```
+
+:::
+
 ## Configuration
 
 An object can be passed as the second argument instead of a string to have more fine-grained control over the output.

--- a/website/docs/api/import.mdx
+++ b/website/docs/api/import.mdx
@@ -60,6 +60,22 @@ Output (`RuleGroupType`):
 }
 ```
 
+:::info
+
+Since v5.0, `parseSQL` can detect `XOR` operators and convert the expressions into rule groups with combinator "xor". However, since "xor" is not one of the members of `defaultCombinators`, you will need to specify `defaultCombinatorsExtended` (or some derivation of that) in your `<QueryBuilder />` props if you believe the original SQL might contain `XOR` clauses.
+
+```ts
+import { defaultCombinatorsExtended, parseSQL, QueryBuilder } from 'react-querybuilder';
+
+const query = parseSQL(sql);
+
+const App = () => {
+  return <QueryBuilder query={query} combinators={defaultCombinatorsExtended} />;
+};
+```
+
+:::
+
 ## Common Expression Language (CEL)
 
 `parseCEL` takes a [CEL](https://github.com/google/cel-spec) string and converts it to `RuleGroupType`.


### PR DESCRIPTION
Fixes #375.

TODO:

- [x] Fix combinator order of precedence per [MySQL docs](https://dev.mysql.com/doc/refman/8.0/en/operator-precedence.html): `AND`->`XOR`->`OR`.