### PR TITLE
Fix `parseCEL` negated "like" operators without parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-N/A
+### Fixed
+
+- [#682] `parseCEL` processes "like" operators ("contains"/"startsWith"/"endsWith") that are negated without parentheses, like `!f1.contains(f2)`.
 
 ## [v7.2.0] - 2024-04-15
 
@@ -1592,6 +1594,7 @@ Maintenance release focused on converting to a monorepo with Vite driving the bu
 [#663]: https://github.com/react-querybuilder/react-querybuilder/pull/663
 [#671]: https://github.com/react-querybuilder/react-querybuilder/pull/671
 [#677]: https://github.com/react-querybuilder/react-querybuilder/issues/677
+[#682]: https://github.com/react-querybuilder/react-querybuilder/issues/682
 
 <!-- Release comparison links -->
 

--- a/packages/react-querybuilder/src/utils/parseCEL/parseCEL.test.ts
+++ b/packages/react-querybuilder/src/utils/parseCEL/parseCEL.test.ts
@@ -104,35 +104,31 @@ it('handles "like" comparisons', () => {
   );
   testParseCEL(
     'f1.contains(f2)',
-    wrapRule({
-      field: 'f1',
-      operator: 'contains',
-      value: 'f2',
-      valueSource: 'field',
-    })
+    wrapRule({ field: 'f1', operator: 'contains', value: 'f2', valueSource: 'field' })
   );
   testParseCEL(
     'f1.startsWith(f2)',
-    wrapRule({
-      field: 'f1',
-      operator: 'beginsWith',
-      value: 'f2',
-      valueSource: 'field',
-    })
+    wrapRule({ field: 'f1', operator: 'beginsWith', value: 'f2', valueSource: 'field' })
   );
   testParseCEL(
     'f1.endsWith(f2)',
-    wrapRule({
-      field: 'f1',
-      operator: 'endsWith',
-      value: 'f2',
-      valueSource: 'field',
-    })
+    wrapRule({ field: 'f1', operator: 'endsWith', value: 'f2', valueSource: 'field' })
   );
 });
 
 it('negates "like" comparisons', () => {
-  // TODO: support negation without parentheses ('!f1.contains("Test")')
+  testParseCEL(
+    '!f1.contains("Test")',
+    wrapRule({ field: 'f1', operator: 'doesNotContain', value: 'Test' })
+  );
+  testParseCEL(
+    '!f1.contains(f2)',
+    wrapRule({ field: 'f1', operator: 'doesNotContain', value: 'f2', valueSource: 'field' })
+  );
+  testParseCEL(
+    '!f1.f2.contains("Test")',
+    wrapRule({ field: 'f1.f2', operator: 'doesNotContain', value: 'Test' })
+  );
   testParseCEL(
     '!(f1.contains("Test"))',
     wrapRule({ field: 'f1', operator: 'doesNotContain', value: 'Test' })
@@ -140,6 +136,10 @@ it('negates "like" comparisons', () => {
   testParseCEL(
     '!(f1.startsWith("Test"))',
     wrapRule({ field: 'f1', operator: 'doesNotBeginWith', value: 'Test' })
+  );
+  testParseCEL(
+    '!(f1.f2.startsWith("Test"))',
+    wrapRule({ field: 'f1.f2', operator: 'doesNotBeginWith', value: 'Test' })
   );
   testParseCEL(
     '!(f1.endsWith("Test"))',
@@ -329,22 +329,12 @@ describe('fields and getValueSources', () => {
     // fields as option groups
     testParseCEL(
       parseCEL(`f3 == f1`, { fields: optionGroups }),
-      wrapRule({
-        field: 'f3',
-        operator: '=',
-        value: 'f1',
-        valueSource: 'field',
-      })
+      wrapRule({ field: 'f3', operator: '=', value: 'f1', valueSource: 'field' })
     );
     // fields as object
     testParseCEL(
       parseCEL(`f3 == f1`, { fields: fieldsObject }),
-      wrapRule({
-        field: 'f3',
-        operator: '=',
-        value: 'f1',
-        valueSource: 'field',
-      })
+      wrapRule({ field: 'f3', operator: '=', value: 'f1', valueSource: 'field' })
     );
     // `f3` and `f4` allow the valueSource "field" and have no filter
     const baseFields = ['f3', 'f4'];
@@ -354,12 +344,7 @@ describe('fields and getValueSources', () => {
           parseCEL(`${baseField} == ${f.name}`, { fields }),
           f.name === baseField
             ? wrapRule()
-            : wrapRule({
-                field: baseField,
-                operator: '=',
-                value: f.name,
-                valueSource: 'field',
-              })
+            : wrapRule({ field: baseField, operator: '=', value: f.name, valueSource: 'field' })
         );
       }
     }
@@ -368,48 +353,23 @@ describe('fields and getValueSources', () => {
   it('uses the getValueSources option', () => {
     testParseCEL(
       parseCEL(`f5 == f6`, { fields, getValueSources }),
-      wrapRule({
-        field: 'f5',
-        operator: '=',
-        value: 'f6',
-        valueSource: 'field',
-      })
+      wrapRule({ field: 'f5', operator: '=', value: 'f6', valueSource: 'field' })
     );
     testParseCEL(
       parseCEL(`f8 == f7`, { fields, getValueSources }),
-      wrapRule({
-        field: 'f8',
-        operator: '=',
-        value: 'f7',
-        valueSource: 'field',
-      })
+      wrapRule({ field: 'f8', operator: '=', value: 'f7', valueSource: 'field' })
     );
     testParseCEL(
       parseCEL(`f9 == f1`, { fields, getValueSources }),
-      wrapRule({
-        field: 'f9',
-        operator: '=',
-        value: 'f1',
-        valueSource: 'field',
-      })
+      wrapRule({ field: 'f9', operator: '=', value: 'f1', valueSource: 'field' })
     );
     testParseCEL(
       parseCEL(`f10 == f7`, { fields, getValueSources }),
-      wrapRule({
-        field: 'f10',
-        operator: '=',
-        value: 'f7',
-        valueSource: 'field',
-      })
+      wrapRule({ field: 'f10', operator: '=', value: 'f7', valueSource: 'field' })
     );
     testParseCEL(
       parseCEL(`f10 == f8`, { fields, getValueSources }),
-      wrapRule({
-        field: 'f10',
-        operator: '=',
-        value: 'f8',
-        valueSource: 'field',
-      })
+      wrapRule({ field: 'f10', operator: '=', value: 'f8', valueSource: 'field' })
     );
   });
 
@@ -482,12 +442,7 @@ it('outputs lists as arrays', () => {
   );
   testParseCEL(
     parseCEL('f1 in [f2,f3]', { listsAsArrays: true }),
-    wrapRule({
-      field: 'f1',
-      operator: 'in',
-      value: ['f2', 'f3'],
-      valueSource: 'field',
-    })
+    wrapRule({ field: 'f1', operator: 'in', value: ['f2', 'f3'], valueSource: 'field' })
   );
   testParseCEL(
     parseCEL('f1 in {f2: "v2", "f3": "v3"}', { listsAsArrays: true }),
@@ -496,6 +451,14 @@ it('outputs lists as arrays', () => {
 });
 
 it('handles multiple negations', () => {
+  testParseCEL(
+    '!!!f1.contains("Test")',
+    wrapRule({ field: 'f1', operator: 'doesNotContain', value: 'Test' })
+  );
+  testParseCEL(
+    '!!!!f1.contains("Test")',
+    wrapRule({ field: 'f1', operator: 'contains', value: 'Test' })
+  );
   testParseCEL(
     '!!!(f1.contains("Test"))',
     wrapRule({ field: 'f1', operator: 'doesNotContain', value: 'Test' })
@@ -520,6 +483,15 @@ it('handles independent combinators', () => {
       { field: 'f2', operator: '=', value: 'Test2' },
       'or',
       { field: 'f3', operator: '=', value: 'Test3' },
+    ],
+  });
+  testParseCELic('!f1.f2.startsWith("Test") && f3 > 26 || !!f4.f5.endsWith("Test")', {
+    rules: [
+      { field: 'f1.f2', operator: 'doesNotBeginWith', value: 'Test' },
+      'and',
+      { field: 'f3', operator: '>', value: 26 },
+      'or',
+      { field: 'f4.f5', operator: 'endsWith', value: 'Test' },
     ],
   });
 });

--- a/packages/react-querybuilder/src/utils/parseCEL/types.ts
+++ b/packages/react-querybuilder/src/utils/parseCEL/types.ts
@@ -108,6 +108,15 @@ export interface CELMemberIdentifierChain extends CELMember {
   right: CELIdentifier;
   list: never;
 }
+export interface CELMemberNegatedIdentifier extends CELNegation {
+  value: CELIdentifier;
+}
+export interface CELMemberNegatedIdentifierChain extends CELExpression {
+  value: never;
+  left: CELMemberIdentifierChain | CELMemberNegatedIdentifier;
+  right: CELIdentifier;
+  list: never;
+}
 export interface CELDynamicPropertyAccessor extends CELExpression {
   type: 'DynamicPropertyAccessor';
   left: CELMember;
@@ -207,6 +216,12 @@ export interface CELMapInit extends CELExpression {
 export interface CELLikeExpression extends CELExpression {
   type: 'LikeExpression';
   left: CELIdentifier | CELMemberIdentifierChain;
+  right: CELIdentifier<'contains' | 'startsWith' | 'endsWith'>;
+  list: CELExpressionList & { value: [CELStringLiteral | CELIdentifier] };
+}
+export interface CELNegatedLikeExpression extends CELExpression {
+  type: 'LikeExpression';
+  left: CELMemberNegatedIdentifier | CELMemberNegatedIdentifierChain;
   right: CELIdentifier<'contains' | 'startsWith' | 'endsWith'>;
   list: CELExpressionList & { value: [CELStringLiteral | CELIdentifier] };
 }

--- a/packages/react-querybuilder/src/utils/parseSQL/parseSQL.test.ts
+++ b/packages/react-querybuilder/src/utils/parseSQL/parseSQL.test.ts
@@ -205,25 +205,13 @@ is a ''bad'' guy!`,
       wrapRule({ field: 'firstName', operator: 'endsWith', value: 'Steve' })
     );
     expect(parseSQL(`firstName NOT LIKE '%Steve%'`)).toEqual(
-      wrapRule({
-        field: 'firstName',
-        operator: 'doesNotContain',
-        value: 'Steve',
-      })
+      wrapRule({ field: 'firstName', operator: 'doesNotContain', value: 'Steve' })
     );
     expect(parseSQL(`firstName NOT LIKE 'Steve%'`)).toEqual(
-      wrapRule({
-        field: 'firstName',
-        operator: 'doesNotBeginWith',
-        value: 'Steve',
-      })
+      wrapRule({ field: 'firstName', operator: 'doesNotBeginWith', value: 'Steve' })
     );
     expect(parseSQL(`firstName NOT LIKE '%Steve'`)).toEqual(
-      wrapRule({
-        field: 'firstName',
-        operator: 'doesNotEndWith',
-        value: 'Steve',
-      })
+      wrapRule({ field: 'firstName', operator: 'doesNotEndWith', value: 'Steve' })
     );
   });
 
@@ -334,24 +322,12 @@ describe('options', () => {
       );
       // fields as option groups
       expect(parseSQL(`f3 = f1`, { fields: optionGroups })).toEqual(
-        wrapRule({
-          field: 'f3',
-          operator: '=',
-          value: 'f1',
-          valueSource: 'field',
-        })
+        wrapRule({ field: 'f3', operator: '=', value: 'f1', valueSource: 'field' })
       );
       // fields as object
       expect(
         parseSQL(`f3 = f1`, { fields: Object.fromEntries(fields.map(f => [f.name, f])) })
-      ).toEqual(
-        wrapRule({
-          field: 'f3',
-          operator: '=',
-          value: 'f1',
-          valueSource: 'field',
-        })
-      );
+      ).toEqual(wrapRule({ field: 'f3', operator: '=', value: 'f1', valueSource: 'field' }));
       // `f3` and `f4` allow the valueSource "field" and have no filter
       const baseFields = ['f3', 'f4'];
       for (const baseField of baseFields) {
@@ -359,12 +335,7 @@ describe('options', () => {
           expect(parseSQL(`${baseField} = ${f.name}`, { fields })).toEqual(
             f.name === baseField
               ? wrapRule()
-              : wrapRule({
-                  field: baseField,
-                  operator: '=',
-                  value: f.name,
-                  valueSource: 'field',
-                })
+              : wrapRule({ field: baseField, operator: '=', value: f.name, valueSource: 'field' })
           );
         }
       }
@@ -372,44 +343,19 @@ describe('options', () => {
 
     it('uses the getValueSources option', () => {
       expect(parseSQL(`f5 = f6`, { fields, getValueSources })).toEqual(
-        wrapRule({
-          field: 'f5',
-          operator: '=',
-          value: 'f6',
-          valueSource: 'field',
-        })
+        wrapRule({ field: 'f5', operator: '=', value: 'f6', valueSource: 'field' })
       );
       expect(parseSQL(`f8 = f7`, { fields, getValueSources })).toEqual(
-        wrapRule({
-          field: 'f8',
-          operator: '=',
-          value: 'f7',
-          valueSource: 'field',
-        })
+        wrapRule({ field: 'f8', operator: '=', value: 'f7', valueSource: 'field' })
       );
       expect(parseSQL(`f9 = f1`, { fields, getValueSources })).toEqual(
-        wrapRule({
-          field: 'f9',
-          operator: '=',
-          value: 'f1',
-          valueSource: 'field',
-        })
+        wrapRule({ field: 'f9', operator: '=', value: 'f1', valueSource: 'field' })
       );
       expect(parseSQL(`f10 = f7`, { fields, getValueSources })).toEqual(
-        wrapRule({
-          field: 'f10',
-          operator: '=',
-          value: 'f7',
-          valueSource: 'field',
-        })
+        wrapRule({ field: 'f10', operator: '=', value: 'f7', valueSource: 'field' })
       );
       expect(parseSQL(`f10 = f8`, { fields, getValueSources })).toEqual(
-        wrapRule({
-          field: 'f10',
-          operator: '=',
-          value: 'f8',
-          valueSource: 'field',
-        })
+        wrapRule({ field: 'f10', operator: '=', value: 'f8', valueSource: 'field' })
       );
     });
 
@@ -453,12 +399,7 @@ describe('options', () => {
       expect(parseSQL(`${invalidField} = ${subField}`, { fields })).toEqual(wrapRule());
       expect(parseSQL(`${baseField} = ${invalidSubField}`, { fields })).toEqual(wrapRule());
       expect(parseSQL(`${baseField} = ${subField}`, { fields })).toEqual(
-        wrapRule({
-          field: baseField,
-          operator: '=',
-          value: subField,
-          valueSource: 'field',
-        })
+        wrapRule({ field: baseField, operator: '=', value: subField, valueSource: 'field' })
       );
       // InExpressionListPredicate
       expect(parseSQL(`${invalidField} in (${subField})`, { fields })).toEqual(wrapRule());
@@ -511,12 +452,7 @@ describe('options', () => {
       expect(parseSQL(`${invalidField} like ${subField}`, { fields })).toEqual(wrapRule());
       expect(parseSQL(`${baseField} like ${invalidSubField}`, { fields })).toEqual(wrapRule());
       expect(parseSQL(`${baseField} like ${subField}`, { fields })).toEqual(
-        wrapRule({
-          field: baseField,
-          operator: '=',
-          value: `${subField}`,
-          valueSource: 'field',
-        })
+        wrapRule({ field: baseField, operator: '=', value: `${subField}`, valueSource: 'field' })
       );
     });
 
@@ -529,42 +465,12 @@ describe('options', () => {
       ).toEqual({
         combinator: 'and',
         rules: [
-          {
-            field: 'f3',
-            operator: 'contains',
-            value: 'f1',
-            valueSource: 'field',
-          },
-          {
-            field: 'f3',
-            operator: 'beginsWith',
-            value: 'f1',
-            valueSource: 'field',
-          },
-          {
-            field: 'f3',
-            operator: 'endsWith',
-            value: 'f1',
-            valueSource: 'field',
-          },
-          {
-            field: 'f3',
-            operator: 'doesNotContain',
-            value: 'f1',
-            valueSource: 'field',
-          },
-          {
-            field: 'f3',
-            operator: 'doesNotBeginWith',
-            value: 'f1',
-            valueSource: 'field',
-          },
-          {
-            field: 'f3',
-            operator: 'doesNotEndWith',
-            value: 'f1',
-            valueSource: 'field',
-          },
+          { field: 'f3', operator: 'contains', value: 'f1', valueSource: 'field' },
+          { field: 'f3', operator: 'beginsWith', value: 'f1', valueSource: 'field' },
+          { field: 'f3', operator: 'endsWith', value: 'f1', valueSource: 'field' },
+          { field: 'f3', operator: 'doesNotContain', value: 'f1', valueSource: 'field' },
+          { field: 'f3', operator: 'doesNotBeginWith', value: 'f1', valueSource: 'field' },
+          { field: 'f3', operator: 'doesNotEndWith', value: 'f1', valueSource: 'field' },
         ],
       });
     });

--- a/packages/react-querybuilder/src/utils/parseSpEL/parseSpEL.test.ts
+++ b/packages/react-querybuilder/src/utils/parseSpEL/parseSpEL.test.ts
@@ -335,22 +335,12 @@ describe('fields and getValueSources', () => {
     // fields as option groups
     testParseSpEL(
       parseSpEL(`f3 == f1`, { fields: optionGroups }),
-      wrapRule({
-        field: 'f3',
-        operator: '=',
-        value: 'f1',
-        valueSource: 'field',
-      })
+      wrapRule({ field: 'f3', operator: '=', value: 'f1', valueSource: 'field' })
     );
     // fields as object
     testParseSpEL(
       parseSpEL(`f3 == f1`, { fields: fieldsObject }),
-      wrapRule({
-        field: 'f3',
-        operator: '=',
-        value: 'f1',
-        valueSource: 'field',
-      })
+      wrapRule({ field: 'f3', operator: '=', value: 'f1', valueSource: 'field' })
     );
     // `f3` and `f4` allow the valueSource "field" and have no filter
     const baseFields = ['f3', 'f4'];
@@ -360,12 +350,7 @@ describe('fields and getValueSources', () => {
           parseSpEL(`${baseField} == ${f.name}`, { fields }),
           f.name === baseField
             ? wrapRule()
-            : wrapRule({
-                field: baseField,
-                operator: '=',
-                value: f.name,
-                valueSource: 'field',
-              })
+            : wrapRule({ field: baseField, operator: '=', value: f.name, valueSource: 'field' })
         );
       }
     }
@@ -374,48 +359,23 @@ describe('fields and getValueSources', () => {
   it('uses the getValueSources option', () => {
     testParseSpEL(
       parseSpEL(`f5 == f6`, { fields, getValueSources }),
-      wrapRule({
-        field: 'f5',
-        operator: '=',
-        value: 'f6',
-        valueSource: 'field',
-      })
+      wrapRule({ field: 'f5', operator: '=', value: 'f6', valueSource: 'field' })
     );
     testParseSpEL(
       parseSpEL(`f8 == f7`, { fields, getValueSources }),
-      wrapRule({
-        field: 'f8',
-        operator: '=',
-        value: 'f7',
-        valueSource: 'field',
-      })
+      wrapRule({ field: 'f8', operator: '=', value: 'f7', valueSource: 'field' })
     );
     testParseSpEL(
       parseSpEL(`f9 == f1`, { fields, getValueSources }),
-      wrapRule({
-        field: 'f9',
-        operator: '=',
-        value: 'f1',
-        valueSource: 'field',
-      })
+      wrapRule({ field: 'f9', operator: '=', value: 'f1', valueSource: 'field' })
     );
     testParseSpEL(
       parseSpEL(`f10 == f7`, { fields, getValueSources }),
-      wrapRule({
-        field: 'f10',
-        operator: '=',
-        value: 'f7',
-        valueSource: 'field',
-      })
+      wrapRule({ field: 'f10', operator: '=', value: 'f7', valueSource: 'field' })
     );
     testParseSpEL(
       parseSpEL(`f10 == f8`, { fields, getValueSources }),
-      wrapRule({
-        field: 'f10',
-        operator: '=',
-        value: 'f8',
-        valueSource: 'field',
-      })
+      wrapRule({ field: 'f10', operator: '=', value: 'f8', valueSource: 'field' })
     );
   });
 


### PR DESCRIPTION
Fixes #682