### PR TITLE
fix: pass Event to handler with augmented nativeEvent

### DIFF
--- a/packages/dnd/src/adapters/dnd-kit.test.tsx
+++ b/packages/dnd/src/adapters/dnd-kit.test.tsx
@@ -962,7 +962,10 @@ describe('createDndKitAdapter', () => {
       handle.dispatchEvent(pointerEvent);
 
       expect(onPointerDown).toHaveBeenCalledTimes(1);
-      expect(onPointerDown).toHaveBeenCalledWith({ nativeEvent: pointerEvent });
+      expect(onPointerDown).toHaveBeenCalledWith(
+        expect.objectContaining({ nativeEvent: pointerEvent })
+      );
+      expect(onPointerDown).toHaveBeenCalledWith(expect.any(Event));
     });
 
     it('attaches sensor listeners to drag handle in useRuleGroupDnD', () => {
@@ -1004,7 +1007,10 @@ describe('createDndKitAdapter', () => {
       handle.dispatchEvent(pointerEvent);
 
       expect(onPointerDown).toHaveBeenCalledTimes(1);
-      expect(onPointerDown).toHaveBeenCalledWith({ nativeEvent: pointerEvent });
+      expect(onPointerDown).toHaveBeenCalledWith(
+        expect.objectContaining({ nativeEvent: pointerEvent })
+      );
+      expect(onPointerDown).toHaveBeenCalledWith(expect.any(Event));
     });
   });
 

--- a/packages/dnd/src/adapters/dnd-kit.tsx
+++ b/packages/dnd/src/adapters/dnd-kit.tsx
@@ -109,7 +109,12 @@ const useNativeListeners = (
 
     for (const [reactEventName, handler] of Object.entries(listeners)) {
       const nativeEventName = reactEventName.slice(2).toLowerCase();
-      const nativeHandler: EventListener = e => handler({ nativeEvent: e });
+      const nativeHandler: EventListener = e => {
+        // Need to make sure the instance type stays the same, so add property
+        // instead of create new event with nativeEvent property
+        (e as Event & { nativeEvent: Event }).nativeEvent = e;
+        return handler(e);
+      };
       node.addEventListener(nativeEventName, nativeHandler);
       nativeHandlers.push([nativeEventName, nativeHandler]);
     }


### PR DESCRIPTION
Small fix to get keyboard navigation working for the dnd-kit adapter.

The `KeyboardSensor` assumes that the `event` will be an instance of `KeyboardEvent` otherwise it never handles the keydown's that it is registered to do so. Getting this to work required a bit of typescript casting, but I didn't see an alternate that would appease typescript and still achieve the state needed for the dnd-kit code to work.

fixes #1031 

I'm going to explore using the sortable context in a branch into this one