### PR TITLE
Fix: formatQuery MongoDB ignores not: true on rule groups

### DIFF
--- a/packages/core/src/utils/formatQuery/__tests__/formatQuery.MongoDB.test.ts
+++ b/packages/core/src/utils/formatQuery/__tests__/formatQuery.MongoDB.test.ts
@@ -668,7 +668,7 @@ it('handles not: true on rule groups', () => {
         },
       ],
     },
-    { $not: { $or: [{ f1: 'v1' }, { f2: 'v2' }] } }
+    { $and: [{ $not: { $or: [{ f1: 'v1' }, { f2: 'v2' }] } }] }
   );
   // Double negation: not group inside not group
   testBoth(
@@ -686,7 +686,7 @@ it('handles not: true on rule groups', () => {
         },
       ],
     },
-    { $not: { $not: { $or: [{ f1: 'v1' }, { f2: 'v2' }] } } }
+    { $not: { $and: [{ $not: { $or: [{ f1: 'v1' }, { f2: 'v2' }] } }] } }
   );
 });
 

--- a/packages/core/src/utils/formatQuery/__tests__/formatQuery.MongoDB.test.ts
+++ b/packages/core/src/utils/formatQuery/__tests__/formatQuery.MongoDB.test.ts
@@ -623,6 +623,89 @@ it('ruleProcessor', () => {
 });
 
 // oxlint-disable-next-line expect-expect
+it('handles not: true on rule groups', () => {
+  // Single rule in negated group
+  testBoth(
+    { combinator: 'and', not: true, rules: [{ field: 'f1', operator: '=', value: 'v1' }] },
+    { $not: { f1: 'v1' } }
+  );
+  // Multiple rules in negated group
+  testBoth(
+    {
+      combinator: 'and',
+      not: true,
+      rules: [
+        { field: 'f1', operator: '=', value: 'v1' },
+        { field: 'f2', operator: '=', value: 'v2' },
+      ],
+    },
+    { $not: { $and: [{ f1: 'v1' }, { f2: 'v2' }] } }
+  );
+  // Negated $or group
+  testBoth(
+    {
+      combinator: 'or',
+      not: true,
+      rules: [
+        { field: 'f1', operator: '=', value: 'v1' },
+        { field: 'f2', operator: '=', value: 'v2' },
+      ],
+    },
+    { $not: { $or: [{ f1: 'v1' }, { f2: 'v2' }] } }
+  );
+  // Nested negated group inside non-negated group
+  testBoth(
+    {
+      combinator: 'and',
+      rules: [
+        {
+          combinator: 'or',
+          not: true,
+          rules: [
+            { field: 'f1', operator: '=', value: 'v1' },
+            { field: 'f2', operator: '=', value: 'v2' },
+          ],
+        },
+      ],
+    },
+    { $not: { $or: [{ f1: 'v1' }, { f2: 'v2' }] } }
+  );
+  // Double negation: not group inside not group
+  testBoth(
+    {
+      combinator: 'and',
+      not: true,
+      rules: [
+        {
+          combinator: 'or',
+          not: true,
+          rules: [
+            { field: 'f1', operator: '=', value: 'v1' },
+            { field: 'f2', operator: '=', value: 'v2' },
+          ],
+        },
+      ],
+    },
+    { $not: { $not: { $or: [{ f1: 'v1' }, { f2: 'v2' }] } } }
+  );
+});
+
+// oxlint-disable-next-line expect-expect
+it('handles not: true with independent combinators', () => {
+  testBoth(
+    {
+      rules: [
+        { field: 'f1', operator: '=', value: 'v1' },
+        'and',
+        { field: 'f2', operator: '=', value: 'v2' },
+      ],
+      not: true,
+    },
+    { $not: { $and: [{ f1: 'v1' }, { f2: 'v2' }] } }
+  );
+});
+
+// oxlint-disable-next-line expect-expect
 it('preserveValueOrder', () => {
   testMongoDB(
     queryForPreserveValueOrder,


### PR DESCRIPTION
## Summary
- `formatQuery` with `mongodb` and `mongodb_query` formats ignored the `not` property on rule groups, never emitting `$not` in the output
- Both `defaultRuleGroupProcessorMongoDB` and `defaultRuleGroupProcessorMongoDBQuery` now wrap their output in `$not` when `rg.not` is truthy
- Adds tests covering single rule, multi-rule `$and`/`$or`, nested negation, double negation, and independent combinators

## Test plan
- [x] All existing MongoDB format tests pass
- [x] All existing parseMongoDB tests pass
- [x] New `not: true` format tests pass for both `mongodb` and `mongodb_query` formats
- [ ] `bun checkall` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)