### PR TITLE
adding the ability to have custom logic for jsonlogic groups

### DIFF
--- a/packages/react-querybuilder/src/types/importExport.ts
+++ b/packages/react-querybuilder/src/types/importExport.ts
@@ -297,7 +297,7 @@ export interface ParseJSONataOptions extends ParserCommonOptions {}
  */
 export interface ParseJsonLogicOptions extends ParserCommonOptions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  jsonLogicOperations?: Record<string, (value: any) => RuleType | RuleGroupTypeAny>;
+  jsonLogicOperations?: Record<string, (value: any) => RuleType | RuleGroupTypeAny | false>;
 }
 
 /**

--- a/packages/react-querybuilder/src/utils/parseJsonLogic/parseJsonLogic.test.ts
+++ b/packages/react-querybuilder/src/utils/parseJsonLogic/parseJsonLogic.test.ts
@@ -414,6 +414,61 @@ it('parses custom operations', () => {
   });
 });
 
+it('parses custom group operations', () => {
+  const jsonLogicOperations = {
+    and: () => ({ combinator: 'fooAnd', rules: [] }),
+    or: () => ({ combinator: 'fooOr', rules: [] }),
+    '!': () => ({ combinator: 'fooNot', rules: [], not: true }),
+    '!!': () => ({ combinator: 'fooNotNot', rules: [], not: true }),
+  };
+
+  // and
+  expect(
+    parseJsonLogic(
+      { and: [] } as unknown as RQBJsonLogic,
+      { jsonLogicOperations }
+    )
+  ).toEqual({
+    combinator: 'fooAnd',
+    rules: [],
+  });
+
+  // or
+  expect(
+    parseJsonLogic(
+      { or: [] } as unknown as RQBJsonLogic,
+      { jsonLogicOperations }
+    )
+  ).toEqual({
+    combinator: 'fooOr',
+    rules: [],
+  });
+
+  // !
+  expect(
+    parseJsonLogic(
+      { '!': { not: [] } } as unknown as RQBJsonLogic,
+      { jsonLogicOperations }
+    )
+  ).toEqual({
+    combinator: 'fooNot',
+    rules: [],
+    not: true,
+  });
+
+  // !!
+  expect(
+    parseJsonLogic(
+      { '!!': { notNot: [] } } as unknown as RQBJsonLogic,
+      { jsonLogicOperations }
+    )
+  ).toEqual({
+    combinator: 'fooNotNot',
+    rules: [],
+    not: true,
+  });
+});
+
 it('translates lists as arrays', () => {
   expect(
     parseJsonLogic(

--- a/packages/react-querybuilder/src/utils/parseJsonLogic/parseJsonLogic.test.ts
+++ b/packages/react-querybuilder/src/utils/parseJsonLogic/parseJsonLogic.test.ts
@@ -423,33 +423,20 @@ it('parses custom group operations', () => {
   };
 
   // and
-  expect(
-    parseJsonLogic(
-      { and: [] } as unknown as RQBJsonLogic,
-      { jsonLogicOperations }
-    )
-  ).toEqual({
+  expect(parseJsonLogic({ and: [] } as unknown as RQBJsonLogic, { jsonLogicOperations })).toEqual({
     combinator: 'fooAnd',
     rules: [],
   });
 
   // or
-  expect(
-    parseJsonLogic(
-      { or: [] } as unknown as RQBJsonLogic,
-      { jsonLogicOperations }
-    )
-  ).toEqual({
+  expect(parseJsonLogic({ or: [] } as unknown as RQBJsonLogic, { jsonLogicOperations })).toEqual({
     combinator: 'fooOr',
     rules: [],
   });
 
   // !
   expect(
-    parseJsonLogic(
-      { '!': { not: [] } } as unknown as RQBJsonLogic,
-      { jsonLogicOperations }
-    )
+    parseJsonLogic({ '!': { not: [] } } as unknown as RQBJsonLogic, { jsonLogicOperations })
   ).toEqual({
     combinator: 'fooNot',
     rules: [],
@@ -458,10 +445,7 @@ it('parses custom group operations', () => {
 
   // !!
   expect(
-    parseJsonLogic(
-      { '!!': { notNot: [] } } as unknown as RQBJsonLogic,
-      { jsonLogicOperations }
-    )
+    parseJsonLogic({ '!!': { notNot: [] } } as unknown as RQBJsonLogic, { jsonLogicOperations })
   ).toEqual({
     combinator: 'fooNotNot',
     rules: [],

--- a/packages/react-querybuilder/src/utils/parseJsonLogic/parseJsonLogic.ts
+++ b/packages/react-querybuilder/src/utils/parseJsonLogic/parseJsonLogic.ts
@@ -9,8 +9,6 @@ import type {
   ParseJsonLogicOptions,
   RQBJsonLogic,
   RQBJsonLogicVar,
-  RuleGroupTypeAny,
-  RuleType,
   ValueSource,
 } from '../../types/index.noReact';
 import { convertToIC } from '../convertQuery';


### PR DESCRIPTION
This PR adds the ability to override jsonLogic groups processing functions. The previous logic would not allow for `and`, `or`, `!`, and `!!`to be overridden.

@jakeboone02 there is probably a better way to structure this, but wanted to get your thoughts on the current changes.