### PR TITLE
feat(mongodb): add support for `not` in rule groups

### DIFF
--- a/packages/core/src/utils/formatQuery/__tests__/formatQuery.MongoDB.test.ts
+++ b/packages/core/src/utils/formatQuery/__tests__/formatQuery.MongoDB.test.ts
@@ -468,6 +468,28 @@ it('formats to mongo query correctly', () => {
     format: 'mongodb',
     valueProcessor: defaultMongoDBValueProcessor,
   });
+  // Test for `not` at top level
+  testBoth(
+    { not: true, combinator: 'and', rules: [{ field: 'f1', operator: '=', value: 'v1' }] },
+    { $not: { f1: 'v1' } }
+  );
+  // Test for `not` at nested group level
+  testBoth(
+    {
+      combinator: 'and',
+      rules: [
+        {
+          not: true,
+          combinator: 'or',
+          rules: [
+            { field: 'f1', operator: '=', value: 'v1' },
+            { field: 'f2', operator: '=', value: 'v2' },
+          ],
+        },
+      ],
+    },
+    { $and: [{ $not: { $or: [{ f1: 'v1' }, { f2: 'v2' }] } }] }
+  );
   testBoth(queryWithMatchModes, mongoQueryExpectationForMatchModes);
   // Just a coverage thing here:
   testBoth(

--- a/packages/core/src/utils/formatQuery/defaultRuleGroupProcessorMongoDB.ts
+++ b/packages/core/src/utils/formatQuery/defaultRuleGroupProcessorMongoDB.ts
@@ -73,11 +73,14 @@ export const defaultRuleGroupProcessorMongoDB: RuleGroupProcessor<string> = (
       })
       .filter(Boolean);
 
-    return expressions.length > 0
-      ? expressions.length === 1 && !hasChildRules
-        ? expressions[0]
-        : `${combinator}:[${expressions.join(',')}]`
-      : fallbackExpression;
+    const result =
+      expressions.length > 0
+        ? expressions.length === 1 && !hasChildRules
+          ? expressions[0]
+          : `${combinator}:[${expressions.join(',')}]`
+        : fallbackExpression;
+
+    return rg.not ? `"$not":${isBracketed(result) ? result : `{${result}}`}` : result;
   };
 
   const processedQuery = processRuleGroup(convertFromIC(ruleGroup), true);

--- a/packages/core/src/utils/formatQuery/defaultRuleGroupProcessorMongoDBQuery.ts
+++ b/packages/core/src/utils/formatQuery/defaultRuleGroupProcessorMongoDBQuery.ts
@@ -74,11 +74,14 @@ export const defaultRuleGroupProcessorMongoDBQuery: RuleGroupProcessor = (
       })
       .filter(Boolean);
 
-    return expressions.length > 0
-      ? expressions.length === 1 && !hasChildRules
-        ? expressions[0]
-        : { [combinator]: expressions }
-      : mongoDbFallback;
+    const result =
+      expressions.length > 0
+        ? expressions.length === 1 && !hasChildRules
+          ? expressions[0]
+          : { [combinator]: expressions }
+        : mongoDbFallback;
+
+    return rg.not ? { $not: result } : result;
   };
 
   return processRuleGroup(convertFromIC(ruleGroup), true);


### PR DESCRIPTION
Add handling for the `not` property at both top-level and nested group levels in MongoDB query formatting.