### PR TITLE
Additional generics

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -273,6 +273,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "Austin-Stowe",
+      "name": "Austin Stowe",
+      "avatar_url": "https://avatars.githubusercontent.com/u/60020423?v=4",
+      "profile": "https://github.com/Austin-Stowe",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -273,15 +273,6 @@
       "contributions": [
         "code"
       ]
-    },
-    {
-      "login": "Austin-Stowe",
-      "name": "Austin Stowe",
-      "avatar_url": "https://avatars.githubusercontent.com/u/60020423?v=4",
-      "profile": "https://github.com/Austin-Stowe",
-      "contributions": [
-        "code"
-      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/packages/ts/src/basic.ts
+++ b/packages/ts/src/basic.ts
@@ -28,8 +28,8 @@ export type OptionGroup<Opt extends NameLabelPair = NameLabelPair> = {
 export interface Field<
   FieldName extends string = string,
   OperatorName extends string = string,
-  OperatorObj extends NameLabelPair = NameLabelPair<OperatorName>,
   ValueName extends string = string,
+  OperatorObj extends NameLabelPair = NameLabelPair<OperatorName>,
   ValueObj extends NameLabelPair = NameLabelPair<ValueName>
   > extends NameLabelPair<FieldName> {
   id?: string;

--- a/packages/ts/src/basic.ts
+++ b/packages/ts/src/basic.ts
@@ -14,8 +14,8 @@ export type ValueEditorType =
 
 export type ValueSources = ['value'] | ['value', 'field'] | ['field', 'value'] | ['field'];
 
-export interface NameLabelPair {
-  name: string;
+export interface NameLabelPair<N extends string = string> {
+  name: N;
   label: string;
   [x: string]: any;
 }
@@ -25,13 +25,19 @@ export type OptionGroup<Opt extends NameLabelPair = NameLabelPair> = {
   options: Opt[];
 };
 
-export interface Field extends NameLabelPair {
+export interface Field<
+  FieldName extends string = string,
+  OperatorName extends string = string,
+  OperatorObj extends NameLabelPair = NameLabelPair<OperatorName>,
+  ValueName extends string = string,
+  ValueObj extends NameLabelPair = NameLabelPair<ValueName>
+  > extends NameLabelPair<FieldName> {
   id?: string;
-  operators?: NameLabelPair[] | OptionGroup[];
+  operators?: OperatorObj[] | OptionGroup<OperatorObj>[];
   valueEditorType?: ValueEditorType | ((operator: string) => ValueEditorType);
   valueSources?: ValueSources | ((operator: string) => ValueSources);
   inputType?: string | null;
-  values?: NameLabelPair[] | OptionGroup[];
+  values?: ValueObj[] | OptionGroup<ValueObj>[];
   defaultOperator?: string;
   defaultValue?: any;
   placeholder?: string;

--- a/packages/ts/src/props.ts
+++ b/packages/ts/src/props.ts
@@ -87,12 +87,12 @@ export type VersatileSelectorProps = ValueSelectorProps &
   Partial<OperatorSelectorProps> &
   Partial<CombinatorSelectorProps>;
 
-export interface ValueEditorProps extends SelectorOrEditorProps {
-  field: string;
-  operator: string;
+export interface ValueEditorProps<F extends Field = Field> extends SelectorOrEditorProps {
+  field: F['name'];
+  operator: F['operators'] extends Array<Exclude<F['operators'], undefined>> ? F['operators'][number] : undefined;
   value?: any;
   valueSource: ValueSource;
-  fieldData: Field;
+  fieldData: F;
   type?: ValueEditorType;
   inputType?: string | null;
   values?: any[];

--- a/packages/ts/src/props.ts
+++ b/packages/ts/src/props.ts
@@ -89,7 +89,7 @@ export type VersatileSelectorProps = ValueSelectorProps &
 
 export interface ValueEditorProps<F extends Field = Field> extends SelectorOrEditorProps {
   field: F['name'];
-  operator: F['operators'] extends Array<Exclude<F['operators'], undefined>> ? F['operators'][number] : undefined;
+  operator: NonNullable<F['operators']>[number] extends NameLabelPair ? NonNullable<F['operators']>[number]['name'] : NonNullable<F['operators']>[number] extends OptionGroup ? NonNullable<F['operators']>[number]['options'][number]['name'] : string;
   value?: any;
   valueSource: ValueSource;
   fieldData: F;

--- a/packages/ts/src/props.ts
+++ b/packages/ts/src/props.ts
@@ -87,9 +87,12 @@ export type VersatileSelectorProps = ValueSelectorProps &
   Partial<OperatorSelectorProps> &
   Partial<CombinatorSelectorProps>;
 
-export interface ValueEditorProps<F extends Field = Field> extends SelectorOrEditorProps {
+export interface ValueEditorProps<
+  F extends Field = Field,
+  O extends string = string,
+  > extends SelectorOrEditorProps {
   field: F['name'];
-  operator: NonNullable<F['operators']>[number] extends NameLabelPair ? NonNullable<F['operators']>[number]['name'] : NonNullable<F['operators']>[number] extends OptionGroup ? NonNullable<F['operators']>[number]['options'][number]['name'] : string;
+  operator: O;
   value?: any;
   valueSource: ValueSource;
   fieldData: F;


### PR DESCRIPTION
First discussed in #406.

# Purpose
To add generic support for custom `Field` types used for access when creating custom value editors.

# Code Changes
## `packages/ts/src/props.ts`
### `ValueEditorProps`
- Update interface from `ValueEditorProps extends SelectorOrEditorProps` to `ValueEditorProps<F extends Field = Field> extends SelectorOrEditorProps`
- Pass `F` type to fields in interface to inherit any custom fields added to the `Field` type by way of the `[x: string]: any` available in `NameLabelPair`
  - This can also be used to add typing to the context field that is available
  - Useful mostly for adding strongly typed additional attribution to fields 