### PR TITLE
Allow specification of preceding combinator when adding a rule/group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#417](https://github.com/react-querybuilder/react-querybuilder/issues/417) Optional `arity` property for operators. When `arity` is either "unary" or a number less than 2, the value editor will not render when that operator is selected (similar to the standard "null"/"notNull" operators).
 - [#408](https://github.com/react-querybuilder/react-querybuilder/issues/408) The interfaces `Option` (née `NameLabelPair`), `Field`, and `ValueEditorProps` now accept generics for `name` and other properties.
 - [#418](https://github.com/react-querybuilder/react-querybuilder/issues/418) A new `OptionList` type covers the `options` property for all standard selection lists (field, operator, combinator, etc.). Previously this was a union type: `NameLabelPair[] | OptionGroup<NameLabelPair>[]`. `OptionList` is equivalent to this type, but 1) doesn't require typing the base type twice, and 2) uses the new `Option` name instead of the deprecated `NameLabelPair`.
+- [#421](https://github.com/react-querybuilder/react-querybuilder/issues/421) When `independentCombinators` is enabled, custom `onAddRule` and `onAddGroup` callbacks can add a `combinatorPreceding` property to the rule/group which will end up being the combinator inserted above the new rule/group (if the parent group is not empty).
 
 ## [v5.2.0] - 2022-11-26
 

--- a/packages/react-querybuilder/src/QueryBuilder.test.tsx
+++ b/packages/react-querybuilder/src/QueryBuilder.test.tsx
@@ -788,6 +788,29 @@ describe('onAddRule prop', () => {
     expect(onQueryChange.mock.calls[1][0].rules[0].value).toBe('modified');
   });
 
+  it('specifies the preceding combinator', async () => {
+    const onQueryChange = jest.fn();
+    const rule: RuleType = {
+      field: 'test',
+      operator: '=',
+      value: 'modified',
+      combinatorPreceding: 'or',
+    };
+    render(
+      <QueryBuilder
+        independentCombinators
+        onAddRule={() => rule}
+        onQueryChange={onQueryChange}
+        defaultQuery={{ rules: [{ field: 'f1', operator: '=', value: 'v1' }] }}
+      />
+    );
+
+    await user.click(screen.getByTestId(TestID.addRule));
+
+    expect((onQueryChange.mock.calls[1][0] as RuleGroupTypeIC).rules[1]).toBe('or');
+    expect(screen.getByTestId(TestID.combinators)).toHaveValue('or');
+  });
+
   it('passes handleOnClick context to onAddRule', async () => {
     const onQueryChange = jest.fn();
     const rule: RuleType = { field: 'test', operator: '=', value: 'modified' };
@@ -842,6 +865,24 @@ describe('onAddGroup prop', () => {
     await user.click(screen.getByTestId(TestID.addGroup));
 
     expect(onQueryChange.mock.calls[1][0].rules[0].combinator).toBe('fake');
+  });
+
+  it('specifies the preceding combinator', async () => {
+    const onQueryChange = jest.fn();
+    const group: RuleGroupTypeIC = { rules: [], combinatorPreceding: 'or' };
+    render(
+      <QueryBuilder
+        independentCombinators
+        onAddGroup={() => group}
+        onQueryChange={onQueryChange}
+        defaultQuery={{ rules: [{ field: 'f1', operator: '=', value: 'v1' }] }}
+      />
+    );
+
+    await user.click(screen.getByTestId(TestID.addGroup));
+
+    expect((onQueryChange.mock.calls[1][0] as RuleGroupTypeIC).rules[1]).toBe('or');
+    expect(screen.getByTestId(TestID.combinators)).toHaveValue('or');
   });
 
   it('passes handleOnClick context to onAddGroup', async () => {

--- a/packages/react-querybuilder/src/QueryBuilder.tsx
+++ b/packages/react-querybuilder/src/QueryBuilder.tsx
@@ -466,7 +466,10 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
       }
       return;
     }
-    const newQuery = add(query, newRule, parentPath, { combinators });
+    const newQuery = add(query, newRule, parentPath, {
+      combinators,
+      combinatorPreceding: newRule.combinatorPreceding ?? undefined,
+    });
     dispatch(newQuery);
   };
 
@@ -491,7 +494,10 @@ export const QueryBuilder = <RG extends RuleGroupType | RuleGroupTypeIC>({
       }
       return;
     }
-    const newQuery = add(query, newGroup, parentPath, { combinators });
+    const newQuery = add(query, newGroup, parentPath, {
+      combinators,
+      combinatorPreceding: (newGroup as RuleGroupTypeIC).combinatorPreceding ?? undefined,
+    });
     dispatch(newQuery);
   };
 

--- a/packages/react-querybuilder/src/utils/queryTools.test.ts
+++ b/packages/react-querybuilder/src/utils/queryTools.test.ts
@@ -95,6 +95,16 @@ describe('add', () => {
         rules: [r1, or, r2, or, r3],
       }
     );
+    testQT(
+      'adds a rule with specified combinator, ignoring defaults',
+      add({ rules: [r1, and, r2] } as DefaultRuleGroupTypeIC, r3, [], {
+        combinators: defaultCombinators.map(c => ({ ...c, name: `custom-${c.name}` })),
+        combinatorPreceding: or,
+      }),
+      {
+        rules: [r1, and, r2, or, r3],
+      }
+    );
     testQT('adds a group', add(rgic1, rgic2, []), {
       rules: [rgic2],
     });

--- a/packages/ts/src/ruleGroups.ts
+++ b/packages/ts/src/ruleGroups.ts
@@ -9,12 +9,17 @@ interface CommonProperties {
 export type RuleType<
   F extends string = string,
   O extends string = string,
-  V = any
+  V = any,
+  C extends string = string
 > = CommonProperties & {
   field: F;
   operator: O;
   value: V;
   valueSource?: ValueSource;
+  /**
+   * Only used when adding a rule to a query that uses independent combinators
+   */
+  combinatorPreceding?: C;
 };
 
 export type RuleGroupType<

--- a/packages/ts/src/ruleGroupsIC.ts
+++ b/packages/ts/src/ruleGroupsIC.ts
@@ -16,6 +16,10 @@ export type RuleGroupTypeIC<R extends RuleType = RuleType, C extends string = st
   'combinator' | 'rules'
 > & {
   rules: RuleGroupICArray<RuleGroupTypeIC<R, C>, R, C>;
+  /**
+   * Only used when adding a rule to a query that uses independent combinators
+   */
+  combinatorPreceding?: C;
 };
 
 export type RuleGroupTypeAny = RuleGroupType | RuleGroupTypeIC;

--- a/website/docs/api/querybuilder.mdx
+++ b/website/docs/api/querybuilder.mdx
@@ -559,6 +559,8 @@ This function returns the default value for new rules.
 
 This callback is invoked before a new rule is added. The function should either manipulate the rule and return it as an object of type `RuleType`, or return `false` to cancel the addition of the rule. You can use [`findPath`](./misc#findpath) to locate the parent group to which the new rule will be added within the query hierarchy. The `context` parameter (fourth argument) can be passed from a custom [`addRuleAction`](#addruleaction) component to its `onHandleClick` prop, which will in turn pass it to `onAddRule`. This allows one to change the rule that gets added (or avoid the action completely) based on arbitrary data.
 
+If [`independentCombinators`](#independentcombinators) is enabled, you can specify the combinator inserted immediately before the new rule (if the parent group is not empty) by adding a `combinatorPreceding` property with value "and" or "or" to the rule before returning it. Otherwise the combinator preceding the last rule, or the first combinator in the default list if the parent group has only one rule, will be used.
+
 :::tip
 
 To completely [prevent the addition of new rules](../tips/limit-groups), pass `controlElements={{ addRuleAction: () => null }}` which will prevent the "+Rule" button from rendering.
@@ -570,6 +572,8 @@ To completely [prevent the addition of new rules](../tips/limit-groups), pass `c
 `<RG extends RuleGroupTypeAny>(ruleGroup: RG, parentPath: number[], query: RG, context?: any) => RG | false`
 
 This callback is invoked before a new group is added. The function should either manipulate the group and return it as an object of the same type (either `RuleGroupType` or `RuleGroupTypeIC`), or return `false` to cancel the addition of the group. You can use [`findPath`](./misc#findpath) to locate the parent group to which the new group will be added within the query hierarchy. The `context` parameter (fourth argument) can be passed from a custom [`addGroupAction`](#addgroupaction) component to its `onHandleClick` prop, which will in turn pass it to `onAddGroup`. This allows one to change the group that gets added (or avoid the action completely) based on arbitrary data.
+
+If [`independentCombinators`](#independentcombinators) is enabled, you can specify the combinator inserted immediately before the new group (if the parent group is not empty) by adding a `combinatorPreceding` property with value "and" or "or" to the group before returning it. Otherwise the combinator preceding the last rule, or the first combinator in the default list if the parent group has only one rule, will be used.
 
 :::tip
 

--- a/website/versioned_docs/version-5/api/querybuilder.mdx
+++ b/website/versioned_docs/version-5/api/querybuilder.mdx
@@ -559,6 +559,8 @@ This function returns the default value for new rules.
 
 This callback is invoked before a new rule is added. The function should either manipulate the rule and return it as an object of type `RuleType`, or return `false` to cancel the addition of the rule. You can use [`findPath`](./misc#findpath) to locate the parent group to which the new rule will be added within the query hierarchy. The `context` parameter (fourth argument) can be passed from a custom [`addRuleAction`](#addruleaction) component to its `onHandleClick` prop, which will in turn pass it to `onAddRule`. This allows one to change the rule that gets added (or avoid the action completely) based on arbitrary data.
 
+If [`independentCombinators`](#independentcombinators) is enabled, you can specify the combinator inserted immediately before the new rule (if the parent group is not empty) by adding a `combinatorPreceding` property with value "and" or "or" to the rule before returning it. Otherwise the combinator preceding the last rule, or the first combinator in the default list if the parent group has only one rule, will be used.
+
 :::tip
 
 To completely [prevent the addition of new rules](../tips/limit-groups), pass `controlElements={{ addRuleAction: () => null }}` which will prevent the "+Rule" button from rendering.
@@ -570,6 +572,8 @@ To completely [prevent the addition of new rules](../tips/limit-groups), pass `c
 `<RG extends RuleGroupTypeAny>(ruleGroup: RG, parentPath: number[], query: RG, context?: any) => RG | false`
 
 This callback is invoked before a new group is added. The function should either manipulate the group and return it as an object of the same type (either `RuleGroupType` or `RuleGroupTypeIC`), or return `false` to cancel the addition of the group. You can use [`findPath`](./misc#findpath) to locate the parent group to which the new group will be added within the query hierarchy. The `context` parameter (fourth argument) can be passed from a custom [`addGroupAction`](#addgroupaction) component to its `onHandleClick` prop, which will in turn pass it to `onAddGroup`. This allows one to change the group that gets added (or avoid the action completely) based on arbitrary data.
+
+If [`independentCombinators`](#independentcombinators) is enabled, you can specify the combinator inserted immediately before the new group (if the parent group is not empty) by adding a `combinatorPreceding` property with value "and" or "or" to the group before returning it. Otherwise the combinator preceding the last rule, or the first combinator in the default list if the parent group has only one rule, will be used.
 
 :::tip
 


### PR DESCRIPTION
Adds an optional `combinatorPreceding` property to `RuleType` and `RuleGroupTypeIC` that, when specified, will be used as the preceding combinator when adding a rule or group to a non-empty group.

Only applicable for `independentCombinators`.