### PR TITLE
No automatic updates to `value` when `valueEditorType` is "multiselect"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#595] `MantineValueSelector` now correctly renders option group headers.
 - [#619] The package.json#types location has been corrected for all packages. This (probably) only affected legacy build systems that don't support/respect package.json#exports.
 - [#623] Fixed an issue where Next triggered the "uncontrolled to controlled" warning unnecessarily. Removed a `useEffect` call from `usePrevious`.
+- The `useValueEditor` hook no longer updates values that are arrays to `value[0]` when `valueEditorType === "multiselect"`.
 
 ## [v6.5.4] - 2023-11-04
 

--- a/packages/react-querybuilder/src/components/ValueEditor.tsx
+++ b/packages/react-querybuilder/src/components/ValueEditor.tsx
@@ -22,23 +22,12 @@ export const ValueEditor = (allProps: ValueEditorProps) => {
     fieldData,
     disabled,
     separator = null,
-    skipHook = false,
     testID,
     selectorComponent: SelectorComponent = allProps.schema.controls.valueSelector,
     ...props
   } = allProps;
 
-  const { valueAsArray, multiValueHandler } = useValueEditor({
-    skipHook,
-    handleOnChange,
-    inputType,
-    operator,
-    value,
-    type,
-    listsAsArrays,
-    parseNumbers,
-    values,
-  });
+  const { valueAsArray, multiValueHandler } = useValueEditor(allProps);
 
   if (operator === 'null' || operator === 'notNull') {
     return null;

--- a/packages/react-querybuilder/src/hooks/useValueEditor.test.ts
+++ b/packages/react-querybuilder/src/hooks/useValueEditor.test.ts
@@ -40,6 +40,19 @@ it('sets valueAsArray when operator is "between"', async () => {
   expect(hr.result.current.valueAsArray).toEqual([12, 14]);
 });
 
+it('does not call handleOnChange when type is "multiselect"', async () => {
+  const handleOnChange = jest.fn();
+  renderHook(() =>
+    useValueEditor({
+      handleOnChange,
+      type: 'multiselect',
+      operator: 'custom',
+      value: ['twelve', 'fourteen'],
+    })
+  );
+  expect(handleOnChange).not.toHaveBeenCalled();
+});
+
 it('does not call handleOnChange when skipHook is true', async () => {
   const handleOnChange = jest.fn();
   const hr = renderHook(() =>

--- a/packages/react-querybuilder/src/hooks/useValueEditor.ts
+++ b/packages/react-querybuilder/src/hooks/useValueEditor.ts
@@ -51,18 +51,20 @@ export const useValueEditor = ({
   listsAsArrays,
   parseNumbers,
   values,
+  type,
   skipHook,
 }: UseValueEditorParams) => {
   useEffect(() => {
     if (skipHook) return;
     if (
+      type !== 'multiselect' &&
       !['between', 'notBetween', 'in', 'notIn'].includes(operator) &&
       (Array.isArray(value) ||
         (inputType === 'number' && typeof value === 'string' && value.includes(',')))
     ) {
       handleOnChange(toArray(value)[0] ?? '');
     }
-  }, [handleOnChange, inputType, operator, skipHook, value]);
+  }, [handleOnChange, inputType, operator, skipHook, type, value]);
 
   const valueAsArray = useMemo(() => toArray(value), [value]);
 


### PR DESCRIPTION
Fixes #631 for v7.