### PR TITLE
Support chakra v3

### DIFF
--- a/packages/chakra/dev/main.tsx
+++ b/packages/chakra/dev/main.tsx
@@ -1,33 +1,18 @@
-import { ChakraProvider, extendTheme } from '@chakra-ui/react';
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import { QueryBuilder } from 'react-querybuilder';
 import { DevLayout, useDevApp } from '@rqb-devapp';
 import 'react-querybuilder/query-builder.scss';
 import { QueryBuilderChakra } from '../src';
+import { Provider } from '../src/snippets/provider';
 import './styles.scss';
-
-const chakraTheme = extendTheme({
-  components: {
-    Button: {
-      baseStyle: {
-        color: 'rebeccapurple',
-        fontWeight: 'bold', // Normally "semibold"
-      },
-    },
-  },
-  config: {
-    initialColorMode: 'light',
-    useSystemColorMode: false,
-  },
-});
 
 const App = () => {
   const devApp = useDevApp();
 
   return (
     <DevLayout {...devApp}>
-      <ChakraProvider theme={chakraTheme}>
+      <Provider>
         <QueryBuilderChakra>
           {devApp.optVals.independentCombinators ? (
             <QueryBuilder
@@ -45,7 +30,7 @@ const App = () => {
             />
           )}
         </QueryBuilderChakra>
-      </ChakraProvider>
+      </Provider>
     </DevLayout>
   );
 };

--- a/packages/chakra/dev/styles.scss
+++ b/packages/chakra/dev/styles.scss
@@ -1,4 +1,4 @@
-.chakra-select__wrapper {
+.chakra-native-select__root {
   width: fit-content !important;
   display: inline-block;
 }

--- a/packages/chakra/package.json
+++ b/packages/chakra/package.json
@@ -52,16 +52,13 @@
     "typecheck:watch": "tsc --noEmit --watch"
   },
   "devDependencies": {
-    "@chakra-ui/icons": "^2.2.4",
-    "@chakra-ui/react": "^2.10.3",
-    "@chakra-ui/system": "^2.6.2",
+    "@chakra-ui/cli": "^3.0.1",
+    "@chakra-ui/react": "^3.0.1",
     "@emotion/react": "^11.13.3",
-    "@emotion/styled": "^11.13.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.0.1",
     "@types/react": "^18.3.11",
     "@vitejs/plugin-react-swc": "^3.7.1",
-    "framer-motion": "^11.11.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-querybuilder": "workspace:*",
@@ -70,13 +67,13 @@
     "vite": "^5.4.9"
   },
   "peerDependencies": {
-    "@chakra-ui/icons": "^2",
-    "@chakra-ui/react": "^2",
-    "@chakra-ui/system": "^2",
+    "@chakra-ui/react": "^3",
     "@emotion/react": "^11",
-    "@emotion/styled": "^11",
-    "framer-motion": "^11",
     "react": ">=18",
     "react-querybuilder": "7.7.1"
+  },
+  "dependencies": {
+    "next-themes": "^0.3.0",
+    "react-icons": "^5.3.0"
   }
 }

--- a/packages/chakra/package.json
+++ b/packages/chakra/package.json
@@ -52,15 +52,16 @@
     "typecheck:watch": "tsc --noEmit --watch"
   },
   "devDependencies": {
-    "@chakra-ui/cli": "^3.0.1",
     "@chakra-ui/react": "^3.0.1",
     "@emotion/react": "^11.13.3",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.0.1",
     "@types/react": "^18.3.11",
     "@vitejs/plugin-react-swc": "^3.7.1",
+    "next-themes": "^0.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.3.0",
     "react-querybuilder": "workspace:*",
     "rollup-plugin-visualizer": "^5.12.0",
     "typescript": "^5.6.3",
@@ -71,9 +72,5 @@
     "@emotion/react": "^11",
     "react": ">=18",
     "react-querybuilder": "7.7.1"
-  },
-  "dependencies": {
-    "next-themes": "^0.3.0",
-    "react-icons": "^5.3.0"
   }
 }

--- a/packages/chakra/src/Chakra.test.tsx
+++ b/packages/chakra/src/Chakra.test.tsx
@@ -1,4 +1,3 @@
-import { theme, ThemeProvider } from '@chakra-ui/react';
 import { render, screen } from '@testing-library/react';
 import type { ComponentPropsWithoutRef } from 'react';
 import * as React from 'react';
@@ -13,6 +12,7 @@ import {
   testValueEditor,
   testValueSelector,
 } from '@rqb-testing';
+import { Provider } from './snippets/provider';
 import { ChakraActionElement } from './ChakraActionElement';
 import { ChakraDragHandle } from './ChakraDragHandle';
 import { ChakraNotToggle } from './ChakraNotToggle';
@@ -24,17 +24,17 @@ import { QueryBuilderChakra } from './index';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const generateWrapper = (RQBComponent: React.ComponentType<any>) => {
   const Wrapper = (props: ComponentPropsWithoutRef<typeof RQBComponent>) => (
-    <ThemeProvider theme={theme}>
+    <Provider>
       <RQBComponent {...props} />
-    </ThemeProvider>
+    </Provider>
   );
   Wrapper.displayName = RQBComponent.displayName;
   return Wrapper;
 };
 const WrapperDH = forwardRef<HTMLSpanElement, DragHandleProps>((props, ref) => (
-  <ThemeProvider theme={{}}>
+  <Provider>
     <ChakraDragHandle {...props} ref={ref} />
-  </ThemeProvider>
+  </Provider>
 ));
 
 testActionElement(generateWrapper(ChakraActionElement));
@@ -46,11 +46,11 @@ testValueSelector(generateWrapper(ChakraValueSelector), { multi: true });
 
 it('renders with composition', () => {
   render(
-    <ThemeProvider theme={theme}>
+    <Provider>
       <QueryBuilderChakra>
         <QueryBuilder />
       </QueryBuilderChakra>
-    </ThemeProvider>
+    </Provider>
   );
   expect(screen.getByTestId(TestID.ruleGroup)).toBeInTheDocument();
   expect(screen.getByTestId(TestID.ruleGroup).querySelector('button')).toHaveClass('chakra-button');

--- a/packages/chakra/src/ChakraActionElement.tsx
+++ b/packages/chakra/src/ChakraActionElement.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@chakra-ui/react';
 import type { ComponentPropsWithoutRef } from 'react';
 import * as React from 'react';
 import type { ActionWithRulesProps } from 'react-querybuilder';
+import { Button } from './snippets/button';
 
 export type ChakraActionProps = ActionWithRulesProps & ComponentPropsWithoutRef<typeof Button>;
 
@@ -27,7 +27,7 @@ export const ChakraActionElement = ({
     className={className}
     title={disabledTranslation && disabled ? disabledTranslation.title : title}
     onClick={e => handleOnClick(e)}
-    isDisabled={disabled && !disabledTranslation}
+    disabled={disabled && !disabledTranslation}
     {...extraProps}>
     {disabledTranslation && disabled ? disabledTranslation.label : label}
   </Button>

--- a/packages/chakra/src/ChakraDragHandle.tsx
+++ b/packages/chakra/src/ChakraDragHandle.tsx
@@ -1,8 +1,8 @@
-import { DragHandleIcon } from '@chakra-ui/icons';
 import { IconButton } from '@chakra-ui/react';
 import type { ComponentPropsWithRef } from 'react';
 import * as React from 'react';
 import { forwardRef } from 'react';
+import { MdDragIndicator } from "react-icons/md";
 import type { DragHandleProps } from 'react-querybuilder';
 
 type IBP = ComponentPropsWithRef<typeof IconButton>;
@@ -34,11 +34,12 @@ export const ChakraDragHandle: React.ForwardRefExoticComponent<
   ) => (
     <span ref={dragRef} className={className} title={title}>
       <IconButton
-        isDisabled={disabled}
-        icon={<DragHandleIcon />}
+        disabled={disabled}
         aria-label={title ?? /* istanbul ignore next */ ''}
         {...extraProps}
-      />
+      >
+        <MdDragIndicator />
+      </IconButton>
     </span>
   )
 );

--- a/packages/chakra/src/ChakraNotToggle.tsx
+++ b/packages/chakra/src/ChakraNotToggle.tsx
@@ -1,8 +1,10 @@
-import { FormControl, FormLabel, Switch } from '@chakra-ui/react';
+import { Fieldset } from '@chakra-ui/react';
 import type { ComponentPropsWithoutRef } from 'react';
 import * as React from 'react';
 import { useId } from 'react';
 import type { NotToggleProps } from 'react-querybuilder';
+import { Switch } from './snippets/switch';
+import { Field } from './snippets/field';
 
 export type ChakraNotToggleProps = NotToggleProps & ComponentPropsWithoutRef<typeof Switch>;
 
@@ -26,23 +28,26 @@ export const ChakraNotToggle = ({
 
   return (
     <div style={{ display: 'inline-block' }}>
-      <FormControl
+      <Fieldset.Root
         display="flex"
         alignItems="center"
         className={className}
         title={title}
-        isDisabled={disabled}>
-        <Switch
-          id={id}
-          isChecked={checked}
-          isDisabled={disabled}
-          onChange={e => handleOnChange(e.target.checked)}
-          {...extraProps}
-        />
-        <FormLabel htmlFor={id} marginBottom={0}>
-          {label}
-        </FormLabel>
-      </FormControl>
+        disabled={disabled}
+      >
+        <Fieldset.Content>
+          <Switch
+            id={id}
+            checked={checked}
+            disabled={disabled}
+            onChange={e => handleOnChange(e.target.checked)}
+            {...extraProps}
+          />
+          <Field marginBottom={0} htmlFor={id}>
+            {label}
+          </Field>
+        </Fieldset.Content>
+      </Fieldset.Root>
     </div>
   );
 };

--- a/packages/chakra/src/ChakraShiftActions.tsx
+++ b/packages/chakra/src/ChakraShiftActions.tsx
@@ -14,11 +14,11 @@ export const ChakraShiftActions = ({
   testID,
 }: ShiftActionsProps): React.JSX.Element => (
   <div data-testid={testID} className={className}>
-    <Button isDisabled={disabled || shiftUpDisabled} onClick={shiftUp} title={titles?.shiftUp}>
+    <Button disabled={disabled || shiftUpDisabled} onClick={shiftUp} title={titles?.shiftUp}>
       {labels?.shiftUp}
     </Button>
     <Button
-      isDisabled={disabled || shiftDownDisabled}
+      disabled={disabled || shiftDownDisabled}
       onClick={shiftDown}
       title={titles?.shiftDown}>
       {labels?.shiftDown}

--- a/packages/chakra/src/ChakraValueEditor.tsx
+++ b/packages/chakra/src/ChakraValueEditor.tsx
@@ -1,7 +1,10 @@
-import { Checkbox, Input, Radio, RadioGroup, Stack, Switch, Textarea } from '@chakra-ui/react';
+import { Input, Stack, Textarea } from '@chakra-ui/react';
 import * as React from 'react';
 import type { ValueEditorProps } from 'react-querybuilder';
 import { ValueSelector, getFirstOption, useValueEditor } from 'react-querybuilder';
+import { Checkbox } from './snippets/checkbox';
+import { Radio, RadioGroup } from './snippets/radio';
+import { Switch } from './snippets/switch';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ChakraValueEditorProps = ValueEditorProps & { extraProps?: Record<string, any> };
@@ -47,7 +50,7 @@ export const ChakraValueEditor = (allProps: ChakraValueEditorProps): React.JSX.E
             key={key}
             type={inputTypeCoerced}
             value={valueAsArray[i] ?? ''}
-            isDisabled={disabled}
+            disabled={disabled}
             className={valueListItemClassName}
             placeholder={placeHolderText}
             onChange={e => multiValueHandler(e.target.value, i)}
@@ -111,7 +114,7 @@ export const ChakraValueEditor = (allProps: ChakraValueEditorProps): React.JSX.E
         <Textarea
           value={value}
           title={title}
-          isDisabled={disabled}
+          disabled={disabled}
           className={className}
           placeholder={placeHolderText}
           onChange={e => handleOnChange(e.target.value)}
@@ -123,9 +126,9 @@ export const ChakraValueEditor = (allProps: ChakraValueEditorProps): React.JSX.E
       return (
         <Switch
           className={className}
-          isChecked={!!value}
+          checked={!!value}
           title={title}
-          isDisabled={disabled}
+          disabled={disabled}
           onChange={e => handleOnChange(e.target.checked)}
           {...extraProps}
         />
@@ -136,9 +139,9 @@ export const ChakraValueEditor = (allProps: ChakraValueEditorProps): React.JSX.E
         <Checkbox
           className={className}
           title={title}
-          isDisabled={disabled}
+          disabled={disabled}
           onChange={e => handleOnChange(e.target.checked)}
-          isChecked={!!value}
+          checked={!!value}
           {...extraProps}
         />
       );
@@ -150,7 +153,7 @@ export const ChakraValueEditor = (allProps: ChakraValueEditorProps): React.JSX.E
           title={title}
           value={value}
           onChange={handleOnChange}
-          isDisabled={disabled}
+          disabled={disabled}
           {...extraProps}>
           <Stack direction="row">
             {values.map(v => (
@@ -168,7 +171,7 @@ export const ChakraValueEditor = (allProps: ChakraValueEditorProps): React.JSX.E
       type={inputTypeCoerced}
       value={value}
       title={title}
-      isDisabled={disabled}
+      disabled={disabled}
       className={className}
       placeholder={placeHolderText}
       onChange={e => handleOnChange(e.target.value)}

--- a/packages/chakra/src/ChakraValueSelector.tsx
+++ b/packages/chakra/src/ChakraValueSelector.tsx
@@ -1,11 +1,11 @@
-import { Select } from '@chakra-ui/react';
 import type { ComponentPropsWithoutRef } from 'react';
 import * as React from 'react';
 import type { VersatileSelectorProps } from 'react-querybuilder';
 import { toOptions } from './utils';
+import { NativeSelectRoot, NativeSelectField } from './snippets/native-select';
 
 export type ChakraValueSelectorProps = VersatileSelectorProps &
-  ComponentPropsWithoutRef<typeof Select>;
+  ComponentPropsWithoutRef<typeof NativeSelectRoot>;
 
 export const ChakraValueSelector = ({
   className,
@@ -30,13 +30,17 @@ export const ChakraValueSelector = ({
   schema: _schema,
   ...extraProps
 }: ChakraValueSelectorProps): React.JSX.Element => (
-  <Select
+  <NativeSelectRoot
     className={className}
     title={title}
-    value={value}
     disabled={disabled}
-    onChange={e => handleOnChange(e.target.value)}
-    {...extraProps}>
-    {toOptions(options)}
-  </Select>
+    {...extraProps}
+  >
+    <NativeSelectField
+      value={value}
+      onChange={e => handleOnChange(e.target.value)}
+    >
+      {toOptions(options)}
+    </NativeSelectField>
+  </NativeSelectRoot>
 );

--- a/packages/chakra/src/index.tsx
+++ b/packages/chakra/src/index.tsx
@@ -1,11 +1,11 @@
 import {
-  ChevronDownIcon,
-  ChevronUpIcon,
-  CloseIcon,
-  CopyIcon,
-  LockIcon,
-  UnlockIcon,
-} from '@chakra-ui/icons';
+  FaCopy,
+  FaChevronDown,
+  FaChevronUp,
+  FaTimes,
+  FaLock,
+  FaLockOpen,
+} from 'react-icons/fa';
 import * as React from 'react';
 import type {
   ControlElementsProp,
@@ -35,16 +35,16 @@ export const chakraControlElements: ControlElementsProp<FullField, string> = {
 };
 
 export const chakraTranslations: Partial<Translations> = {
-  removeGroup: { label: <CloseIcon /> },
-  removeRule: { label: <CloseIcon /> },
-  cloneRuleGroup: { label: <CopyIcon /> },
-  cloneRule: { label: <CopyIcon /> },
-  lockGroup: { label: <UnlockIcon /> },
-  lockRule: { label: <UnlockIcon /> },
-  lockGroupDisabled: { label: <LockIcon /> },
-  lockRuleDisabled: { label: <LockIcon /> },
-  shiftActionDown: { label: <ChevronDownIcon /> },
-  shiftActionUp: { label: <ChevronUpIcon /> },
+  removeGroup: { label: <FaTimes /> },
+  removeRule: { label: <FaTimes /> },
+  cloneRuleGroup: { label: <FaCopy /> },
+  cloneRule: { label: <FaCopy /> },
+  lockGroup: { label: <FaLockOpen /> },
+  lockRule: { label: <FaLockOpen /> },
+  lockGroupDisabled: { label: <FaLock /> },
+  lockRuleDisabled: { label: <FaLock /> },
+  shiftActionDown: { label: <FaChevronDown /> },
+  shiftActionUp: { label: <FaChevronUp /> },
 };
 
 export const QueryBuilderChakra: QueryBuilderContextProvider = getCompatContextProvider({

--- a/packages/chakra/src/snippets/button.tsx
+++ b/packages/chakra/src/snippets/button.tsx
@@ -1,0 +1,40 @@
+import type { ButtonProps as ChakraButtonProps } from "@chakra-ui/react"
+import {
+  AbsoluteCenter,
+  Button as ChakraButton,
+  Span,
+  Spinner,
+} from "@chakra-ui/react"
+import { forwardRef } from "react"
+
+interface ButtonLoadingProps {
+  loading?: boolean
+  loadingText?: React.ReactNode
+}
+
+export interface ButtonProps extends ChakraButtonProps, ButtonLoadingProps {}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  function Button(props, ref) {
+    const { loading, disabled, loadingText, children, ...rest } = props
+    return (
+      <ChakraButton disabled={loading || disabled} ref={ref} {...rest}>
+        {loading && !loadingText ? (
+          <>
+            <AbsoluteCenter display="inline-flex">
+              <Spinner size="inherit" color="inherit" />
+            </AbsoluteCenter>
+            <Span opacity={0}>{children}</Span>
+          </>
+        ) : loading && loadingText ? (
+          <>
+            <Spinner size="inherit" color="inherit" />
+            {loadingText}
+          </>
+        ) : (
+          children
+        )}
+      </ChakraButton>
+    )
+  },
+)

--- a/packages/chakra/src/snippets/button.tsx
+++ b/packages/chakra/src/snippets/button.tsx
@@ -1,18 +1,18 @@
-import type { ButtonProps as ChakraButtonProps } from "@chakra-ui/react"
+import type { ButtonProps as ChakraButtonProps } from '@chakra-ui/react'
 import {
   AbsoluteCenter,
   Button as ChakraButton,
   Span,
   Spinner,
-} from "@chakra-ui/react"
-import { forwardRef } from "react"
+} from '@chakra-ui/react'
+import { forwardRef } from 'react'
 
 interface ButtonLoadingProps {
   loading?: boolean
   loadingText?: React.ReactNode
 }
 
-export interface ButtonProps extends ChakraButtonProps, ButtonLoadingProps {}
+export interface ButtonProps extends ChakraButtonProps, ButtonLoadingProps { }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   function Button(props, ref) {

--- a/packages/chakra/src/snippets/checkbox.tsx
+++ b/packages/chakra/src/snippets/checkbox.tsx
@@ -1,0 +1,25 @@
+import { Checkbox as ChakraCheckbox } from "@chakra-ui/react"
+import { forwardRef } from "react"
+
+export interface CheckboxProps extends ChakraCheckbox.RootProps {
+  icon?: React.ReactNode
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>
+  rootRef?: React.Ref<HTMLLabelElement>
+}
+
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  function Checkbox(props, ref) {
+    const { icon, children, inputProps, rootRef, ...rest } = props
+    return (
+      <ChakraCheckbox.Root ref={rootRef} {...rest}>
+        <ChakraCheckbox.HiddenInput ref={ref} {...inputProps} />
+        <ChakraCheckbox.Control>
+          {icon || <ChakraCheckbox.Indicator />}
+        </ChakraCheckbox.Control>
+        {children != null && (
+          <ChakraCheckbox.Label>{children}</ChakraCheckbox.Label>
+        )}
+      </ChakraCheckbox.Root>
+    )
+  },
+)

--- a/packages/chakra/src/snippets/checkbox.tsx
+++ b/packages/chakra/src/snippets/checkbox.tsx
@@ -1,5 +1,5 @@
-import { Checkbox as ChakraCheckbox } from "@chakra-ui/react"
-import { forwardRef } from "react"
+import { Checkbox as ChakraCheckbox } from '@chakra-ui/react'
+import { forwardRef } from 'react'
 
 export interface CheckboxProps extends ChakraCheckbox.RootProps {
   icon?: React.ReactNode

--- a/packages/chakra/src/snippets/color-mode.tsx
+++ b/packages/chakra/src/snippets/color-mode.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import type { IconButtonProps } from "@chakra-ui/react"
+import { ClientOnly, IconButton, Skeleton } from "@chakra-ui/react"
+import { ThemeProvider, useTheme } from "next-themes"
+import type { ThemeProviderProps } from "next-themes/dist/types"
+import { forwardRef } from "react"
+import { LuMoon, LuSun } from "react-icons/lu"
+
+export function ColorModeProvider(props: ThemeProviderProps) {
+  return (
+    <ThemeProvider attribute="class" disableTransitionOnChange {...props} />
+  )
+}
+
+export function useColorMode() {
+  const { resolvedTheme, setTheme } = useTheme()
+  const toggleColorMode = () => {
+    setTheme(resolvedTheme === "light" ? "dark" : "light")
+  }
+  return {
+    colorMode: resolvedTheme,
+    setColorMode: setTheme,
+    toggleColorMode,
+  }
+}
+
+export function useColorModeValue<T>(light: T, dark: T) {
+  const { colorMode } = useColorMode()
+  return colorMode === "light" ? light : dark
+}
+
+export function ColorModeIcon() {
+  const { colorMode } = useColorMode()
+  return colorMode === "light" ? <LuSun /> : <LuMoon />
+}
+
+interface ColorModeButtonProps extends Omit<IconButtonProps, "aria-label"> {}
+
+export const ColorModeButton = forwardRef<
+  HTMLButtonElement,
+  ColorModeButtonProps
+>(function ColorModeButton(props, ref) {
+  const { toggleColorMode } = useColorMode()
+  return (
+    <ClientOnly fallback={<Skeleton boxSize="8" />}>
+      <IconButton
+        onClick={toggleColorMode}
+        variant="ghost"
+        aria-label="Toggle color mode"
+        size="sm"
+        ref={ref}
+        {...props}
+        css={{
+          _icon: {
+            width: "5",
+            height: "5",
+          },
+        }}
+      >
+        <ColorModeIcon />
+      </IconButton>
+    </ClientOnly>
+  )
+})

--- a/packages/chakra/src/snippets/color-mode.tsx
+++ b/packages/chakra/src/snippets/color-mode.tsx
@@ -1,65 +1,10 @@
-"use client"
+'use client'
 
-import type { IconButtonProps } from "@chakra-ui/react"
-import { ClientOnly, IconButton, Skeleton } from "@chakra-ui/react"
-import { ThemeProvider, useTheme } from "next-themes"
-import type { ThemeProviderProps } from "next-themes/dist/types"
-import { forwardRef } from "react"
-import { LuMoon, LuSun } from "react-icons/lu"
+import { ThemeProvider, useTheme } from 'next-themes'
+import type { ThemeProviderProps } from 'next-themes/dist/types'
 
 export function ColorModeProvider(props: ThemeProviderProps) {
   return (
     <ThemeProvider attribute="class" disableTransitionOnChange {...props} />
   )
 }
-
-export function useColorMode() {
-  const { resolvedTheme, setTheme } = useTheme()
-  const toggleColorMode = () => {
-    setTheme(resolvedTheme === "light" ? "dark" : "light")
-  }
-  return {
-    colorMode: resolvedTheme,
-    setColorMode: setTheme,
-    toggleColorMode,
-  }
-}
-
-export function useColorModeValue<T>(light: T, dark: T) {
-  const { colorMode } = useColorMode()
-  return colorMode === "light" ? light : dark
-}
-
-export function ColorModeIcon() {
-  const { colorMode } = useColorMode()
-  return colorMode === "light" ? <LuSun /> : <LuMoon />
-}
-
-interface ColorModeButtonProps extends Omit<IconButtonProps, "aria-label"> {}
-
-export const ColorModeButton = forwardRef<
-  HTMLButtonElement,
-  ColorModeButtonProps
->(function ColorModeButton(props, ref) {
-  const { toggleColorMode } = useColorMode()
-  return (
-    <ClientOnly fallback={<Skeleton boxSize="8" />}>
-      <IconButton
-        onClick={toggleColorMode}
-        variant="ghost"
-        aria-label="Toggle color mode"
-        size="sm"
-        ref={ref}
-        {...props}
-        css={{
-          _icon: {
-            width: "5",
-            height: "5",
-          },
-        }}
-      >
-        <ColorModeIcon />
-      </IconButton>
-    </ClientOnly>
-  )
-})

--- a/packages/chakra/src/snippets/field.tsx
+++ b/packages/chakra/src/snippets/field.tsx
@@ -1,0 +1,33 @@
+import { Field as ChakraField } from "@chakra-ui/react"
+import { forwardRef } from "react"
+
+export interface FieldProps extends Omit<ChakraField.RootProps, "label"> {
+  label?: React.ReactNode
+  helperText?: React.ReactNode
+  errorText?: React.ReactNode
+  optionalText?: React.ReactNode
+}
+
+export const Field = forwardRef<HTMLDivElement, FieldProps>(
+  function Field(props, ref) {
+    const { label, children, helperText, errorText, optionalText, ...rest } =
+      props
+    return (
+      <ChakraField.Root ref={ref} {...rest}>
+        {label && (
+          <ChakraField.Label>
+            {label}
+            <ChakraField.RequiredIndicator fallback={optionalText} />
+          </ChakraField.Label>
+        )}
+        {children}
+        {helperText && (
+          <ChakraField.HelperText>{helperText}</ChakraField.HelperText>
+        )}
+        {errorText && (
+          <ChakraField.ErrorText>{errorText}</ChakraField.ErrorText>
+        )}
+      </ChakraField.Root>
+    )
+  },
+)

--- a/packages/chakra/src/snippets/field.tsx
+++ b/packages/chakra/src/snippets/field.tsx
@@ -1,7 +1,7 @@
-import { Field as ChakraField } from "@chakra-ui/react"
-import { forwardRef } from "react"
+import { Field as ChakraField } from '@chakra-ui/react'
+import { forwardRef } from 'react'
 
-export interface FieldProps extends Omit<ChakraField.RootProps, "label"> {
+export interface FieldProps extends Omit<ChakraField.RootProps, 'label'> {
   label?: React.ReactNode
   helperText?: React.ReactNode
   errorText?: React.ReactNode

--- a/packages/chakra/src/snippets/native-select.tsx
+++ b/packages/chakra/src/snippets/native-select.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { NativeSelect as Select } from "@chakra-ui/react"
+import { forwardRef, useMemo } from "react"
+
+interface NativeSelectRootProps extends Select.RootProps {
+  icon?: React.ReactNode
+}
+
+export const NativeSelectRoot = forwardRef<
+  HTMLDivElement,
+  NativeSelectRootProps
+>(function NativeSelect(props, ref) {
+  const { icon, children, ...rest } = props
+  return (
+    <Select.Root ref={ref} {...rest}>
+      {children}
+      <Select.Indicator>{icon}</Select.Indicator>
+    </Select.Root>
+  )
+})
+
+interface NativeSelectItem {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+interface NativeSelectField extends Select.FieldProps {
+  items?: Array<string | NativeSelectItem>
+}
+
+export const NativeSelectField = forwardRef<
+  HTMLSelectElement,
+  NativeSelectField
+>(function NativeSelectField(props, ref) {
+  const { items: itemsProp, children, ...rest } = props
+
+  const items = useMemo(
+    () =>
+      itemsProp?.map((item) =>
+        typeof item === "string" ? { label: item, value: item } : item,
+      ),
+    [itemsProp],
+  )
+
+  return (
+    <Select.Field ref={ref} {...rest}>
+      {children}
+      {items?.map((item) => (
+        <option key={item.value} value={item.value} disabled={item.disabled}>
+          {item.label}
+        </option>
+      ))}
+    </Select.Field>
+  )
+})

--- a/packages/chakra/src/snippets/native-select.tsx
+++ b/packages/chakra/src/snippets/native-select.tsx
@@ -1,7 +1,7 @@
-"use client"
+'use client'
 
-import { NativeSelect as Select } from "@chakra-ui/react"
-import { forwardRef, useMemo } from "react"
+import { NativeSelect as Select } from '@chakra-ui/react'
+import { forwardRef, useMemo } from 'react'
 
 interface NativeSelectRootProps extends Select.RootProps {
   icon?: React.ReactNode
@@ -39,7 +39,7 @@ export const NativeSelectField = forwardRef<
   const items = useMemo(
     () =>
       itemsProp?.map((item) =>
-        typeof item === "string" ? { label: item, value: item } : item,
+        typeof item === 'string' ? { label: item, value: item } : item,
       ),
     [itemsProp],
   )

--- a/packages/chakra/src/snippets/provider.tsx
+++ b/packages/chakra/src/snippets/provider.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { ChakraProvider, createSystem, defaultConfig } from "@chakra-ui/react"
+import { ColorModeProvider } from "./color-mode"
+
+const chakraTheme = createSystem(defaultConfig, {
+  theme: {
+    recipes: {
+      button: {
+        // baseStyle: {
+        //   color: 'rebeccapurple',
+        //   fontWeight: 'bold', // Normally "semibold"
+        // },
+      },
+    },
+  },
+  // config: {
+  //   initialColorMode: 'light',
+  //   useSystemColorMode: false,
+  // },
+});
+
+export function Provider(props: React.PropsWithChildren) {
+  return (
+    <ChakraProvider value={chakraTheme}>
+      <ColorModeProvider>{props.children}</ColorModeProvider>
+    </ChakraProvider>
+  )
+}

--- a/packages/chakra/src/snippets/provider.tsx
+++ b/packages/chakra/src/snippets/provider.tsx
@@ -1,23 +1,21 @@
-"use client"
+'use client'
 
-import { ChakraProvider, createSystem, defaultConfig } from "@chakra-ui/react"
-import { ColorModeProvider } from "./color-mode"
+import { ChakraProvider, createSystem, defaultConfig, defineRecipe } from '@chakra-ui/react'
+import { ColorModeProvider } from './color-mode'
+
+const buttonRecipe = defineRecipe({
+  base: {
+    color: 'rebeccapurple',
+    fontWeight: 'bold', // Normally "semibold"
+  },
+})
 
 const chakraTheme = createSystem(defaultConfig, {
   theme: {
     recipes: {
-      button: {
-        // baseStyle: {
-        //   color: 'rebeccapurple',
-        //   fontWeight: 'bold', // Normally "semibold"
-        // },
-      },
+      button: buttonRecipe,
     },
   },
-  // config: {
-  //   initialColorMode: 'light',
-  //   useSystemColorMode: false,
-  // },
 });
 
 export function Provider(props: React.PropsWithChildren) {

--- a/packages/chakra/src/snippets/radio.tsx
+++ b/packages/chakra/src/snippets/radio.tsx
@@ -1,5 +1,5 @@
-import { RadioGroup as ChakraRadioGroup } from "@chakra-ui/react"
-import { forwardRef } from "react"
+import { RadioGroup as ChakraRadioGroup } from '@chakra-ui/react'
+import { forwardRef } from 'react'
 
 export interface RadioProps extends ChakraRadioGroup.ItemProps {
   rootRef?: React.Ref<HTMLDivElement>

--- a/packages/chakra/src/snippets/radio.tsx
+++ b/packages/chakra/src/snippets/radio.tsx
@@ -1,0 +1,26 @@
+import { RadioGroup as ChakraRadioGroup } from "@chakra-ui/react"
+import { forwardRef } from "react"
+
+export interface RadioProps extends ChakraRadioGroup.ItemProps {
+  rootRef?: React.Ref<HTMLDivElement>
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>
+  children?: React.ReactNode
+  value?: string
+}
+
+export const Radio = forwardRef<HTMLInputElement, RadioProps>(
+  function Radio(props, ref) {
+    const { children, inputProps, rootRef, ...rest } = props
+    return (
+      <ChakraRadioGroup.Item ref={rootRef} {...rest}>
+        <ChakraRadioGroup.ItemHiddenInput ref={ref} {...inputProps} />
+        <ChakraRadioGroup.ItemIndicator />
+        {children && (
+          <ChakraRadioGroup.ItemText>{children}</ChakraRadioGroup.ItemText>
+        )}
+      </ChakraRadioGroup.Item>
+    )
+  },
+)
+
+export const RadioGroup = ChakraRadioGroup.Root

--- a/packages/chakra/src/snippets/switch.tsx
+++ b/packages/chakra/src/snippets/switch.tsx
@@ -1,0 +1,39 @@
+import { Switch as ChakraSwitch } from "@chakra-ui/react"
+import { forwardRef } from "react"
+
+export interface SwitchProps extends ChakraSwitch.RootProps {
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>
+  rootRef?: React.Ref<HTMLLabelElement>
+  trackLabel?: { on: React.ReactNode; off: React.ReactNode }
+  thumbLabel?: { on: React.ReactNode; off: React.ReactNode }
+}
+
+export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
+  function Switch(props, ref) {
+    const { inputProps, children, rootRef, trackLabel, thumbLabel, ...rest } =
+      props
+
+    return (
+      <ChakraSwitch.Root ref={rootRef} {...rest}>
+        <ChakraSwitch.HiddenInput ref={ref} {...inputProps} />
+        <ChakraSwitch.Control>
+          <ChakraSwitch.Thumb>
+            {thumbLabel && (
+              <ChakraSwitch.ThumbIndicator fallback={thumbLabel?.off}>
+                {thumbLabel?.on}
+              </ChakraSwitch.ThumbIndicator>
+            )}
+          </ChakraSwitch.Thumb>
+          {trackLabel && (
+            <ChakraSwitch.Indicator fallback={trackLabel.off}>
+              {trackLabel.on}
+            </ChakraSwitch.Indicator>
+          )}
+        </ChakraSwitch.Control>
+        {children != null && (
+          <ChakraSwitch.Label>{children}</ChakraSwitch.Label>
+        )}
+      </ChakraSwitch.Root>
+    )
+  },
+)

--- a/packages/chakra/src/snippets/switch.tsx
+++ b/packages/chakra/src/snippets/switch.tsx
@@ -1,5 +1,5 @@
-import { Switch as ChakraSwitch } from "@chakra-ui/react"
-import { forwardRef } from "react"
+import { Switch as ChakraSwitch } from '@chakra-ui/react'
+import { forwardRef } from 'react'
 
 export interface SwitchProps extends ChakraSwitch.RootProps {
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>


### PR DESCRIPTION
Wanted to get the ball rolling on supporting chakra-ui v3!

There have been some changes in v3 that removed some of the built-in components chakra originally offered in favor of a snippet based system. In this approach I premade the snippets in the `packages/chakra/src/snippets` directory, and replaced the relevant `@chakra/icons` (now deprecated) with equivalents from `react-icons`.

This PR needs some work still, but wanted to open a draft to determine if this is the route the maintainers would like to move in.

Closes #802 