### PR TITLE
Respect `parseNumbers: false` for "between" operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - New parser option `bigIntOnOverflow`. When true, a `bigint` will be generated for parsed tokens that represent valid integers outside the safe boundaries of the `number` type. (This currently only applies to `parseSQL`.)
+- [#911] Support for `inputType: "bigint"` in all value editors, which will render a "text"-type input but will store the value as a `bigint` if a valid integer is entered.
 
 #### Fixed
 
@@ -1926,6 +1927,7 @@ Maintenance release focused on converting to a monorepo with Vite driving the bu
 [#890]: https://github.com/react-querybuilder/react-querybuilder/pull/890
 [#891]: https://github.com/react-querybuilder/react-querybuilder/pull/891
 [#893]: https://github.com/react-querybuilder/react-querybuilder/pull/893
+[#911]: https://github.com/react-querybuilder/react-querybuilder/pull/911
 
 <!-- #endregion -->
 

--- a/packages/antd/src/AntDValueEditor.tsx
+++ b/packages/antd/src/AntDValueEditor.tsx
@@ -28,6 +28,7 @@ export const AntDValueEditor = (allProps: AntDValueEditorProps): React.JSX.Eleme
     title,
     className,
     type,
+    inputType,
     values = [],
     listsAsArrays,
     separator,
@@ -36,13 +37,17 @@ export const AntDValueEditor = (allProps: AntDValueEditorProps): React.JSX.Eleme
     testID,
     selectorComponent: SelectorComponent = allProps.schema.controls.valueSelector,
     extraProps,
-    inputType: _inputType,
     parseNumbers: _parseNumbers,
     ...propsForValueSelector
   } = allProps;
 
-  const { valueAsArray, multiValueHandler, valueListItemClassName, inputTypeCoerced } =
-    useValueEditor(allProps);
+  const {
+    valueAsArray,
+    multiValueHandler,
+    bigIntValueHandler,
+    valueListItemClassName,
+    inputTypeCoerced,
+  } = useValueEditor(allProps);
 
   if (operator === 'null' || operator === 'notNull') {
     return null;
@@ -257,6 +262,22 @@ export const AntDValueEditor = (allProps: AntDValueEditorProps): React.JSX.Eleme
         />
       );
     }
+  }
+
+  if (inputType === 'bigint') {
+    return (
+      <Input
+        data-testid={testID}
+        type={inputTypeCoerced}
+        placeholder={placeHolderText}
+        value={`${value}`}
+        title={title}
+        className={className}
+        disabled={disabled}
+        onChange={e => bigIntValueHandler(e.target.value)}
+        {...extraProps}
+      />
+    );
   }
 
   return (

--- a/packages/chakra/src/ChakraValueEditor.tsx
+++ b/packages/chakra/src/ChakraValueEditor.tsx
@@ -25,6 +25,7 @@ export const ChakraValueEditor = (allProps: ChakraValueEditorProps): React.JSX.E
     title,
     className,
     type,
+    inputType,
     values = [],
     listsAsArrays: _listsAsArrays,
     separator,
@@ -33,13 +34,17 @@ export const ChakraValueEditor = (allProps: ChakraValueEditorProps): React.JSX.E
     disabled,
     selectorComponent: SelectorComponent = allProps.schema.controls.valueSelector,
     extraProps,
-    inputType: _inputType,
     parseNumbers: _parseNumbers,
     ...propsForValueSelector
   } = allProps;
 
-  const { valueAsArray, multiValueHandler, valueListItemClassName, inputTypeCoerced } =
-    useValueEditor(allProps);
+  const {
+    valueAsArray,
+    multiValueHandler,
+    bigIntValueHandler,
+    valueListItemClassName,
+    inputTypeCoerced,
+  } = useValueEditor(allProps);
 
   if (operator === 'null' || operator === 'notNull') {
     return null;
@@ -152,6 +157,22 @@ export const ChakraValueEditor = (allProps: ChakraValueEditorProps): React.JSX.E
           </Stack>
         </RadioGroup>
       );
+  }
+
+  if (inputType === 'bigint') {
+    return (
+      <Input
+        data-testid={testID}
+        type={inputTypeCoerced}
+        placeholder={placeHolderText}
+        value={`${value}`}
+        title={title}
+        className={className}
+        disabled={disabled}
+        onChange={e => bigIntValueHandler(e.target.value)}
+        {...extraProps}
+      />
+    );
   }
 
   return (

--- a/packages/fluent/src/FluentValueEditor.tsx
+++ b/packages/fluent/src/FluentValueEditor.tsx
@@ -23,6 +23,7 @@ export const FluentValueEditor = (allProps: FluentValueEditorProps): React.JSX.E
     title,
     className,
     type,
+    inputType,
     values = [],
     listsAsArrays: _listsAsArrays,
     separator,
@@ -32,13 +33,17 @@ export const FluentValueEditor = (allProps: FluentValueEditorProps): React.JSX.E
     selectorComponent: _SelectorComponent,
     validation: _validation,
     extraProps,
-    inputType: _inputType,
     parseNumbers: _parseNumbers,
     ..._propsForValueSelector
   } = allProps;
 
-  const { valueAsArray, multiValueHandler, valueListItemClassName, inputTypeCoerced } =
-    useValueEditor(allProps);
+  const {
+    valueAsArray,
+    multiValueHandler,
+    bigIntValueHandler,
+    valueListItemClassName,
+    inputTypeCoerced,
+  } = useValueEditor(allProps);
 
   if (operator === 'null' || operator === 'notNull') {
     return null;
@@ -131,6 +136,22 @@ export const FluentValueEditor = (allProps: FluentValueEditorProps): React.JSX.E
           ))}
         </RadioGroup>
       );
+  }
+
+  if (inputType === 'bigint') {
+    return (
+      <Input
+        data-testid={testID}
+        type={inputTypeCoerced as InputProps['type']}
+        placeholder={placeHolderText}
+        value={`${value}`}
+        title={title}
+        className={className}
+        disabled={disabled}
+        onChange={e => bigIntValueHandler(e.target.value)}
+        {...extraProps}
+      />
+    );
   }
 
   return (

--- a/packages/mantine/src/MantineValueEditor.tsx
+++ b/packages/mantine/src/MantineValueEditor.tsx
@@ -38,13 +38,18 @@ export const MantineValueEditor = (allProps: MantineValueEditorProps): React.JSX
     selectorComponent: SelectorComponent = allProps.schema.controls.valueSelector,
     validation: _validation,
     extraProps,
-    inputType: _inputType,
+    inputType,
     parseNumbers: _parseNumbers,
     ...propsForValueSelector
   } = allProps;
 
-  const { valueAsArray, multiValueHandler, valueListItemClassName, inputTypeCoerced } =
-    useValueEditor(allProps);
+  const {
+    valueAsArray,
+    multiValueHandler,
+    valueListItemClassName,
+    inputTypeCoerced,
+    bigIntValueHandler,
+  } = useValueEditor(allProps);
 
   if (operator === 'null' || operator === 'notNull') {
     return null;
@@ -243,6 +248,22 @@ export const MantineValueEditor = (allProps: MantineValueEditorProps): React.JSX
           handleOnChange(d ? dayjs(d).format(dateFormat) : /* istanbul ignore next */ '')
         }
         popoverProps={{ withinPortal: false }}
+        {...extraProps}
+      />
+    );
+  }
+
+  if (inputType === 'bigint') {
+    return (
+      <TextInput
+        data-testid={testID}
+        type={inputTypeCoerced}
+        placeholder={placeHolderText}
+        value={`${value}`}
+        title={title}
+        className={className}
+        disabled={disabled}
+        onChange={e => bigIntValueHandler(e.target.value)}
         {...extraProps}
       />
     );

--- a/packages/material/src/MaterialValueEditor.tsx
+++ b/packages/material/src/MaterialValueEditor.tsx
@@ -28,6 +28,7 @@ export const MaterialValueEditor = (props: MaterialValueEditorProps): React.JSX.
     title,
     className,
     type,
+    inputType,
     path,
     level,
     values = [],
@@ -39,7 +40,6 @@ export const MaterialValueEditor = (props: MaterialValueEditorProps): React.JSX.
     selectorComponent: SelectorComponent = props.schema.controls
       .valueSelector as typeof MaterialValueSelector,
     extraProps,
-    inputType: _inputType,
     parseNumbers: _parseNumbers,
     ...propsForValueSelector
   } = propsForValueEditor;
@@ -47,6 +47,7 @@ export const MaterialValueEditor = (props: MaterialValueEditorProps): React.JSX.
   const {
     valueAsArray,
     multiValueHandler,
+    bigIntValueHandler,
     parseNumberMethod,
     valueListItemClassName,
     inputTypeCoerced,
@@ -214,6 +215,22 @@ export const MaterialValueEditor = (props: MaterialValueEditorProps): React.JSX.
    * "date", "datetime-local", and "time", with components from `@mui/x-date-pickers`
    * (`<DatePicker />`, `<DateTimePicker />`, and `<TimePicker />`, respecitively).
    */
+
+  if (inputType === 'bigint') {
+    return (
+      <TextField
+        data-testid={testID}
+        type={inputTypeCoerced}
+        placeholder={placeHolderText}
+        value={`${value}`}
+        title={title}
+        className={className}
+        disabled={disabled}
+        onChange={e => bigIntValueHandler(e.target.value)}
+        {...extraProps}
+      />
+    );
+  }
 
   return (
     <TextField

--- a/packages/react-querybuilder/src/components/ValueEditor.tsx
+++ b/packages/react-querybuilder/src/components/ValueEditor.tsx
@@ -21,6 +21,7 @@ export const ValueEditor = <F extends FullField>(
     title,
     className,
     type = 'text',
+    inputType,
     values = [],
     listsAsArrays,
     fieldData,
@@ -32,7 +33,6 @@ export const ValueEditor = <F extends FullField>(
     // we cherry pick these out of `propsForValueSelector` to keep them from being
     // assigned to DOM elements. (The props with mixed case are the only ones that
     // really matter. Props in all lowercase don't emit warnings.)
-    inputType: _inputType,
     parseNumbers: _parseNumbers,
     skipHook: _skipHook,
     valueSource: _valueSource,
@@ -42,6 +42,7 @@ export const ValueEditor = <F extends FullField>(
   const {
     valueAsArray,
     multiValueHandler,
+    bigIntValueHandler,
     parseNumberMethod,
     valueListItemClassName,
     inputTypeCoerced,
@@ -160,6 +161,23 @@ export const ValueEditor = <F extends FullField>(
       );
   }
 
+  // Note that we don't use `inputTypeCoerced` for this condition.
+  // We need to know that its uncoerced value is "bigint".
+  if (inputType === 'bigint') {
+    return (
+      <input
+        data-testid={testID}
+        type={inputTypeCoerced}
+        placeholder={placeHolderText}
+        value={`${value}`}
+        title={title}
+        className={className}
+        disabled={disabled}
+        onChange={e => bigIntValueHandler(e.target.value)}
+      />
+    );
+  }
+
   return (
     <input
       data-testid={testID}
@@ -175,6 +193,44 @@ export const ValueEditor = <F extends FullField>(
     />
   );
 };
+
+export interface UseValueEditor {
+  /**
+   * Array of values for when the main value represents a list, e.g. when operator
+   * is "between" or "in".
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  valueAsArray: any[];
+  /**
+   * An update handler for a series of value editors, e.g. when operator is "between".
+   * Calling this function will update a single element of the value array and leave
+   * the rest of the array as is.
+   *
+   * @param {string} val The new value for the editor
+   * @param {number} idx The index of the editor (and the array element to update)
+   */
+  multiValueHandler: (val: unknown, idx: number) => void;
+  /**
+   * An update handler for bigint editors, e.g. when `inputType` is "bigint" and
+   * `parseNumbersMethod` is truthy.
+   */
+  bigIntValueHandler: (val: unknown) => void;
+  /**
+   * Evaluated `parseNumber` method based on `parseNumbers` prop. This property ends up
+   * being the same as the `parseNumbers` prop minus the "-limited" suffix, unless
+   * the "-limited" suffix is present and the `inputType` is not "number", in which case
+   * it's set to `false`.
+   */
+  parseNumberMethod: ParseNumberMethod;
+  /**
+   * Class for items in a value editor series (e.g. "between" value editors).
+   */
+  valueListItemClassName: string;
+  /**
+   * Coerced `inputType` based on `inputType` and `operator`.
+   */
+  inputTypeCoerced: InputType;
+}
 
 /**
  * This hook is primarily concerned with multi-value editors like date range
@@ -210,39 +266,7 @@ export const ValueEditor = <F extends FullField>(
  */
 export const useValueEditor = <F extends FullField = FullField, O extends string = string>(
   props: ValueEditorProps<F, O>
-): {
-  /**
-   * Array of values for when the main value represents a list, e.g. when operator
-   * is "between" or "in".
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  valueAsArray: any[];
-  /**
-   * An update handler for a series of value editors, e.g. when operator is "between".
-   * Calling this function will update a single element of the value array and leave
-   * the rest of the array as is.
-   *
-   * @param {string} val The new value for the editor
-   * @param {number} idx The index of the editor (and the array element to update)
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  multiValueHandler: (val: any, idx: number) => void;
-  /**
-   * Evaluated `parseNumber` method based on `parseNumbers` prop. This property ends up
-   * being the same as the `parseNumbers` prop minus the "-limited" suffix, unless
-   * the "-limited" suffix is present and the `inputType` is not "number", in which case
-   * it's set to `false`.
-   */
-  parseNumberMethod: ParseNumberMethod;
-  /**
-   * Class for items in a value editor series (e.g. "between" value editors).
-   */
-  valueListItemClassName: string;
-  /**
-   * Coerced `inputType` based on `inputType` and `operator`.
-   */
-  inputTypeCoerced: InputType;
-} => {
+): UseValueEditor => {
   const {
     handleOnChange,
     inputType,
@@ -294,17 +318,39 @@ export const useValueEditor = <F extends FullField = FullField, O extends string
     [handleOnChange, listsAsArrays, operator, parseNumberMethod, valueAsArray, values]
   );
 
+  const bigIntValueHandler = useCallback(
+    (v: unknown) => {
+      const valAsMaybeNumber = parseNumber(v, {
+        parseNumbers: parseNumberMethod,
+        bigIntOnOverflow: true,
+      });
+      let bi: bigint;
+      try {
+        bi = BigInt(valAsMaybeNumber);
+      } catch {
+        handleOnChange(valAsMaybeNumber);
+        return;
+      }
+      handleOnChange(bi);
+    },
+    [handleOnChange, parseNumberMethod]
+  );
+
   const valueListItemClassName = clsx(
     suppressStandardClassnames || standardClassnames.valueListItem,
     // Optional chaining is necessary for QueryBuilderNative
     classNamesProp?.valueListItem
   );
 
-  const inputTypeCoerced = operator === 'in' || operator === 'notIn' ? 'text' : inputType || 'text';
+  const inputTypeCoerced =
+    inputType === 'bigint' || operator === 'in' || operator === 'notIn'
+      ? 'text'
+      : inputType || 'text';
 
   return {
     valueAsArray,
     multiValueHandler,
+    bigIntValueHandler,
     parseNumberMethod,
     valueListItemClassName,
     inputTypeCoerced,

--- a/packages/react-querybuilder/src/types/basic.ts
+++ b/packages/react-querybuilder/src/types/basic.ts
@@ -82,6 +82,9 @@ export type InputType =
   | 'time'
   | 'url'
   | 'week'
+  // "bigint" is not supported by browsers directly, but it can
+  // be used to trigger alternate value editor functionality
+  | 'bigint'
   | (string & {});
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/react-querybuilder/src/types/export.ts
+++ b/packages/react-querybuilder/src/types/export.ts
@@ -329,11 +329,17 @@ export interface FormatQueryFinalOptions
   extends Required<
     Except<
       FormatQueryOptions,
-      'context' | 'valueProcessor' | 'validator' | 'placeholderValueName' | 'ruleGroupProcessor'
+      | 'context'
+      | 'valueProcessor'
+      | 'validator'
+      | 'placeholderValueName'
+      | 'ruleGroupProcessor'
+      | 'parseNumbers'
     >
   > {
   fields: FullOptionList<FullField>;
-  getParseNumberBoolean: (inputType?: InputType | null) => boolean;
+  getParseNumberBoolean: (inputType?: InputType | null) => boolean | undefined;
+  parseNumbers?: ParseNumbersPropConfig | undefined;
   placeholderValueName?: string | undefined;
   valueProcessor: ValueProcessorByRule;
   validator?: QueryValidator;

--- a/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.CEL.test.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.CEL.test.ts
@@ -137,3 +137,28 @@ it('preserveValueOrder', () => {
     `(f1 >= 12 && f1 <= 14) && (f2 >= 14 && f2 <= 12)`
   );
 });
+
+it('parseNumbers with between operators', () => {
+  const betweenQuery: RuleGroupType = {
+    combinator: 'and',
+    rules: [
+      { field: 'age', operator: 'between', value: '22,34' },
+      { field: 'score', operator: 'notBetween', value: ['10', '20'] },
+    ],
+  };
+
+  // Default behavior (backwards compatibility) - should parse numbers
+  expect(formatQuery(betweenQuery, { format: 'cel' })).toBe(
+    '(age >= 22 && age <= 34) && (score < 10 || score > 20)'
+  );
+
+  // Explicit parseNumbers: true - should parse numbers
+  expect(formatQuery(betweenQuery, { format: 'cel', parseNumbers: true })).toBe(
+    '(age >= 22 && age <= 34) && (score < 10 || score > 20)'
+  );
+
+  // parseNumbers: false - should NOT parse numbers (keep as strings)
+  expect(formatQuery(betweenQuery, { format: 'cel', parseNumbers: false })).toBe(
+    '(age >= "22" && age <= "34") && (score < "10" || score > "20")'
+  );
+});

--- a/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.Drizzle.test.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.Drizzle.test.ts
@@ -17,6 +17,7 @@ import {
   queryIC,
   queryWithValueSourceField,
 } from '../formatQueryTestUtils';
+import type { RuleGroupType } from '../../../types';
 
 const operatorStub = (...x: unknown[]) => x;
 
@@ -149,5 +150,28 @@ it('preserveValueOrder', () => {
       parseNumbers: true,
       preserveValueOrder: true,
     })(fields, drizzleOperators)
+  ).toBeTruthy();
+});
+
+it('parseNumbers with between operators', () => {
+  const betweenQuery: RuleGroupType = {
+    combinator: 'and',
+    rules: [
+      { field: 'age', operator: 'between', value: '22,34' },
+      { field: 'age', operator: 'notBetween', value: ['10', '20'] },
+    ],
+  };
+
+  // Default behavior (backwards compatibility) - should parse numbers
+  expect(formatQuery(betweenQuery, { format: 'drizzle' })(fields, drizzleOperators)).toBeTruthy();
+
+  // Explicit parseNumbers: true - should parse numbers
+  expect(
+    formatQuery(betweenQuery, { format: 'drizzle', parseNumbers: true })(fields, drizzleOperators)
+  ).toBeTruthy();
+
+  // parseNumbers: false - should NOT parse numbers (keep as strings)
+  expect(
+    formatQuery(betweenQuery, { format: 'drizzle', parseNumbers: false })(fields, drizzleOperators)
   ).toBeTruthy();
 });

--- a/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.ElasticSearch.test.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.ElasticSearch.test.ts
@@ -1,4 +1,8 @@
-import type { FormatQueryOptions, RuleProcessor } from '../../../types/index.noReact';
+import type {
+  FormatQueryOptions,
+  RuleGroupType,
+  RuleProcessor,
+} from '../../../types/index.noReact';
 import { defaultRuleProcessorElasticSearch } from '../defaultRuleProcessorElasticSearch';
 import { formatQuery } from '../formatQuery';
 import {
@@ -356,6 +360,46 @@ it('preserveValueOrder', () => {
   ).toEqual({
     bool: {
       must: [{ range: { f1: { gte: 12, lte: 14 } } }, { range: { f2: { gte: 14, lte: 12 } } }],
+    },
+  });
+});
+
+it('parseNumbers with between operators', () => {
+  const betweenQuery: RuleGroupType = {
+    combinator: 'and',
+    rules: [
+      { field: 'age', operator: 'between', value: '22,34' },
+      { field: 'score', operator: 'notBetween', value: ['10', '20'] },
+    ],
+  };
+
+  // Default behavior (backwards compatibility) - should parse numbers
+  expect(formatQuery(betweenQuery, { format: 'elasticsearch' })).toEqual({
+    bool: {
+      must: [
+        { range: { age: { gte: 22, lte: 34 } } },
+        { bool: { must_not: { range: { score: { gte: 10, lte: 20 } } } } },
+      ],
+    },
+  });
+
+  // Explicit parseNumbers: true - should parse numbers
+  expect(formatQuery(betweenQuery, { format: 'elasticsearch', parseNumbers: true })).toEqual({
+    bool: {
+      must: [
+        { range: { age: { gte: 22, lte: 34 } } },
+        { bool: { must_not: { range: { score: { gte: 10, lte: 20 } } } } },
+      ],
+    },
+  });
+
+  // parseNumbers: false - should NOT parse numbers (keep as strings)
+  expect(formatQuery(betweenQuery, { format: 'elasticsearch', parseNumbers: false })).toEqual({
+    bool: {
+      must: [
+        { range: { age: { gte: '22', lte: '34' } } },
+        { bool: { must_not: { range: { score: { gte: '10', lte: '20' } } } } },
+      ],
     },
   });
 });

--- a/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.JSONata.test.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.JSONata.test.ts
@@ -170,3 +170,29 @@ it('preserveValueOrder', () => {
     })
   ).toBe(`(f1 >= 12 and f1 <= 14) and (f2 >= 14 and f2 <= 12)`);
 });
+
+it('parseNumbers with between operators', () => {
+  const betweenQuery: RuleGroupType = {
+    combinator: 'and',
+    rules: [
+      { field: 'age', operator: 'between', value: '22,34' },
+      { field: 'score', operator: 'notBetween', value: ['10', '20'] },
+    ],
+  };
+
+  // Default behavior (backwards compatibility) - should NOT parse numbers
+  // TODO: JSONata always did this correctly?
+  expect(formatQuery(betweenQuery, { format: 'jsonata' })).toBe(
+    '(age >= "22" and age <= "34") and $not(score >= "10" and score <= "20")'
+  );
+
+  // Explicit parseNumbers: true - should parse numbers
+  expect(formatQuery(betweenQuery, { format: 'jsonata', parseNumbers: true })).toBe(
+    '(age >= 22 and age <= 34) and $not(score >= 10 and score <= 20)'
+  );
+
+  // parseNumbers: false - should NOT parse numbers (keep as strings)
+  expect(formatQuery(betweenQuery, { format: 'jsonata', parseNumbers: false })).toBe(
+    '(age >= "22" and age <= "34") and $not(score >= "10" and score <= "20")'
+  );
+});

--- a/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.JsonLogic.test.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.JsonLogic.test.ts
@@ -322,6 +322,31 @@ it('preserveValueOrder', () => {
   ).toEqual({ and: [{ '<=': [12, { var: 'f1' }, 14] }, { '<=': [14, { var: 'f2' }, 12] }] });
 });
 
+it('parseNumbers with between operators', () => {
+  const betweenQuery: RuleGroupType = {
+    combinator: 'and',
+    rules: [
+      { field: 'age', operator: 'between', value: '22,34' },
+      { field: 'score', operator: 'notBetween', value: ['10', '20'] },
+    ],
+  };
+
+  // Default behavior (backwards compatibility) - should parse numbers
+  expect(formatQuery(betweenQuery, { format: 'jsonlogic' })).toEqual({
+    and: [{ '<=': [22, { var: 'age' }, 34] }, { '!': { '<=': [10, { var: 'score' }, 20] } }],
+  });
+
+  // Explicit parseNumbers: true - should parse numbers
+  expect(formatQuery(betweenQuery, { format: 'jsonlogic', parseNumbers: true })).toEqual({
+    and: [{ '<=': [22, { var: 'age' }, 34] }, { '!': { '<=': [10, { var: 'score' }, 20] } }],
+  });
+
+  // parseNumbers: false - should NOT parse numbers (keep as strings)
+  expect(formatQuery(betweenQuery, { format: 'jsonlogic', parseNumbers: false })).toEqual({
+    and: [{ '<=': ['22', { var: 'age' }, '34'] }, { '!': { '<=': ['10', { var: 'score' }, '20'] } }],
+  });
+});
+
 it('runs the jsonLogic additional operators', () => {
   const { startsWith, endsWith } = jsonLogicAdditionalOperators;
   expect(startsWith('TestString', 'Test')).toBe(true);

--- a/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.Prisma.test.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.Prisma.test.ts
@@ -77,7 +77,7 @@ const prismaQueryExpectation = {
     { firstName: { gte: 'Test', lte: 'This' } },
     { firstName: { gte: 'Test', lte: 'This' } },
     { OR: [{ lastName: { lt: 'Test' } }, { lastName: { gt: 'This' } }] },
-    { age: { gte: 12, lte: 14 } },
+    { age: { gte: '12', lte: '14' } },
     { age: '26' },
     { isMusician: true },
     { isLucky: false },
@@ -87,9 +87,7 @@ const prismaQueryExpectation = {
     { NOT: { hello: { contains: 'com' } } },
     { NOT: { job: { startsWith: 'Man' } } },
     { NOT: { job: { endsWith: 'ger' } } },
-    {
-      OR: [{ job: 'Sales Executive' }, { job: { in: [] } }],
-    },
+    { OR: [{ job: 'Sales Executive' }, { job: { in: [] } }] },
   ],
 };
 
@@ -175,13 +173,23 @@ it('ruleProcessor', () => {
 it('preserveValueOrder', () => {
   testPrisma(
     queryForPreserveValueOrder,
-    { AND: [{ f1: { gte: 12, lte: 14 } }, { f2: { gte: 12, lte: 14 } }] },
+    { AND: [{ f1: { gte: '12', lte: '14' } }, { f2: { gte: '12', lte: '14' } }] },
     {}
   );
   testPrisma(
     queryForPreserveValueOrder,
-    { AND: [{ f1: { gte: 12, lte: 14 } }, { f2: { gte: 14, lte: 12 } }] },
+    { AND: [{ f1: { gte: '12', lte: '14' } }, { f2: { gte: '14', lte: '12' } }] },
     { preserveValueOrder: true }
+  );
+  testPrisma(
+    queryForPreserveValueOrder,
+    { AND: [{ f1: { gte: 12, lte: 14 } }, { f2: { gte: 12, lte: 14 } }] },
+    { parseNumbers: true }
+  );
+  testPrisma(
+    queryForPreserveValueOrder,
+    { AND: [{ f1: { gte: 12, lte: 14 } }, { f2: { gte: 14, lte: 12 } }] },
+    { parseNumbers: true, preserveValueOrder: true }
   );
 });
 
@@ -209,4 +217,21 @@ it('parseNumbers', () => {
   ] as FormatQueryOptions[]) {
     testPrisma(queryForNumberParsing, allNumbersParsed, opts);
   }
+  const noNumbersParsed = {
+    AND: [
+      { f: { gt: 'NaN' } },
+      { f: '0' },
+      { f: '    0    ' },
+      { f: 0 },
+      { OR: [{ f: { lt: '1.5' } }, { f: { gt: 1.5 } }] },
+      { f: { in: ['0', '1', '2'] } },
+      { f: { in: [0, 1, 2] } },
+      { f: { in: ['0', 'abc', '2'] } },
+      { f: { gte: '0', lte: '1' } },
+      { f: { gte: 0, lte: 1 } },
+      { f: { gte: '0', lte: 'abc' } },
+      { f: { gte: {}, lte: {} } },
+    ],
+  };
+  testPrisma(queryForNumberParsing, noNumbersParsed, { parseNumbers: false });
 });

--- a/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.SpEL.test.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.SpEL.test.ts
@@ -131,3 +131,28 @@ it('preserveValueOrder', () => {
     })
   ).toBe(`(f1 >= 12 and f1 <= 14) and (f2 >= 14 and f2 <= 12)`);
 });
+
+it('parseNumbers with between operators', () => {
+  const betweenQuery: RuleGroupType = {
+    combinator: 'and',
+    rules: [
+      { field: 'age', operator: 'between', value: '22,34' },
+      { field: 'score', operator: 'notBetween', value: ['10', '20'] },
+    ],
+  };
+
+  // Default behavior (backwards compatibility) - should parse numbers
+  expect(formatQuery(betweenQuery, { format: 'spel' })).toBe(
+    '(age >= 22 and age <= 34) and (score < 10 or score > 20)'
+  );
+
+  // Explicit parseNumbers: true - should parse numbers
+  expect(formatQuery(betweenQuery, { format: 'spel', parseNumbers: true })).toBe(
+    '(age >= 22 and age <= 34) and (score < 10 or score > 20)'
+  );
+
+  // parseNumbers: false - should NOT parse numbers (keep as strings)
+  expect(formatQuery(betweenQuery, { format: 'spel', parseNumbers: false })).toBe(
+    "(age >= '22' and age <= '34') and (score < '10' or score > '20')"
+  );
+});

--- a/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.test.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/__tests__/formatQuery.test.ts
@@ -3,7 +3,11 @@ import { convertToIC } from '../../convertQuery';
 import { prepareRuleGroup } from '../../prepareQueryObjects';
 import { formatQuery } from '../formatQuery';
 import { query, queryForNumberParsing, queryWithValueSourceField } from '../formatQueryTestUtils';
-import { getQuoteFieldNamesWithArray } from '../utils';
+import {
+  bigIntJsonParseReviver,
+  bigIntJsonStringifyReplacer,
+  getQuoteFieldNamesWithArray,
+} from '../utils';
 
 it('formats JSON correctly', () => {
   expect(formatQuery(query)).toBe(JSON.stringify(query, null, 2));
@@ -249,4 +253,21 @@ it('quoteFieldNamesWithArray handles null', () => {
 
 it('handles custom ruleGroupProcessor correctly', () => {
   expect(formatQuery(query, { ruleGroupProcessor: () => '' })).toBe('');
+});
+
+describe('JSON.stringify/parse utils', () => {
+  const query: RuleGroupType = {
+    combinator: 'and',
+    rules: [{ field: 'f', operator: '=', value: 1214n }],
+  };
+  const queryAsString = `{"combinator":"and","rules":[{"field":"f","operator":"=","value":{"$bigint":"1214"}}]}`;
+
+  it('stringifies bigints correctly', () => {
+    expect(JSON.stringify(query, bigIntJsonStringifyReplacer)).toMatch(
+      `"value":{"$bigint":"1214"}`
+    );
+  });
+  it('parses bigints correctly', () => {
+    expect(JSON.parse(queryAsString, bigIntJsonParseReviver)).toEqual(query);
+  });
 });

--- a/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorCEL.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorCEL.ts
@@ -94,11 +94,14 @@ export const defaultRuleProcessorCEL: RuleProcessor = (
         !nullOrUndefinedOrEmpty(valueAsArray[1])
       ) {
         const [first, second] = valueAsArray;
-        const firstNum = shouldRenderAsNumber(first, true)
-          ? parseNumber(first, { parseNumbers: true })
+        // For backwards compatibility, default to parsing numbers for between operators
+        // unless parseNumbers is explicitly set to false
+        const shouldParseNumbers = parseNumbers === false ? false : true;
+        const firstNum = shouldRenderAsNumber(first, shouldParseNumbers)
+          ? parseNumber(first, { parseNumbers: shouldParseNumbers })
           : NaN;
-        const secondNum = shouldRenderAsNumber(second, true)
-          ? parseNumber(second, { parseNumbers: true })
+        const secondNum = shouldRenderAsNumber(second, shouldParseNumbers)
+          ? parseNumber(second, { parseNumbers: shouldParseNumbers })
           : NaN;
         let firstValue = isNaN(firstNum)
           ? valueIsField

--- a/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorDrizzle.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorDrizzle.ts
@@ -12,7 +12,7 @@ import { isValidValue, shouldRenderAsNumber } from './utils';
 export const defaultRuleProcessorDrizzle: RuleProcessor = (
   rule,
   // istanbul ignore next
-  { preserveValueOrder, context = {} } = {}
+  { parseNumbers, preserveValueOrder, context = {} } = {}
 ): SQL | undefined => {
   const { columns, drizzleOperators } = context as {
     columns: Record<string, Column>;
@@ -99,13 +99,16 @@ export const defaultRuleProcessorDrizzle: RuleProcessor = (
         isValidValue(valueAsArray[1])
       ) {
         let [first, second] = valueAsArray;
+        // For backwards compatibility, default to parsing numbers for between operators
+        // unless parseNumbers is explicitly set to false
+        const shouldParseNumbers = parseNumbers === false ? false : true;
         if (
           !valueIsField &&
-          shouldRenderAsNumber(first, true) &&
-          shouldRenderAsNumber(second, true)
+          shouldRenderAsNumber(first, shouldParseNumbers) &&
+          shouldRenderAsNumber(second, shouldParseNumbers)
         ) {
-          const firstNum = parseNumber(first, { parseNumbers: true });
-          const secondNum = parseNumber(second, { parseNumbers: true });
+          const firstNum = parseNumber(first, { parseNumbers: shouldParseNumbers });
+          const secondNum = parseNumber(second, { parseNumbers: shouldParseNumbers });
           if (!preserveValueOrder && secondNum < firstNum) {
             const tempNum = secondNum;
             second = firstNum;

--- a/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorElasticSearch.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorElasticSearch.ts
@@ -199,9 +199,12 @@ export const defaultRuleProcessorElasticSearch: RuleProcessor = (
         isValidValue(valueAsArray[1])
       ) {
         let [first, second] = valueAsArray;
-        if (shouldRenderAsNumber(first, true) && shouldRenderAsNumber(second, true)) {
-          const firstNum = parseNumber(first, { parseNumbers: true });
-          const secondNum = parseNumber(second, { parseNumbers: true });
+        // For backwards compatibility, default to parsing numbers for between operators
+        // unless parseNumbers is explicitly set to false
+        const shouldParseNumbers = parseNumbers === false ? false : true;
+        if (shouldRenderAsNumber(first, shouldParseNumbers) && shouldRenderAsNumber(second, shouldParseNumbers)) {
+          const firstNum = parseNumber(first, { parseNumbers: shouldParseNumbers });
+          const secondNum = parseNumber(second, { parseNumbers: shouldParseNumbers });
           if (!preserveValueOrder && secondNum < firstNum) {
             const tempNum = secondNum;
             second = firstNum;

--- a/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorJsonLogic.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorJsonLogic.ts
@@ -64,13 +64,16 @@ export const defaultRuleProcessorJsonLogic: RuleProcessor = (
         isValidValue(valueAsArray[1])
       ) {
         let [first, second] = valueAsArray;
+        // For backwards compatibility, default to parsing numbers for between operators
+        // unless parseNumbers is explicitly set to false
+        const shouldParseNumbers = parseNumbers === false ? false : true;
         if (
           !valueIsField &&
-          shouldRenderAsNumber(first, true) &&
-          shouldRenderAsNumber(second, true)
+          shouldRenderAsNumber(first, shouldParseNumbers) &&
+          shouldRenderAsNumber(second, shouldParseNumbers)
         ) {
-          const firstNum = parseNumber(first, { parseNumbers: true });
-          const secondNum = parseNumber(second, { parseNumbers: true });
+          const firstNum = parseNumber(first, { parseNumbers: shouldParseNumbers });
+          const secondNum = parseNumber(second, { parseNumbers: shouldParseNumbers });
           if (!preserveValueOrder && secondNum < firstNum) {
             const tempNum = secondNum;
             second = firstNum;

--- a/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorLDAP.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorLDAP.ts
@@ -20,7 +20,7 @@ const ldapEscape = (s: unknown) =>
 export const defaultRuleProcessorLDAP: RuleProcessor = (
   { field, operator, value, valueSource },
   // istanbul ignore next
-  { preserveValueOrder } = {}
+  { parseNumbers, preserveValueOrder } = {}
 ) => {
   const operatorLC = operator.toLowerCase();
 
@@ -84,11 +84,15 @@ export const defaultRuleProcessorLDAP: RuleProcessor = (
       }
 
       const [first, second] = valueAsArray;
-      const firstNum = shouldRenderAsNumber(first, true)
-        ? parseNumber(first, { parseNumbers: true })
+      // For backwards compatibility, default to parsing numbers for between operators
+      // unless parseNumbers is explicitly set to false
+      // istanbul ignore next
+      const shouldParseNumbers = parseNumbers === false ? false : true;
+      const firstNum = shouldRenderAsNumber(first, shouldParseNumbers)
+        ? parseNumber(first, { parseNumbers: shouldParseNumbers })
         : NaN;
-      const secondNum = shouldRenderAsNumber(second, true)
-        ? parseNumber(second, { parseNumbers: true })
+      const secondNum = shouldRenderAsNumber(second, shouldParseNumbers)
+        ? parseNumber(second, { parseNumbers: shouldParseNumbers })
         : NaN;
       let firstValue = isNaN(firstNum) ? first : firstNum;
       let secondValue = isNaN(secondNum) ? second : secondNum;

--- a/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorPrisma.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorPrisma.ts
@@ -11,7 +11,7 @@ import { isValidValue, prismaOperators, shouldRenderAsNumber } from './utils';
 export const defaultRuleProcessorPrisma: RuleProcessor = (
   { field, operator, value, valueSource },
   // istanbul ignore next
-  { parseNumbers = true, preserveValueOrder } = {}
+  { parseNumbers, preserveValueOrder } = {}
 ) => {
   if (valueSource === 'field') return;
 
@@ -20,7 +20,7 @@ export const defaultRuleProcessorPrisma: RuleProcessor = (
     case '=':
       return {
         [field]: shouldRenderAsNumber(value, parseNumbers)
-          ? parseNumber(value, { parseNumbers: 'strict' })
+          ? parseNumber(value, { parseNumbers })
           : value,
       };
 
@@ -33,7 +33,7 @@ export const defaultRuleProcessorPrisma: RuleProcessor = (
       return {
         [field]: {
           [prismaOperator]: shouldRenderAsNumber(value, parseNumbers)
-            ? parseNumber(value, { parseNumbers: 'strict' })
+            ? parseNumber(value, { parseNumbers })
             : value,
         },
       };
@@ -69,9 +69,7 @@ export const defaultRuleProcessorPrisma: RuleProcessor = (
       return {
         [field]: {
           [prismaOperators[operatorLC]]: valueAsArray.map(val =>
-            shouldRenderAsNumber(val, parseNumbers)
-              ? parseNumber(val, { parseNumbers: 'strict' })
-              : val
+            shouldRenderAsNumber(val, parseNumbers) ? parseNumber(val, { parseNumbers }) : val
           ),
         },
       };
@@ -86,11 +84,14 @@ export const defaultRuleProcessorPrisma: RuleProcessor = (
         isValidValue(valueAsArray[1])
       ) {
         const [first, second] = valueAsArray;
-        const firstNum = shouldRenderAsNumber(first, true)
-          ? parseNumber(first, { parseNumbers: 'strict' })
+        // For backwards compatibility, default to parsing numbers for between operators
+        // unless parseNumbers is explicitly set to false
+        const shouldParseNumbers = parseNumbers === false ? false : true;
+        const firstNum = shouldRenderAsNumber(first, shouldParseNumbers)
+          ? parseNumber(first, { parseNumbers })
           : NaN;
-        const secondNum = shouldRenderAsNumber(second, true)
-          ? parseNumber(second, { parseNumbers: 'strict' })
+        const secondNum = shouldRenderAsNumber(second, shouldParseNumbers)
+          ? parseNumber(second, { parseNumbers })
           : NaN;
         let firstValue = isNaN(firstNum) ? first : firstNum;
         let secondValue = isNaN(secondNum) ? second : secondNum;

--- a/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorSpEL.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/defaultRuleProcessorSpEL.ts
@@ -108,11 +108,14 @@ export const defaultRuleProcessorSpEL: RuleProcessor = (
         !nullOrUndefinedOrEmpty(valueAsArray[1])
       ) {
         const [first, second] = valueAsArray;
-        const firstNum = shouldRenderAsNumber(first, true)
-          ? parseNumber(first, { parseNumbers: true })
+        // For backwards compatibility in SpEL format, between operators should parse numbers
+        // unless parseNumbers is explicitly set to false
+        const shouldParseNumbers = parseNumbers === false ? false : true;
+        const firstNum = shouldRenderAsNumber(first, shouldParseNumbers)
+          ? parseNumber(first, { parseNumbers: shouldParseNumbers })
           : NaN;
-        const secondNum = shouldRenderAsNumber(second, true)
-          ? parseNumber(second, { parseNumbers: true })
+        const secondNum = shouldRenderAsNumber(second, shouldParseNumbers)
+          ? parseNumber(second, { parseNumbers: shouldParseNumbers })
           : NaN;
         let firstValue = isNaN(firstNum)
           ? valueIsField

--- a/packages/react-querybuilder/src/utils/formatQuery/formatQuery.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/formatQuery.ts
@@ -58,7 +58,12 @@ import { defaultRuleProcessorSpEL } from './defaultRuleProcessorSpEL';
 import { defaultOperatorProcessorSQL, defaultRuleProcessorSQL } from './defaultRuleProcessorSQL';
 import { defaultValueProcessorByRule } from './defaultValueProcessorByRule';
 import { defaultValueProcessorNL } from './defaultValueProcessorNL';
-import { getQuoteFieldNamesWithArray, isValueProcessorLegacy, numerifyValues } from './utils';
+import {
+  bigIntJsonStringifyReplacer,
+  getQuoteFieldNamesWithArray,
+  isValueProcessorLegacy,
+  numerifyValues,
+} from './utils';
 
 /**
  * @group Export
@@ -500,10 +505,10 @@ function formatQuery(ruleGroup: RuleGroupTypeAny, options: FormatQueryOptions | 
       if (format === 'json_without_ids') {
         return JSON.stringify(rg, (key, value) =>
           // Remove `id` and `path` keys; leave everything else unchanged.
-          key === 'id' || key === 'path' ? undefined : value
+          key === 'id' || key === 'path' ? undefined : bigIntJsonStringifyReplacer(key, value)
         );
       }
-      return JSON.stringify(rg, null, 2);
+      return JSON.stringify(rg, bigIntJsonStringifyReplacer, 2);
     }
 
     case 'sql':

--- a/packages/react-querybuilder/src/utils/formatQuery/formatQuery.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/formatQuery.ts
@@ -146,6 +146,7 @@ type MostFormatQueryOptions = SetOptional<
   | 'validator'
   | 'valueProcessor'
   | 'placeholderValueName'
+  | 'parseNumbers'
 >;
 
 const defaultFormatQueryOptions = {
@@ -157,7 +158,6 @@ const defaultFormatQueryOptions = {
   paramPrefix: ':',
   paramsKeepPrefix: false,
   numberedParams: false,
-  parseNumbers: false,
   preserveValueOrder: false,
   placeholderFieldName: defaultPlaceholderFieldName,
   placeholderOperatorName: defaultPlaceholderOperatorName,
@@ -298,7 +298,8 @@ function formatQuery(
 /**
  * Generates a JSONata query string from an RQB query object.
  *
- * NOTE: The `parseNumbers` option is recommended for this format.
+ * NOTE: Either `parseNumbers: "strict-limited"` or `parseNumbers: true`
+ * are recommended for this format.
  *
  * @group Export
  */
@@ -362,8 +363,14 @@ function formatQuery(ruleGroup: RuleGroupTypeAny, options: FormatQueryOptions | 
     context,
   } = optObj;
 
-  const getParseNumberBoolean = (inputType?: InputType | null) =>
-    !!getParseNumberMethod({ parseNumbers, inputType });
+  const getParseNumberBoolean = (inputType?: InputType | null): boolean | undefined => {
+    const parseNumberMethod = getParseNumberMethod({ parseNumbers, inputType });
+    return typeof parseNumberMethod === 'string'
+      ? true
+      : typeof parseNumbers === 'boolean'
+        ? parseNumbers
+        : undefined;
+  };
 
   const format = optObj.format.toLowerCase() as ExportFormat;
 

--- a/packages/react-querybuilder/src/utils/formatQuery/utils.ts
+++ b/packages/react-querybuilder/src/utils/formatQuery/utils.ts
@@ -16,7 +16,7 @@ import type {
 import { joinWith, splitBy, toArray } from '../arrayUtils';
 import { getParseNumberMethod } from '../getParseNumberMethod';
 import { isRuleGroup } from '../isRuleGroup';
-import { numericRegex } from '../misc';
+import { isPojo, numericRegex } from '../misc';
 import { getOption } from '../optGroupUtils';
 import { parseNumber } from '../parseNumber';
 
@@ -332,3 +332,28 @@ export const getNLTranslataion = (
       )?.[1] ??
       defaultNLTranslations[key] ??
       /* istanbul ignore next */ '');
+
+/**
+ * "Replacer" method for JSON.stringify's second argument. Converts `bigint` values to
+ * objects with a `$bigint` property having a value of a string representation of
+ * the actual `bigint`-type value.
+ *
+ * Inverse of {@link bigIntJsonParseReviver}.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
+ */
+export const bigIntJsonStringifyReplacer = (_key: string, value: unknown): unknown =>
+  typeof value === 'bigint' ? { $bigint: value.toString() } : value;
+
+/**
+ * "Reviver" method for JSON.parse's second argument. Converts objects having a single
+ * `$bigint: string` property to an actual `bigint` value.
+ *
+ * Inverse of {@link bigIntJsonStringifyReplacer}.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
+ */
+export const bigIntJsonParseReviver = (_key: string, value: unknown): unknown =>
+  isPojo(value) && Object.keys(value).length === 1 && typeof value.$bigint === 'string'
+    ? BigInt(value.$bigint)
+    : value;

--- a/packages/tremor/src/TremorValueEditor.tsx
+++ b/packages/tremor/src/TremorValueEditor.tsx
@@ -39,6 +39,7 @@ export const TremorValueEditor = (allProps: TremorValueEditorProps): React.JSX.E
     title,
     className,
     type,
+    inputType,
     values: _v,
     listsAsArrays,
     parseNumbers: _parseNumbers,
@@ -47,13 +48,17 @@ export const TremorValueEditor = (allProps: TremorValueEditorProps): React.JSX.E
     disabled,
     testID,
     selectorComponent = ClearableValueSelector,
-    inputType: _inputType,
     validation: _validation,
     extraProps,
   } = allProps;
 
-  const { valueAsArray, multiValueHandler, valueListItemClassName, inputTypeCoerced } =
-    useValueEditor(allProps);
+  const {
+    valueAsArray,
+    multiValueHandler,
+    bigIntValueHandler,
+    valueListItemClassName,
+    inputTypeCoerced,
+  } = useValueEditor(allProps);
 
   if (operator === 'null' || operator === 'notNull') {
     return null;
@@ -187,6 +192,22 @@ export const TremorValueEditor = (allProps: TremorValueEditorProps): React.JSX.E
         disabled={disabled}
         value={value}
         onValueChange={handleOnChange}
+        {...extraProps}
+      />
+    );
+  }
+
+  if (inputType === 'bigint') {
+    return (
+      <TextInput
+        data-testid={testID}
+        type={inputTypeCoerced as TextInputProps['type']}
+        placeholder={placeHolderText}
+        value={`${value}`}
+        title={title}
+        className={className}
+        disabled={disabled}
+        onChange={e => bigIntValueHandler(e.target.value)}
         {...extraProps}
       />
     );

--- a/utils/devapp/constants.ts
+++ b/utils/devapp/constants.ts
@@ -218,6 +218,7 @@ export const fields: Field[] = [
   { name: 'birthdate', label: 'Birth Date', inputType: 'date' },
   { name: 'datetime', label: 'Show Time', inputType: 'datetime-local' },
   { name: 'alarm', label: 'Daily Alarm', inputType: 'time' },
+  { name: 'bign', label: 'BigInt', inputType: 'bigint' },
   {
     name: 'groupedField1',
     label: 'Grouped Field 1',

--- a/utils/devapp/utils.ts
+++ b/utils/devapp/utils.ts
@@ -1,6 +1,6 @@
 import queryString from 'query-string';
 import type { FormatQueryOptions, RuleGroupTypeAny } from 'react-querybuilder';
-import { formatQuery } from 'react-querybuilder';
+import { bigIntJsonStringifyReplacer, formatQuery } from 'react-querybuilder';
 import { defaultOptions, optionOrder } from './constants';
 import type { DemoOption, DemoOptions } from './types';
 
@@ -54,7 +54,7 @@ export const getFormatQueryString = (
     options.format === 'elasticsearch' ||
     options.format === 'mongodb_query'
   ) {
-    return JSON.stringify(formatQueryResult, null, 2);
+    return JSON.stringify(formatQueryResult, bigIntJsonStringifyReplacer, 2);
   }
   return formatQueryResult;
 };

--- a/utils/testing/testValueEditor.tsx
+++ b/utils/testing/testValueEditor.tsx
@@ -29,6 +29,7 @@ type ValueEditorTestsToSkip = Partial<{
   switch: boolean;
   between: boolean;
   betweenSelect: boolean;
+  bigint: boolean;
 }>;
 interface ValueEditorAsSelectProps extends ValueEditorProps {
   values: OptionList;
@@ -514,6 +515,39 @@ export const testValueEditor = (
           render(<ValueEditor {...props} type="textarea" handleOnChange={onChange} />);
           await user.type(findTextarea(screen.getByTitle(title)), 'foo');
           expect(onChange).toHaveBeenCalledWith('foo');
+        });
+      });
+    }
+
+    if (!skip.bigint) {
+      describe('when rendering a bigint editor', () => {
+        const bi = BigInt(Number.MAX_VALUE) + 10n;
+        const bigIntProps: ValueEditorProps = {
+          ...props,
+          inputType: 'bigint',
+          parseNumbers: true,
+        };
+
+        it('should have the value passed into the <input /> as text', () => {
+          render(<ValueEditor {...bigIntProps} value={bi} />);
+          expect(findInput(screen.getByTitle(title))).toHaveValue(`${bi}`);
+        });
+
+        it('should call the onChange method passed in', async () => {
+          const onChange = jest.fn();
+          render(<ValueEditor {...bigIntProps} value={bi} handleOnChange={onChange} />);
+          await user.type(findInput(screen.getByTitle(title)), '2');
+          expect(onChange).toHaveBeenCalledWith(bi * 10n + 2n);
+        });
+
+        it('should maintain non-bigint values', async () => {
+          const onChange = jest.fn();
+          render(<ValueEditor {...bigIntProps} value={'bi'} handleOnChange={onChange} />);
+          await user.type(findInput(screen.getByTitle(title)), 't', {
+            // initialSelectionStart: 0,
+            // initialSelectionEnd: 9999,
+          });
+          expect(onChange).toHaveBeenCalledWith('bit');
         });
       });
     }

--- a/website/src/pages/demo/_components/Demo.tsx
+++ b/website/src/pages/demo/_components/Demo.tsx
@@ -581,9 +581,9 @@ export default function Demo({
                     ]),
                   },
                   {
-                    value: 'mongodb',
+                    value: 'mongodb_query',
                     label: 'MongoDB',
-                    attributes: getExportTabAttributes('mongodb'),
+                    attributes: getExportTabAttributes('mongodb_query'),
                   },
                   { value: 'cel', label: 'CEL', attributes: getExportTabAttributes('cel') },
                   { value: 'spel', label: 'SpEL', attributes: getExportTabAttributes('spel') },
@@ -695,9 +695,9 @@ export default function Demo({
                   </div>
                   {exportPresentation}
                 </TabItem>
-                <TabItem value="mongodb">
+                <TabItem value="mongodb_query">
                   <div className={styles.exportOptions}>
-                    <ExportInfoLinks format="mongodb" />
+                    <ExportInfoLinks format="mongodb_query" />
                     {parseNumbersOption}
                   </div>
                   {exportPresentation}

--- a/website/src/pages/demo/_constants/fields.ts
+++ b/website/src/pages/demo/_constants/fields.ts
@@ -66,6 +66,7 @@ export const fields = (
       datatype: 'timestamp with time zone',
     },
     { name: 'alarm', label: 'Daily Alarm', inputType: 'time' },
+    { name: 'bign', label: 'Big Int', inputType: 'bigint' },
     {
       name: 'groupedField1',
       label: 'Grouped Field 1',

--- a/website/src/pages/demo/_constants/index.ts
+++ b/website/src/pages/demo/_constants/index.ts
@@ -250,7 +250,7 @@ export const formatMap: [ExportFormat, string, HttpsURL, string][] = [
   ['parameterized_named', 'SQL (named parameters)', 'https://en.wikipedia.org/wiki/SQL', 'named-parameters'],
   ['json_without_ids', 'JSON (no identifiers)', 'https://en.wikipedia.org/wiki/JSON', 'json-without-identifiers'],
   ['json', 'JSON', 'https://en.wikipedia.org/wiki/JSON', 'json'],
-  ['mongodb', 'MongoDB', 'https://www.mongodb.com/', 'mongodb'],
+  ['mongodb_query', 'MongoDB', 'https://www.mongodb.com/', 'mongodb'],
   ['cel', 'CEL', 'https://github.com/google/cel-spec', 'common-expression-language'],
   ['spel', 'SpEL', 'https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#expressions-language-ref', 'spring-expression-language'],
   ['jsonlogic', 'JsonLogic', 'https://jsonlogic.com/', 'jsonlogic'],

--- a/website/src/pages/demo/_styles/demo.css
+++ b/website/src/pages/demo/_styles/demo.css
@@ -10,6 +10,10 @@
   min-width: 420px;
 }
 
+li.tabs__item {
+  white-space: nowrap;
+}
+
 /* Styles for when "Use validation" option is selected */
 .validateQuery .queryBuilder {
   & .ruleGroup.queryBuilder-invalid {


### PR DESCRIPTION
- Fixes #898
- Fixes #906
- Removes SQL tests from the SpEL test file
- Ensures that the `parseNumbers` option is respected for "between" operators across various formats.