### PR TITLE
Remove `match` for unsupported field modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#932] New `useOptionListProp` hook to standardize option list prop normalization.
 
+### Fixed
+
+- The `match` property is now removed when a rule's `field` is updated to a field that does not support match modes.
+
 ## [v8.8.3] - 2025-08-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The `match` property is now removed when a rule's `field` is updated to a field that does not support match modes.
+- [#937] The `match` property is now removed when a rule's `field` is updated to a field that does not support match modes.
 
 ## [v8.8.3] - 2025-08-13
 
@@ -1986,6 +1986,7 @@ Maintenance release focused on converting to a monorepo with Vite driving the bu
 [#926]: https://github.com/react-querybuilder/react-querybuilder/pull/926
 [#931]: https://github.com/react-querybuilder/react-querybuilder/pull/931
 [#932]: https://github.com/react-querybuilder/react-querybuilder/pull/932
+[#937]: https://github.com/react-querybuilder/react-querybuilder/pull/937
 
 <!-- #endregion -->
 

--- a/packages/react-querybuilder/src/utils/queryTools.ts
+++ b/packages/react-querybuilder/src/utils/queryTools.ts
@@ -189,19 +189,22 @@ export const update = <RG extends RuleGroupTypeAny>(
     let resetValueSource = false;
     let resetValue = false;
 
-    if (prop === 'field' && !isGroup) {
+    if (prop === 'field') {
       const fromFieldMatchModes = getMatchModes(ruleOrGroup.field);
       const toFieldMatchModes = getMatchModes(value);
 
-      const nextMatchMode =
-        ruleOrGroup.match?.mode &&
-        toFieldMatchModes.length > 0 &&
-        getOption(toFieldMatchModes, ruleOrGroup.match.mode)
-          ? null
-          : getFirstOption(toFieldMatchModes);
-      if (nextMatchMode) {
-        ruleOrGroup.match = { mode: nextMatchMode, threshold: 1 };
+      if (toFieldMatchModes.length === 0) {
+        delete ruleOrGroup.match;
+      } else {
+        const nextMatchMode =
+          ruleOrGroup.match?.mode && getOption(toFieldMatchModes, ruleOrGroup.match.mode)
+            ? null
+            : getFirstOption(toFieldMatchModes);
+        if (nextMatchMode) {
+          ruleOrGroup.match = { mode: nextMatchMode, threshold: 1 };
+        }
       }
+
       if (fromFieldMatchModes.length > 0 || toFieldMatchModes.length > 0) {
         // Force `resetOnFieldChange` when field is updated FROM or TO one that has match modes
         resetOnFieldChange = true;


### PR DESCRIPTION
Delete the `match` property when a rule's `field` is changed to one that does not support match modes.

- Fixes #936