### PR TITLE
Prepare query whenever necessary

### DIFF
--- a/examples/next/app/NextQueryBuilder.tsx
+++ b/examples/next/app/NextQueryBuilder.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import { useState } from 'react';
 import type { Field, RuleGroupType } from 'react-querybuilder';
 import { QueryBuilder, formatQuery } from 'react-querybuilder';
@@ -12,10 +11,21 @@ const fields: Field[] = [
 ];
 
 const initialQuery: RuleGroupType = {
+  id: 'root',
   combinator: 'and',
   rules: [
-    { field: 'firstName', operator: 'beginsWith', value: 'Stev' },
-    { field: 'lastName', operator: 'in', value: 'Vai,Vaughan' },
+    {
+      id: 'rule1',
+      field: 'firstName',
+      operator: 'beginsWith',
+      value: 'Stev',
+    },
+    {
+      id: 'rule2',
+      field: 'lastName',
+      operator: 'in',
+      value: 'Vai,Vaughan',
+    },
   ],
 };
 
@@ -33,8 +43,16 @@ const QB = () => {
   );
 };
 
-// Lazy load the QueryBuilder component so it doesn't get rendered on the server.
+// NOTE: This only works if each object in the query hierarchy (including the query
+// object itself) has a unique `id` property at the time of server rendering.
+export const NextQueryBuilder = QB;
+
+// If the query doesn't have `id`s, the component must be lazy-loaded without SSR
+// to avoid conflicting props during hydration.
 // See https://nextjs.org/docs/app/building-your-application/optimizing/lazy-loading#skipping-ssr
-export const NextQueryBuilder = dynamic(() => Promise.resolve(QB), {
-  ssr: false,
-});
+
+// Uncomment the following lines and remove the existing export to enable SSR-less lazy-loading
+// import dynamic from 'next/dynamic';
+// export const NextQueryBuilder = dynamic(() => Promise.resolve(QB), {
+//   ssr: false,
+// });

--- a/examples/next/app/NextQueryBuilder.tsx
+++ b/examples/next/app/NextQueryBuilder.tsx
@@ -19,21 +19,20 @@ const initialQuery: RuleGroupType = {
   ],
 };
 
+const QB = () => {
+  const [query, setQuery] = useState(initialQuery);
+
+  return (
+    <>
+      <QueryBuilder fields={fields} query={query} onQueryChange={setQuery} />
+      <h4>Query</h4>
+      <pre>
+        <code>{formatQuery(query, 'json')}</code>
+      </pre>
+    </>
+  );
+};
+
 // Lazy load the QueryBuilder component so it doesn't get rendered on the server.
 // See https://nextjs.org/docs/app/building-your-application/optimizing/lazy-loading#skipping-ssr
-export const NextQueryBuilder = dynamic(
-  () => {
-    const [query, setQuery] = useState(initialQuery);
-
-    return (
-      <>
-        <QueryBuilder fields={fields} query={query} onQueryChange={setQuery} />
-        <h4>Query</h4>
-        <pre>
-          <code>{formatQuery(query, 'json')}</code>
-        </pre>
-      </>
-    );
-  },
-  { ssr: false }
-);
+export const NextQueryBuilder = dynamic(QB, { ssr: false });

--- a/examples/next/app/NextQueryBuilder.tsx
+++ b/examples/next/app/NextQueryBuilder.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { useState } from 'react';
 import type { Field, RuleGroupType } from 'react-querybuilder';
 import { QueryBuilder, formatQuery } from 'react-querybuilder';
@@ -18,16 +19,21 @@ const initialQuery: RuleGroupType = {
   ],
 };
 
-export const NextQueryBuilder = () => {
-  const [query, setQuery] = useState(initialQuery);
+// Lazy load the QueryBuilder component so it doesn't get rendered on the server.
+// See https://nextjs.org/docs/app/building-your-application/optimizing/lazy-loading#skipping-ssr
+export const NextQueryBuilder = dynamic(
+  () => {
+    const [query, setQuery] = useState(initialQuery);
 
-  return (
-    <>
-      <QueryBuilder fields={fields} query={query} onQueryChange={setQuery} />
-      <h4>Query</h4>
-      <pre>
-        <code>{formatQuery(query, 'json')}</code>
-      </pre>
-    </>
-  );
-};
+    return (
+      <>
+        <QueryBuilder fields={fields} query={query} onQueryChange={setQuery} />
+        <h4>Query</h4>
+        <pre>
+          <code>{formatQuery(query, 'json')}</code>
+        </pre>
+      </>
+    );
+  },
+  { ssr: false }
+);

--- a/examples/next/app/NextQueryBuilder.tsx
+++ b/examples/next/app/NextQueryBuilder.tsx
@@ -35,4 +35,6 @@ const QB = () => {
 
 // Lazy load the QueryBuilder component so it doesn't get rendered on the server.
 // See https://nextjs.org/docs/app/building-your-application/optimizing/lazy-loading#skipping-ssr
-export const NextQueryBuilder = dynamic(QB, { ssr: false });
+export const NextQueryBuilder = dynamic(() => Promise.resolve(QB), {
+  ssr: false,
+});

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -3,9 +3,7 @@
     "@types/node": "20.6.2",
     "@types/react": "18.2.22",
     "@types/react-dom": "18.2.7",
-    "next": "13.5.1",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "next": "14.1.0",
     "react-querybuilder": "^7.0.0-alpha.6",
     "typescript": "5.2.2"
   },

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "npm i -g bun && bun run build && bun run website:build"
+command = "npm i -g bun && bun run build:sequential && bun run website:build"
 publish = "website/build"
 
 [context.production.environment]

--- a/packages/react-querybuilder/src/components/RuleGroup.test.tsx
+++ b/packages/react-querybuilder/src/components/RuleGroup.test.tsx
@@ -20,12 +20,10 @@ const { consoleError } = consoleMocks();
 it('should have correct accessible description', () => {
   // Root group
   const { rerender } = render(<RuleGroup {...getRuleGroupProps()} path={[]} />);
-  expect(screen.getByTestId(TestID.ruleGroup)).toHaveAccessibleDescription('Query builder qbId');
+  expect(screen.getByTestId(TestID.ruleGroup)).toHaveAccessibleDescription('Query builder');
   // Sub group
   rerender(<RuleGroup {...getRuleGroupProps()} path={[0]} />);
-  expect(screen.getByTestId(TestID.ruleGroup)).toHaveAccessibleDescription(
-    'Rule group at path 0 in query builder qbId'
-  );
+  expect(screen.getByTestId(TestID.ruleGroup)).toHaveAccessibleDescription('Rule group at path 0');
 });
 
 it('should have correct classNames', () => {

--- a/packages/react-querybuilder/src/components/RuleGroup.tsx
+++ b/packages/react-querybuilder/src/components/RuleGroup.tsx
@@ -272,7 +272,7 @@ export const RuleGroupBodyComponents = React.memo(
                   !rg.schema.independentCombinators &&
                   rg.schema.showCombinatorsBetweenRules && (
                     <InlineCombinatorControlElement
-                      key="inline-combinator"
+                      key={TestID.inlineCombinator}
                       options={rg.schema.combinators}
                       value={rg.combinator}
                       title={rg.translations.combinators.title}
@@ -291,7 +291,7 @@ export const RuleGroupBodyComponents = React.memo(
                   )}
                 {typeof r === 'string' ? (
                   <InlineCombinatorControlElement
-                    key="inline-combinator-str"
+                    key={`${TestID.inlineCombinator}-independent`}
                     options={rg.schema.combinators}
                     value={r}
                     title={rg.translations.combinators.title}
@@ -309,7 +309,7 @@ export const RuleGroupBodyComponents = React.memo(
                   />
                 ) : isRuleGroup(r) ? (
                   <RuleGroupControlElement
-                    key="rule-group"
+                    key={TestID.ruleGroup}
                     id={r.id}
                     schema={rg.schema}
                     actions={rg.actions}
@@ -327,7 +327,7 @@ export const RuleGroupBodyComponents = React.memo(
                   />
                 ) : (
                   <RuleControlElement
-                    key="rule"
+                    key={TestID.rule}
                     id={r.id!}
                     rule={r}
                     field={r.field}

--- a/packages/react-querybuilder/src/hooks/useQueryBuilderSchema.ts
+++ b/packages/react-querybuilder/src/hooks/useQueryBuilderSchema.ts
@@ -1,5 +1,5 @@
 import { clsx } from 'clsx';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { LogType, standardClassnames } from '../defaults';
 import {
   dispatchThunk,
@@ -131,8 +131,6 @@ export function useQueryBuilderSchema<
     translations,
   } = rqbContext;
 
-  const isFirstRender = useRef(true);
-
   // #region Boolean coercion
   const showCombinatorsBetweenRules = !!showCombinatorsBetweenRulesProp;
   const showNotToggle = !!showNotToggleProp;
@@ -160,16 +158,16 @@ export function useQueryBuilderSchema<
 
   const fallbackQuery = useMemo(() => createRuleGroup(), [createRuleGroup]);
 
-  // We assume here that if this is not the first render, the query has already
-  // been prepared. If `preliminaryQuery === query`, the user is probably
+  // We assume here that if the query has an `id` property, the query has already
+  // been prepared. If `candidateQuery === query`, the user is probably just
   // passing back the parameter from the `onQueryChange` callback.
-  const preliminaryQuery = queryProp ?? storeQuery ?? defaultQueryProp ?? fallbackQuery;
-  const rootGroup = isFirstRender.current
-    ? prepareRuleGroup(preliminaryQuery, { idGenerator })
-    : preliminaryQuery;
+  const candidateQuery = queryProp ?? storeQuery ?? defaultQueryProp ?? fallbackQuery;
+  const rootGroup = !candidateQuery.id
+    ? prepareRuleGroup(candidateQuery, { idGenerator })
+    : candidateQuery;
 
-  // If a query prop is passed in that doesn't match the query in the store,
-  // update the store query to match the prop _without_ calling `onQueryChange`.
+  // If a new `query` prop is passed in that doesn't match the query in the store,
+  // update the store to match the prop _without_ calling `onQueryChange`.
   useEffect(() => {
     if (!!queryProp && queryProp !== storeQuery) {
       queryBuilderDispatch(
@@ -526,8 +524,6 @@ export function useQueryBuilderSchema<
       }),
     [controlClassnames.queryBuilder, queryDisabled, validationResult]
   );
-
-  if (isFirstRender.current) isFirstRender.current = false;
 
   return {
     ...props,

--- a/packages/react-querybuilder/src/types/basic.ts
+++ b/packages/react-querybuilder/src/types/basic.ts
@@ -130,3 +130,5 @@ export interface Combinator<N extends string = string> extends Option<N>, HasOpt
  * - `"native"` forces the use of `parseFloat`, returning `NaN` when parsing fails
  */
 export type ParseNumbersMethod = boolean | 'enhanced' | 'native' | 'strict';
+
+export type AccessibleDescriptionGenerator = (props: { path: Path; qbId: string }) => string;

--- a/packages/react-querybuilder/src/types/propsUsingReact.ts
+++ b/packages/react-querybuilder/src/types/propsUsingReact.ts
@@ -7,6 +7,7 @@ import type {
   RefAttributes,
 } from 'react';
 import type {
+  AccessibleDescriptionGenerator,
   Classname,
   Combinator,
   Field,
@@ -338,7 +339,7 @@ export interface Schema<F extends ToFullOption<Field>, O extends string> {
   getValues(field: string, operator: string, meta: { fieldData: F }): FullOptionList<Option>;
   getRuleClassname(rule: RuleType, misc: { fieldData: F }): Classname;
   getRuleGroupClassname(ruleGroup: RuleGroupTypeAny): Classname;
-  accessibleDescriptionGenerator: (props: { path: Path; qbId: string }) => string;
+  accessibleDescriptionGenerator: AccessibleDescriptionGenerator;
   showCombinatorsBetweenRules: boolean;
   showNotToggle: boolean;
   showShiftActions: boolean;
@@ -777,7 +778,7 @@ export type QueryBuilderProps<
        * rule group. As this is intended to help with accessibility, the text output from this
        * function should be meaningful, descriptive, and unique within the page.
        */
-      accessibleDescriptionGenerator?: (props: { path: Path; qbId: string }) => string;
+      accessibleDescriptionGenerator?: AccessibleDescriptionGenerator;
       /**
        * Container for custom props that are passed to all components.
        */

--- a/packages/react-querybuilder/src/utils/generateAccessibleDescription.ts
+++ b/packages/react-querybuilder/src/utils/generateAccessibleDescription.ts
@@ -1,8 +1,5 @@
-import type { Field, Schema, ToFullOption } from '../types/index';
+import type { AccessibleDescriptionGenerator as ADG } from '../types/index';
 import { pathsAreEqual } from './pathUtils';
 
-export const generateAccessibleDescription = (({ path, qbId }) => {
-  return pathsAreEqual([], path)
-    ? `Query builder ${qbId}`
-    : `Rule group at path ${path.join('-')} in query builder ${qbId}`;
-}) satisfies Schema<ToFullOption<Field>, string>['accessibleDescriptionGenerator'];
+export const generateAccessibleDescription: ADG = ({ path, qbId: _qbID }) =>
+  pathsAreEqual([], path) ? `Query builder` : `Rule group at path ${path.join('-')}`;

--- a/website/src/pages/demo/_components/Demo.module.css
+++ b/website/src/pages/demo/_components/Demo.module.css
@@ -17,16 +17,26 @@
 }
 
 .demoOptionCommands {
-  display: flex;
-  justify-content: flex-start;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
   gap: var(--ifm-global-spacing);
-  margin: var(--ifm-global-spacing) auto;
+  margin: var(--ifm-global-spacing) 0;
+}
+
+.demoOptionCommands button {
+  padding: 0.3rem;
+  height: 100%;
+  width: 100%;
 }
 
 .demoImportCommands {
   display: flex;
   flex-direction: column;
   gap: var(--ifm-global-spacing);
+}
+
+.demoImportCommands button {
+  padding: 0.4rem;
 }
 
 .exportOptions {

--- a/website/src/pages/demo/_components/Demo.tsx
+++ b/website/src/pages/demo/_components/Demo.tsx
@@ -78,8 +78,8 @@ const initialMongoDB = JSON.stringify(
 const initialCEL = `firstName.startsWith("Stev") && age > 28`;
 const initialJsonLogic = JSON.stringify(formatQuery(initialQuery, 'jsonlogic'), null, 2);
 
-const permalinkText = 'Copy link';
-const permalinkCopiedText = 'Copied!';
+const permalinkText = 'Copy permalink';
+const permalinkCopiedText = 'Copied permalink';
 
 interface DemoProps {
   variant?: StyleName;
@@ -476,10 +476,7 @@ export default function Demo({
               Select all
             </button>
           </div>
-          <div
-            title={
-              'Copy a URL that will load this demo with the options set as they are currently'
-            }>
+          <div title="Copy a URL that will load this demo with the same query and the options as currently set">
             <button type="button" onClick={onClickCopyPermalink}>
               {copyPermalinkText}
             </button>
@@ -570,25 +567,20 @@ export default function Demo({
           ]}>
           <TabItem value="code" label="Code">
             <Details summary={<summary>Dependencies</summary>}>
-              <p>
-                The selected options require the following package{packageNames.length > 1 && 's'}:
-              </p>
-              <CodeBlock language="shell">{packageNames.join(' ')}</CodeBlock>
-              <p>
-                Registry link{packageNames.length > 1 && 's'}:{' '}
-                {packageNames.map(packageName => (
-                  <span key={packageName}>
-                    {' '}
-                    <a
-                      href={`https://www.npmjs.com/package/${packageName}`}
-                      target="_blank"
-                      rel="noreferrer"
-                      className={styles.demoNavPackageLink}>
-                      {packageName}
-                    </a>
-                  </span>
-                ))}
-              </p>
+              <Tabs>
+                <TabItem value="npm" label="npm">
+                  <CodeBlock language="shell">npm install {packageNames.join(' ')}</CodeBlock>
+                </TabItem>
+                <TabItem value="bun" label="Bun">
+                  <CodeBlock language="shell">bun add {packageNames.join(' ')}</CodeBlock>
+                </TabItem>
+                <TabItem value="yarn" label="Yarn">
+                  <CodeBlock language="shell">yarn add {packageNames.join(' ')}</CodeBlock>
+                </TabItem>
+                <TabItem value="pnpm" label="pnpm">
+                  <CodeBlock language="shell">pnpm add {packageNames.join(' ')}</CodeBlock>
+                </TabItem>
+              </Tabs>
             </Details>
             <CodeBlock language="tsx" title="App.tsx">
               {codeStringState}

--- a/website/src/pages/demo/_components/Nav.tsx
+++ b/website/src/pages/demo/_components/Nav.tsx
@@ -59,9 +59,16 @@ export default function Nav({ variant, compressedState }: NavProps) {
           style={{ minWidth: '1rem' }}>
           <StackBlitzLogo />
         </a>
+        <a
+          href={getLink({ variant, compressedState, siteLocation })}
+          className={styles.smallerAnchor}
+          target="_blank"
+          rel="noreferrer">
+          Permalink
+        </a>
       </div>
       <div className={styles.demoNavStyleLinks}>
-        <label htmlFor={slId}>{'Style library'}</label>
+        <label htmlFor={slId}>Style library:</label>
         <select name={slId} id={slId} value={variant} onChange={goToStyle}>
           {styleNameArray.map(s => (
             <option key={s} value={s}>


### PR DESCRIPTION
- Prepares the query (adds `id`s) whenever necessary, not just on first render. Removes `isFirstRender` ref.
- Completely avoids the React "unique key" error (finally?).
- Makes the default `accessibleDescriptionGenerator` deterministic.
- Fixes SSR issues in the Next.js example.