### PR TITLE
parseSpEL contains/startsWith/endsWith with 1 char

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ build-stats.*
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+yarn.lock

--- a/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorElasticSearch.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorElasticSearch.ts
@@ -209,7 +209,7 @@ export const defaultRuleProcessorElasticSearch: RuleProcessor = (
 
     case 'contains':
     case 'doesNotContain':
-      return negateIfNotOp(operator, { regexp: { [field]: { value } } });
+      return negateIfNotOp(operator, { regexp: { [field]: { value: `.*${value}.*` } } });
 
     case 'beginsWith':
     case 'doesNotBeginWith':

--- a/packages/react-querybuilder/src/utils/formatQuery/formatQuery.ElasticSearch.test.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/formatQuery.ElasticSearch.test.ts
@@ -31,7 +31,7 @@ const elasticSearchQueryObject = {
               should: [
                 { term: { gender: 'M' } },
                 { bool: { must_not: { term: { job: 'Programmer' } } } },
-                { regexp: { email: { value: '@' } } },
+                { regexp: { email: { value: '.*@.*' } } },
               ],
             },
           },
@@ -40,7 +40,7 @@ const elasticSearchQueryObject = {
       {
         bool: {
           should: [
-            { bool: { must_not: { regexp: { lastName: { value: 'ab' } } } } },
+            { bool: { must_not: { regexp: { lastName: { value: '.*ab.*' } } } } },
             { regexp: { job: { value: 'Prog.*' } } },
             { regexp: { email: { value: '.*com' } } },
             { bool: { must_not: { regexp: { job: { value: 'Man.*' } } } } },

--- a/packages/react-querybuilder/src/utils/parseSpEL/parseSpEL.test.ts
+++ b/packages/react-querybuilder/src/utils/parseSpEL/parseSpEL.test.ts
@@ -85,6 +85,10 @@ it('handles "like" comparisons', () => {
     wrapRule({ field: 'f1', operator: 'contains', value: 'Test' })
   );
   testParseSpEL(
+    'f1 matches "T"',
+    wrapRule({ field: 'f1', operator: 'contains', value: 'T' })
+  );
+  testParseSpEL(
     '"Test" matches f1',
     wrapRule({ field: 'f1', operator: 'contains', value: 'Test' })
   );
@@ -97,8 +101,16 @@ it('handles "like" comparisons', () => {
     wrapRule({ field: 'f1', operator: 'beginsWith', value: 'Test' })
   );
   testParseSpEL(
+    'f1 matches "^T"',
+    wrapRule({ field: 'f1', operator: 'beginsWith', value: 'T' })
+  );
+  testParseSpEL(
     'f1 matches "Test$"',
     wrapRule({ field: 'f1', operator: 'endsWith', value: 'Test' })
+  );
+  testParseSpEL(
+    'f1 matches "T$"',
+    wrapRule({ field: 'f1', operator: 'endsWith', value: 'T' })
   );
   testParseSpEL(
     'f1 matches f2',

--- a/packages/react-querybuilder/src/utils/parseSpEL/parseSpEL.test.ts
+++ b/packages/react-querybuilder/src/utils/parseSpEL/parseSpEL.test.ts
@@ -84,10 +84,7 @@ it('handles "like" comparisons', () => {
     'f1 matches "Test"',
     wrapRule({ field: 'f1', operator: 'contains', value: 'Test' })
   );
-  testParseSpEL(
-    'f1 matches "T"',
-    wrapRule({ field: 'f1', operator: 'contains', value: 'T' })
-  );
+  testParseSpEL('f1 matches "T"', wrapRule({ field: 'f1', operator: 'contains', value: 'T' }));
   testParseSpEL(
     '"Test" matches f1',
     wrapRule({ field: 'f1', operator: 'contains', value: 'Test' })
@@ -100,18 +97,12 @@ it('handles "like" comparisons', () => {
     'f1 matches "^Test"',
     wrapRule({ field: 'f1', operator: 'beginsWith', value: 'Test' })
   );
-  testParseSpEL(
-    'f1 matches "^T"',
-    wrapRule({ field: 'f1', operator: 'beginsWith', value: 'T' })
-  );
+  testParseSpEL('f1 matches "^T"', wrapRule({ field: 'f1', operator: 'beginsWith', value: 'T' }));
   testParseSpEL(
     'f1 matches "Test$"',
     wrapRule({ field: 'f1', operator: 'endsWith', value: 'Test' })
   );
-  testParseSpEL(
-    'f1 matches "T$"',
-    wrapRule({ field: 'f1', operator: 'endsWith', value: 'T' })
-  );
+  testParseSpEL('f1 matches "T$"', wrapRule({ field: 'f1', operator: 'endsWith', value: 'T' }));
   testParseSpEL(
     'f1 matches f2',
     wrapRule({

--- a/packages/react-querybuilder/src/utils/parseSpEL/parseSpEL.ts
+++ b/packages/react-querybuilder/src/utils/parseSpEL/parseSpEL.ts
@@ -178,7 +178,7 @@ function parseSpEL(spel: string, options: ParseSpELOptions = {}): DefaultRuleGro
         }
       }
 
-      if (/^[^^].*[^$]$/.test(regex)) {
+      if (/^(?!\^).*?(?<!\$)$/.test(regex)) {
         // istanbul ignore else
         if (fieldIsValid(field, 'contains')) {
           return {
@@ -189,7 +189,7 @@ function parseSpEL(spel: string, options: ParseSpELOptions = {}): DefaultRuleGro
           };
         }
       } else {
-        if (/^\^.*[^$]/.test(regex)) {
+        if (/^\^.*?(?<!\$)$/.test(regex)) {
           // istanbul ignore else
           if (fieldIsValid(field, 'beginsWith')) {
             return {
@@ -200,7 +200,7 @@ function parseSpEL(spel: string, options: ParseSpELOptions = {}): DefaultRuleGro
           }
         } else {
           // istanbul ignore else
-          if (/[^^].*\$/.test(regex)) {
+          if (/^(?!\^).*?\$$/.test(regex)) {
             // istanbul ignore else
             if (fieldIsValid(field, 'endsWith')) {
               return {


### PR DESCRIPTION
This is related to https://github.com/react-querybuilder/react-querybuilder/pull/730
which only fixed the contains, but the problems is also in startsWith and endsWith

This pr fixes it for parseSpEL.

This would also allow to have no character. If you input only $ or ^ or empty char, it would pass all reqex.

can easily be tested using https://regex101.com/