### PR TITLE
Fix beginsWith/endsWith for ElasticSearch

### DIFF
--- a/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorElasticSearch.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorElasticSearch.ts
@@ -213,11 +213,11 @@ export const defaultRuleProcessorElasticSearch: RuleProcessor = (
 
     case 'beginsWith':
     case 'doesNotBeginWith':
-      return negateIfNotOp(operator, { regexp: { [field]: { value: `^${value}` } } });
+      return negateIfNotOp(operator, { regexp: { [field]: { value: `${value}.*` } } });
 
     case 'endsWith':
     case 'doesNotEndWith':
-      return negateIfNotOp(operator, { regexp: { [field]: { value: `${value}$` } } });
+      return negateIfNotOp(operator, { regexp: { [field]: { value: `.*${value}` } } });
   }
   return false;
 };

--- a/packages/react-querybuilder/src/utils/formatQuery/formatQuery.ElasticSearch.test.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/formatQuery.ElasticSearch.test.ts
@@ -41,10 +41,10 @@ const elasticSearchQueryObject = {
         bool: {
           should: [
             { bool: { must_not: { regexp: { lastName: { value: 'ab' } } } } },
-            { regexp: { job: { value: '^Prog' } } },
-            { regexp: { email: { value: 'com$' } } },
-            { bool: { must_not: { regexp: { job: { value: '^Man' } } } } },
-            { bool: { must_not: { regexp: { email: { value: 'fr$' } } } } },
+            { regexp: { job: { value: 'Prog.*' } } },
+            { regexp: { email: { value: '.*com' } } },
+            { bool: { must_not: { regexp: { job: { value: 'Man.*' } } } } },
+            { bool: { must_not: { regexp: { email: { value: '.*fr' } } } } },
           ],
         },
       },


### PR DESCRIPTION
According to [documentation on Elasticsearch regex syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/regexp-syntax.html#regexp-unsupported-operators) and real testing, beginsWith/endsWith do not work.

I propose to change `^word` to `word.*` and `word$` to `.*word`.
In my testing the fix works, it's possible though that prefix .* search without prefix might be compute heavy.