### PR TITLE
issue-704 prevent nesting of negated groups

### DIFF
--- a/packages/react-querybuilder/src/utils/parseJsonLogic/parseJsonLogic.test.ts
+++ b/packages/react-querybuilder/src/utils/parseJsonLogic/parseJsonLogic.test.ts
@@ -138,6 +138,14 @@ describe('valueSource: "value"', () => {
     });
   });
 
+  it('handles negated groups', () => {
+    expect(parseJsonLogic({ '!': { and: [{ '==': [{ var: 'f1' }, 'Test'] }] } })).toEqual({
+      combinator: 'and',
+      not: true,
+      rules: [{ field: 'f1', operator: '=', value: 'Test' }],
+    });
+  });
+
   it('handles "between" and "in" operations', () => {
     expect(
       parseJsonLogic({

--- a/packages/react-querybuilder/src/utils/parseJsonLogic/parseJsonLogic.ts
+++ b/packages/react-querybuilder/src/utils/parseJsonLogic/parseJsonLogic.ts
@@ -140,7 +140,7 @@ function parseJsonLogic(
             return { combinator: 'and', rules: [newRule] };
           }
           return newRule;
-        } else if (isJsonLogicBetweenExclusive(logic['!']) && isRuleGroupType(rule)) {
+        } else if (isJsonLogicBetweenExclusive(logic['!']) || isRuleGroupType(rule)) {
           return { ...rule, not: true };
         }
         return { combinator: 'and', rules: [rule], not: true };


### PR DESCRIPTION
This PR is intending to fix https://github.com/react-querybuilder/react-querybuilder/issues/704. I found what looks like a logic bug when checking to see if the logic is `isJsonLogicBetweenExclusive` and if `isRuleGroupType`. Changing the AND to an OR fixes the issue. All the current tests are passing and I have added another to test this specific negated group case.