### PR TITLE
`formatQuery` handles lists of numbers correctly when `parseNumbers` is `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Drag-and-drop hooks are now exported from `@react-querybuilder/dnd`, including `useReactDnD`, `useRuleDnD`, `useRuleGroupDnD`, and `useInlineCombinatorDnD`.
-- `formatQuery` correctly handles values that are lists of numbers when `parseNumbers` is `true`.
+- [#748] `formatQuery` correctly handles values that are lists of numbers when `parseNumbers` is `true`.
 
 ## [v7.6.0] - 2024-07-11
 
@@ -1729,6 +1729,7 @@ Maintenance release focused on converting to a monorepo with Vite driving the bu
 [#730]: https://github.com/react-querybuilder/react-querybuilder/pull/730
 [#733]: https://github.com/react-querybuilder/react-querybuilder/pull/733
 [#734]: https://github.com/react-querybuilder/react-querybuilder/pull/734
+[#748]: https://github.com/react-querybuilder/react-querybuilder/pull/748
 
 <!-- #endregion -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Drag-and-drop hooks are now exported from `@react-querybuilder/dnd`, including `useReactDnD`, `useRuleDnD`, `useRuleGroupDnD`, and `useInlineCombinatorDnD`.
+- `formatQuery` correctly handles values that are lists of numbers when `parseNumbers` is `true`.
 
 ## [v7.6.0] - 2024-07-11
 

--- a/packages/react-querybuilder/src/utils/formatQuery/formatQuery.test.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/formatQuery.test.ts
@@ -96,7 +96,11 @@ describe('parseNumbers', () => {
     {
       "field": "f",
       "operator": "in",
-      "value": "0, 1, 2"
+      "value": [
+        0,
+        1,
+        2
+      ]
     },
     {
       "field": "f",
@@ -115,7 +119,10 @@ describe('parseNumbers', () => {
     {
       "field": "f",
       "operator": "between",
-      "value": "0, 1"
+      "value": [
+        0,
+        1
+      ]
     },
     {
       "field": "f",
@@ -170,7 +177,7 @@ describe('parseNumbers', () => {
       )
     ).toEqual(
       JSON.parse(
-        '{"rules":[{"field":"f","value":"NaN","operator":">"},{"field":"f","value":0,"operator":"="},{"field":"f","value":0,"operator":"="},{"field":"f","value":0,"operator":"="},{"rules":[{"field":"f","value":1.5,"operator":"<"},{"field":"f","value":1.5,"operator":">"}],"combinator":"or"},{"field":"f","value":"0, 1, 2","operator":"in"},{"field":"f","value":[0,1,2],"operator":"in"},{"field":"f","value":"0, abc, 2","operator":"in"},{"field":"f","value":"0, 1","operator":"between"},{"field":"f","value":[0,1],"operator":"between"},{"field":"f","value":"0, abc","operator":"between"},{"field":"f","value":1,"operator":"between"},{"field":"f","value":1,"operator":"between"},{"field":"f","value":[1],"operator":"between"},{"field":"f","value":[{},{}],"operator":"between"}],"combinator":"and"}'
+        '{"rules":[{"field":"f","value":"NaN","operator":">"},{"field":"f","value":0,"operator":"="},{"field":"f","value":0,"operator":"="},{"field":"f","value":0,"operator":"="},{"rules":[{"field":"f","value":1.5,"operator":"<"},{"field":"f","value":1.5,"operator":">"}],"combinator":"or"},{"field":"f","value":[0,1,2],"operator":"in"},{"field":"f","value":[0,1,2],"operator":"in"},{"field":"f","value":"0, abc, 2","operator":"in"},{"field":"f","value":[0,1],"operator":"between"},{"field":"f","value":[0,1],"operator":"between"},{"field":"f","value":"0, abc","operator":"between"},{"field":"f","value":1,"operator":"between"},{"field":"f","value":1,"operator":"between"},{"field":"f","value":[1],"operator":"between"},{"field":"f","value":[{},{}],"operator":"between"}],"combinator":"and"}'
       )
     );
   });
@@ -185,7 +192,7 @@ describe('parseNumbers', () => {
       )
     ).toEqual(
       JSON.parse(
-        '{"rules":[{"field":"f","value":"NaN","operator":">"},"and",{"field":"f","value":0,"operator":"="},"and",{"field":"f","value":0,"operator":"="},"and",{"field":"f","value":0,"operator":"="},"and",{"rules":[{"field":"f","value":1.5,"operator":"<"},"or",{"field":"f","value":1.5,"operator":">"}]},"and",{"field":"f","value":"0, 1, 2","operator":"in"},"and",{"field":"f","value":[0,1,2],"operator":"in"},"and",{"field":"f","value":"0, abc, 2","operator":"in"},"and",{"field":"f","value":"0, 1","operator":"between"},"and",{"field":"f","value":[0,1],"operator":"between"},"and",{"field":"f","value":"0, abc","operator":"between"},"and",{"field":"f","value":1,"operator":"between"},"and",{"field":"f","value":1,"operator":"between"},"and",{"field":"f","value":[1],"operator":"between"},"and",{"field":"f","value":[{},{}],"operator":"between"}]}'
+        '{"rules":[{"field":"f","value":"NaN","operator":">"},"and",{"field":"f","value":0,"operator":"="},"and",{"field":"f","value":0,"operator":"="},"and",{"field":"f","value":0,"operator":"="},"and",{"rules":[{"field":"f","value":1.5,"operator":"<"},"or",{"field":"f","value":1.5,"operator":">"}]},"and",{"field":"f","value":[0,1,2],"operator":"in"},"and",{"field":"f","value":[0,1,2],"operator":"in"},"and",{"field":"f","value":"0, abc, 2","operator":"in"},"and",{"field":"f","value":[0,1],"operator":"between"},"and",{"field":"f","value":[0,1],"operator":"between"},"and",{"field":"f","value":"0, abc","operator":"between"},"and",{"field":"f","value":1,"operator":"between"},"and",{"field":"f","value":1,"operator":"between"},"and",{"field":"f","value":[1],"operator":"between"},"and",{"field":"f","value":[{},{}],"operator":"between"}]}'
       )
     );
   });

--- a/packages/react-querybuilder/src/utils/formatQuery/formatQuery.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/formatQuery.ts
@@ -1,3 +1,4 @@
+import { produce } from 'immer';
 import { defaultPlaceholderFieldName, defaultPlaceholderOperatorName } from '../../defaults';
 import type {
   DefaultCombinatorName,
@@ -200,16 +201,18 @@ function formatQuery(ruleGroup: RuleGroupTypeAny, options: FormatQueryOptions | 
 
   // #region JSON
   if (format === 'json' || format === 'json_without_ids') {
-    const rg = parseNumbers ? numerifyValues(ruleGroup) : ruleGroup;
-    if (format === 'json') {
-      return JSON.stringify(rg, null, 2);
+    const rg = parseNumbers ? produce(ruleGroup, numerifyValues) : ruleGroup;
+    if (format === 'json_without_ids') {
+      return JSON.stringify(rg, (key, value) =>
+        // Remove `id` and `path` keys; leave everything else unchanged.
+        key === 'id' || key === 'path' ? undefined : value
+      );
     }
-    return JSON.stringify(rg, (key, value) =>
-      // Remove `id` and `path` keys; leave everything else unchanged.
-      key === 'id' || key === 'path' ? undefined : value
-    );
+    return JSON.stringify(rg, null, 2);
   }
+  // #endregion
 
+  // #region Validation
   // istanbul ignore else
   if (typeof validator === 'function') {
     const validationResult = validator(ruleGroup);

--- a/packages/react-querybuilder/src/utils/formatQuery/utils.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/utils.ts
@@ -83,6 +83,7 @@ export const numerifyValues = (rg: RuleGroupTypeAny): RuleGroupTypeAny => ({
 
     const va = toArray(r.value).map(v => parseNumber(v, { parseNumbers: true }));
     if (va.every(v => typeof v === 'number')) {
+      // istanbul ignore else
       if (va.length > 1) {
         return { ...r, value: va };
       } else if (va.length === 1) {

--- a/packages/react-querybuilder/src/utils/formatQuery/utils.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/utils.ts
@@ -4,6 +4,7 @@ import type {
   ValueProcessorByRule,
   ValueProcessorLegacy,
 } from '../../types/index.noReact';
+import { toArray } from '../arrayUtils';
 import { isRuleGroup } from '../isRuleGroup';
 import { numericRegex } from '../misc';
 import { parseNumber } from '../parseNumber';
@@ -76,12 +77,20 @@ export const numerifyValues = (rg: RuleGroupTypeAny): RuleGroupTypeAny => ({
       return numerifyValues(r);
     }
 
-    let { value } = r;
-    if (typeof value === 'string') {
-      value = parseNumber(value, { parseNumbers: true });
+    if (Array.isArray(r.value)) {
+      return { ...r, value: r.value.map(v => parseNumber(v, { parseNumbers: true })) };
     }
 
-    return { ...r, value };
+    const va = toArray(r.value).map(v => parseNumber(v, { parseNumbers: true }));
+    if (va.every(v => typeof v === 'number')) {
+      if (va.length > 1) {
+        return { ...r, value: va };
+      } else if (va.length === 1) {
+        return { ...r, value: va[0] };
+      }
+    }
+
+    return r;
   }),
 });
 


### PR DESCRIPTION
- Fixes #745