### PR TITLE
Allow different bracket characters in formatQuery

### DIFF
--- a/packages/react-querybuilder/src/utils/formatQuery/formatQuery.test.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/formatQuery.test.ts
@@ -981,6 +981,10 @@ it('handles quoteFieldNamesWith correctly', () => {
   expect(formatQuery(queryToTest, { format: 'sql', quoteFieldNamesWith: '`' })).toBe(
     "(`instrument` in ('Guitar', 'Vocals') and `lastName` = 'Vai')"
   );
+
+  expect(formatQuery(queryToTest, { format: 'sql', quoteFieldNamesWith: ['[', ']'] })).toBe(
+    "([instrument] in ('Guitar', 'Vocals') and [lastName] = 'Vai')"
+  );
 });
 
 it('handles custom fallbackExpression correctly', () => {

--- a/packages/ts/src/importExport.ts
+++ b/packages/ts/src/importExport.ts
@@ -34,10 +34,18 @@ export interface FormatQueryOptions {
   ruleProcessor?: RuleProcessor;
   /**
    * In the "sql"/"parameterized"/"parameterized_named" export formats,
-   * field names will be bracketed by this string. Defaults to the empty
-   * string (''). A common value for this option is the backtick ('`').
+   * field names will be bracketed by this string. If an array of strings
+   * is passed, field names will be preceded by the first element and
+   * succeeded by the second element. A common value for this option is
+   * the backtick ('`').
+   *
+   * @default '' // the empty string
+   *
+   * @example
+   * formatQuery(query, { format: 'sql', quoteFieldNamesWith: ['[', ']'] })
+   * // `[First name] = 'Steve'`
    */
-  quoteFieldNamesWith?: string;
+  quoteFieldNamesWith?: string | [string, string];
   /**
    * Validator function for the entire query. Can be the same function passed
    * as `validator` prop to `<QueryBuilder />`.

--- a/website/docs/typescript.mdx
+++ b/website/docs/typescript.mdx
@@ -121,7 +121,7 @@ interface FormatQueryOptions {
   format?: ExportFormat;
   valueProcessor?: ValueProcessor;
   ruleProcessor?: RuleProcessor;
-  quoteFieldNamesWith?: string;
+  quoteFieldNamesWith?: string | [string, string];
   validator?: QueryValidator;
   fields?: { name: string; validator?: RuleValidator; [k: string]: any }[];
   fallbackExpression?: string;

--- a/website/docs/utils/export.mdx
+++ b/website/docs/utils/export.mdx
@@ -463,11 +463,14 @@ If you use TypeScript, these conditions will be enforced automatically.
 
 ### Quote field names
 
-Some database engines wrap field names in backticks (`` ` ``). This can be configured with the `quoteFieldNamesWith` option.
+Some database engines wrap field names in backticks (`` ` ``) or square brackets (`[]`). This can be configured with the `quoteFieldNamesWith` option.
 
 ```ts
 formatQuery(query, { format: 'sql', quoteFieldNamesWith: '`' });
 // Returns: "(`firstName` = 'Steve' and `lastName` = 'Vai')"
+
+formatQuery(query, { format: 'sql', quoteFieldNamesWith: ['[', ']'] });
+// Returns: "([firstName] = 'Steve' and [lastName] = 'Vai')"
 ```
 
 ### Parameter prefix


### PR DESCRIPTION
Allow `[string, string]` for the `formatQuery` option `quoteFieldNamesWith`.