### PR TITLE
Change usePrevious to sync, without any effects

### DIFF
--- a/packages/react-querybuilder/src/hooks/useControlledOrUncontrolled.ts
+++ b/packages/react-querybuilder/src/hooks/useControlledOrUncontrolled.ts
@@ -24,7 +24,7 @@ export const useControlledOrUncontrolled = ({
   defaultQuery,
   queryProp,
 }: UseControlledOrUncontrolledParams) => {
-  const prevQueryPresent = usePrevious(!!queryProp) !== false;
+  const prevQueryPresent = !!usePrevious(!!queryProp);
 
   useEffect(() => {
     // istanbul ignore else

--- a/packages/react-querybuilder/src/hooks/useControlledOrUncontrolled.ts
+++ b/packages/react-querybuilder/src/hooks/useControlledOrUncontrolled.ts
@@ -24,7 +24,7 @@ export const useControlledOrUncontrolled = ({
   defaultQuery,
   queryProp,
 }: UseControlledOrUncontrolledParams) => {
-  const prevQueryPresent = !!usePrevious(!!queryProp);
+  const prevQueryPresent = usePrevious(!!queryProp);
 
   useEffect(() => {
     // istanbul ignore else
@@ -33,7 +33,7 @@ export const useControlledOrUncontrolled = ({
         console.error(errorBothQueryDefaultQuery);
         didWarnBothQueryDefaultQuery = true;
       } else if (
-        prevQueryPresent &&
+        prevQueryPresent === true &&
         !queryProp &&
         !!defaultQuery &&
         !didWarnControlledToUncontrolled
@@ -41,7 +41,7 @@ export const useControlledOrUncontrolled = ({
         console.error(errorControlledToUncontrolled);
         didWarnControlledToUncontrolled = true;
       } else if (
-        !prevQueryPresent &&
+        prevQueryPresent === false &&
         !!queryProp &&
         !defaultQuery &&
         !didWarnUncontrolledToControlled

--- a/packages/react-querybuilder/src/hooks/useControlledOrUncontrolled.ts
+++ b/packages/react-querybuilder/src/hooks/useControlledOrUncontrolled.ts
@@ -10,7 +10,6 @@ import { usePrevious } from './usePrevious';
 export interface UseControlledOrUncontrolledParams {
   defaultQuery?: RuleGroupTypeAny;
   queryProp?: RuleGroupTypeAny;
-  isFirstRender: boolean;
 }
 
 let didWarnBothQueryDefaultQuery = false;
@@ -24,9 +23,8 @@ let didWarnControlledToUncontrolled = false;
 export const useControlledOrUncontrolled = ({
   defaultQuery,
   queryProp,
-  isFirstRender,
 }: UseControlledOrUncontrolledParams) => {
-  const prevQueryPresent = usePrevious(!!queryProp);
+  const prevQueryPresent = usePrevious(!!queryProp) !== false;
 
   useEffect(() => {
     // istanbul ignore else
@@ -43,7 +41,7 @@ export const useControlledOrUncontrolled = ({
         console.error(errorControlledToUncontrolled);
         didWarnControlledToUncontrolled = true;
       } else if (
-        !(prevQueryPresent || isFirstRender) &&
+        !prevQueryPresent &&
         !!queryProp &&
         !defaultQuery &&
         !didWarnUncontrolledToControlled
@@ -52,5 +50,5 @@ export const useControlledOrUncontrolled = ({
         didWarnUncontrolledToControlled = true;
       }
     }
-  }, [defaultQuery, prevQueryPresent, queryProp, isFirstRender]);
+  }, [defaultQuery, prevQueryPresent, queryProp]);
 };

--- a/packages/react-querybuilder/src/hooks/usePrevious.ts
+++ b/packages/react-querybuilder/src/hooks/usePrevious.ts
@@ -6,18 +6,12 @@ import { useRef } from 'react';
  * Adapted from https://usehooks.com/usePrevious/.
  */
 export const usePrevious = <T>(value: T) => {
-  const ref = useRef<{ value: T | null; prev: T | null }>({
-    value: value,
-    prev: null,
-  });
+  const ref = useRef<{ value: T | null; prev: T | null }>({ value, prev: null });
 
   const current = ref.current.value;
 
   if (value !== current) {
-    ref.current = {
-      value: value,
-      prev: current,
-    };
+    ref.current = { value, prev: current };
   }
 
   return ref.current.prev;

--- a/packages/react-querybuilder/src/hooks/usePrevious.ts
+++ b/packages/react-querybuilder/src/hooks/usePrevious.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 /**
  * Returns the prop value from the last render.
@@ -6,11 +6,19 @@ import { useEffect, useRef } from 'react';
  * Adapted from https://usehooks.com/usePrevious/.
  */
 export const usePrevious = <T>(value: T) => {
-  const ref = useRef<T | null>(null);
+  const ref = useRef<{ value: T | null; prev: T | null }>({
+    value: value,
+    prev: null,
+  });
 
-  useEffect(() => {
-    ref.current = value;
-  }, [value]);
+  const current = ref.current.value;
 
-  return ref.current;
+  if (value !== current) {
+    ref.current = {
+      value: value,
+      prev: current,
+    };
+  }
+
+  return ref.current.prev;
 };

--- a/packages/react-querybuilder/src/hooks/useQueryBuilderSetup.ts
+++ b/packages/react-querybuilder/src/hooks/useQueryBuilderSetup.ts
@@ -51,7 +51,6 @@ export const useQueryBuilderSetup = <
   type OperatorName = GetOptionIdentifierType<O>;
 
   const qbId = useRef(generateID());
-  const firstRender = useRef(true);
 
   const {
     query: queryProp,
@@ -419,12 +418,7 @@ export const useQueryBuilderSetup = <
   useControlledOrUncontrolled({
     defaultQuery,
     queryProp,
-    isFirstRender: firstRender.current,
   });
-
-  if (firstRender.current) {
-    firstRender.current = false;
-  }
 
   return {
     qbId: qbId.current,


### PR DESCRIPTION
This removes the `useEffect` call from `usePrevious` as the effect might fire after obtaining a reference to the result, causing the resulting value to not reflect actual previous value.

Also, the new `usePrevious` function will keep returning null until the value changes (and it makes sense, because there is no previous value unless the value changes at some point). The existence of this `null` state allows removing the “first render” tracking too.

fixes #621