### PR TITLE
Add `onRuleDrop` callback for `QueryBuilderDnD`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-N/A
+### Added
+
+- `onRuleDrop` callback prop for `QueryBuilderDnD` — fires after any drag-and-drop operation completes (same-QB or cross-QB) with source/target qbIds, paths, drop effect, and group mode.
 
 ## [v8.16.2] - 2026-05-26
 

--- a/packages/dnd/src/QueryBuilderDnD.test.tsx
+++ b/packages/dnd/src/QueryBuilderDnD.test.tsx
@@ -828,3 +828,162 @@ it('can group rules/groups to different query builders', async () => {
     rules: [{ field: 'field3', operator: '=', value: '3' }],
   });
 });
+
+describe('onRuleDrop callback', () => {
+  it('fires for same-QB move', () => {
+    const onRuleDrop = vi.fn();
+    const [QueryBuilderWrapped, getDndBackend] = wrapWithTestBackend(
+      (props: QueryBuilderProps<RuleGroupType, FullField, FullOperator, FullCombinator>) => (
+        <QueryBuilderDnD dnd={{ ...reactDnD, ...reactDnDHTML5Backend }} onRuleDrop={onRuleDrop}>
+          <QueryBuilder {...props} />
+        </QueryBuilderDnD>
+      )
+    );
+    render(
+      <QueryBuilderWrapped
+        fields={[
+          { name: 'field1', label: 'Field 1' },
+          { name: 'field2', label: 'Field 2' },
+        ]}
+        query={{
+          combinator: 'and',
+          rules: [
+            { id: 'r1', field: 'field1', operator: '=', value: '1' },
+            { id: 'r2', field: 'field2', operator: '=', value: '2' },
+          ],
+        }}
+      />
+    );
+    const rules = screen.getAllByTestId(TestID.rule);
+    simulateDragDrop(
+      getHandlerId(rules[0], 'drag'),
+      getHandlerId(rules[1], 'drop'),
+      getDndBackend()!
+    );
+    expect(onRuleDrop).toHaveBeenCalledTimes(1);
+    expect(onRuleDrop).toHaveBeenCalledWith(
+      expect.objectContaining({ dropEffect: 'move', groupItems: false, isCrossBuilder: false })
+    );
+    expect(onRuleDrop.mock.calls[0][0].sourceQbId).toBe(onRuleDrop.mock.calls[0][0].targetQbId);
+  });
+
+  it('fires for same-QB copy', async () => {
+    const onRuleDrop = vi.fn();
+    const [QueryBuilderWrapped, getDndBackend] = wrapWithTestBackend(
+      (props: QueryBuilderProps<RuleGroupType, FullField, FullOperator, FullCombinator>) => (
+        <QueryBuilderDnD dnd={{ ...reactDnD, ...reactDnDHTML5Backend }} onRuleDrop={onRuleDrop}>
+          <QueryBuilder {...props} />
+        </QueryBuilderDnD>
+      )
+    );
+    render(
+      <QueryBuilderWrapped
+        fields={[
+          { name: 'field1', label: 'Field 1' },
+          { name: 'field2', label: 'Field 2' },
+        ]}
+        query={{
+          combinator: 'and',
+          rules: [
+            { id: 'r1', field: 'field1', operator: '=', value: '1' },
+            { id: 'r2', field: 'field2', operator: '=', value: '2' },
+          ],
+        }}
+      />
+    );
+    const rules = screen.getAllByTestId(TestID.rule);
+    await user.keyboard('{Alt>}');
+    simulateDragDrop(
+      getHandlerId(rules[0], 'drag'),
+      getHandlerId(rules[1], 'drop'),
+      getDndBackend()!
+    );
+    await user.keyboard('{/Alt}');
+    expect(onRuleDrop).toHaveBeenCalledTimes(1);
+    expect(onRuleDrop).toHaveBeenCalledWith(
+      expect.objectContaining({ dropEffect: 'copy', groupItems: false, isCrossBuilder: false })
+    );
+  });
+
+  it('fires for same-QB group', async () => {
+    const onRuleDrop = vi.fn();
+    const [QueryBuilderWrapped, getDndBackend] = wrapWithTestBackend(
+      (props: QueryBuilderProps<RuleGroupType, FullField, FullOperator, FullCombinator>) => (
+        <QueryBuilderDnD dnd={{ ...reactDnD, ...reactDnDHTML5Backend }} onRuleDrop={onRuleDrop}>
+          <QueryBuilder {...props} />
+        </QueryBuilderDnD>
+      )
+    );
+    render(
+      <QueryBuilderWrapped
+        fields={[
+          { name: 'field1', label: 'Field 1' },
+          { name: 'field2', label: 'Field 2' },
+        ]}
+        query={{
+          combinator: 'and',
+          rules: [
+            { id: 'r1', field: 'field1', operator: '=', value: '1' },
+            { id: 'r2', field: 'field2', operator: '=', value: '2' },
+          ],
+        }}
+      />
+    );
+    const rules = screen.getAllByTestId(TestID.rule);
+    await user.keyboard('{Control>}');
+    simulateDragDrop(
+      getHandlerId(rules[1], 'drag'),
+      getHandlerId(rules[0], 'drop'),
+      getDndBackend()!
+    );
+    await user.keyboard('{/Control}');
+    expect(onRuleDrop).toHaveBeenCalledTimes(1);
+    expect(onRuleDrop).toHaveBeenCalledWith(
+      expect.objectContaining({ dropEffect: 'move', groupItems: true, isCrossBuilder: false })
+    );
+  });
+
+  it('fires for cross-QB move', () => {
+    const onRuleDrop = vi.fn();
+    const fields: Field[] = [
+      { name: 'field1', label: 'Field 1' },
+      { name: 'field2', label: 'Field 2' },
+      { name: 'field3', label: 'Field 3' },
+      { name: 'field4', label: 'Field 4' },
+    ];
+    const query1: RuleGroupType = {
+      combinator: 'and',
+      rules: [
+        { field: 'field1', operator: '=', value: '1' },
+        { field: 'field2', operator: '=', value: '2' },
+      ],
+    };
+    const query2: RuleGroupType = {
+      combinator: 'and',
+      rules: [
+        { field: 'field3', operator: '=', value: '3' },
+        { field: 'field4', operator: '=', value: '4' },
+      ],
+    };
+    const [QueryBuilderWrapped, getDndBackend] = wrapWithTestBackend(
+      (props: QueryBuilderProps<RuleGroupType, FullField, FullOperator, FullCombinator>) => (
+        <QueryBuilderDnD dnd={{ ...reactDnD, ...reactDnDHTML5Backend }} onRuleDrop={onRuleDrop}>
+          <QueryBuilder {...props} query={query1} />
+          <QueryBuilder {...props} query={query2} />
+        </QueryBuilderDnD>
+      )
+    );
+    render(<QueryBuilderWrapped fields={fields} enableDragAndDrop />);
+    const [dropRule, , , dragRule] = screen.getAllByTestId(TestID.rule);
+    simulateDragDrop(
+      getHandlerId(dragRule, 'drag'),
+      getHandlerId(dropRule, 'drop'),
+      getDndBackend()!
+    );
+    expect(onRuleDrop).toHaveBeenCalledTimes(1);
+    expect(onRuleDrop).toHaveBeenCalledWith(
+      expect.objectContaining({ dropEffect: 'move', groupItems: false, isCrossBuilder: true })
+    );
+    expect(onRuleDrop.mock.calls[0][0].sourceQbId).not.toBe(onRuleDrop.mock.calls[0][0].targetQbId);
+  });
+});

--- a/packages/dnd/src/QueryBuilderDnD.tsx
+++ b/packages/dnd/src/QueryBuilderDnD.tsx
@@ -89,7 +89,8 @@ export const QueryBuilderDnD = (props: QueryBuilderDndProps): React.JSX.Element 
           groupModeAfterHoverMs={props.groupModeAfterHoverMs}
           hideDefaultDragPreview={props.hideDefaultDragPreview}
           updateWhileDragging={props.updateWhileDragging}
-          onDragMove={props.onDragMove}>
+          onDragMove={props.onDragMove}
+          onRuleDrop={props.onRuleDrop}>
           {props.children}
         </QueryBuilderDndWithoutProvider>
       </QueryBuilderContext.Provider>
@@ -141,6 +142,7 @@ export const QueryBuilderDndWithoutProvider = (props: QueryBuilderDndProps): Rea
     rqbDndContext.updateWhileDragging
   );
   const onDragMove = preferAnyProp(undefined, props.onDragMove, rqbDndContext.onDragMove);
+  const onRuleDrop = preferAnyProp(undefined, props.onRuleDrop, rqbDndContext.onRuleDrop);
   const key = enableDragAndDrop && adapter ? 'dnd' : 'no-dnd';
 
   const baseControls = useMemo(
@@ -197,6 +199,7 @@ export const QueryBuilderDndWithoutProvider = (props: QueryBuilderDndProps): Rea
       hideDefaultDragPreview,
       updateWhileDragging,
       onDragMove,
+      onRuleDrop,
       adapter,
     }),
     [
@@ -209,6 +212,7 @@ export const QueryBuilderDndWithoutProvider = (props: QueryBuilderDndProps): Rea
       hideDefaultDragPreview,
       updateWhileDragging,
       onDragMove,
+      onRuleDrop,
       adapter,
     ]
   );

--- a/packages/dnd/src/RuleDnD.tsx
+++ b/packages/dnd/src/RuleDnD.tsx
@@ -23,6 +23,7 @@ export const RuleDnD = (props: RuleProps): React.JSX.Element => {
     groupModeModifierKey,
     groupModeAfterHoverMs,
     hideDefaultDragPreview,
+    onRuleDrop,
   } = rqbDndContext;
 
   const disabled = !!props.parentDisabled || !!props.disabled;
@@ -39,6 +40,7 @@ export const RuleDnD = (props: RuleProps): React.JSX.Element => {
     groupModeModifierKey: groupModeModifierKey ?? 'ctrl',
     groupModeAfterHoverMs,
     hideDefaultDragPreview,
+    onRuleDrop,
   });
 
   // When updateWhileDragging is active, suppress isDragging and isOver

--- a/packages/dnd/src/RuleGroupDnD.tsx
+++ b/packages/dnd/src/RuleGroupDnD.tsx
@@ -24,6 +24,7 @@ export const RuleGroupDnD = (props: RuleGroupProps): React.JSX.Element => {
     groupModeModifierKey,
     groupModeAfterHoverMs,
     hideDefaultDragPreview,
+    onRuleDrop,
   } = rqbDndContext;
 
   // When updateWhileDragging is active and this is the root group,
@@ -53,6 +54,7 @@ export const RuleGroupDnD = (props: RuleGroupProps): React.JSX.Element => {
     groupModeModifierKey: groupModeModifierKey ?? 'ctrl',
     groupModeAfterHoverMs,
     hideDefaultDragPreview,
+    onRuleDrop,
   });
 
   // When updateWhileDragging is active, suppress isDragging and isOver

--- a/packages/dnd/src/adapter.ts
+++ b/packages/dnd/src/adapter.ts
@@ -7,7 +7,7 @@ import type {
   RuleType,
   Schema,
 } from 'react-querybuilder';
-import type { CustomCanDropParams } from './types';
+import type { CustomCanDropParams, OnRuleDropCallback } from './types';
 
 /**
  * Parameters for the adapter's `useRuleDnD` hook.
@@ -25,6 +25,7 @@ export interface DndAdapterRuleDnDParams {
   groupModeModifierKey: string;
   groupModeAfterHoverMs?: number;
   hideDefaultDragPreview?: boolean;
+  onRuleDrop?: OnRuleDropCallback;
 }
 
 /**
@@ -43,6 +44,7 @@ export interface DndAdapterRuleGroupDnDParams {
   groupModeModifierKey: string;
   groupModeAfterHoverMs?: number;
   hideDefaultDragPreview?: boolean;
+  onRuleDrop?: OnRuleDropCallback;
 }
 
 /**

--- a/packages/dnd/src/adapters/dnd-kit.tsx
+++ b/packages/dnd/src/adapters/dnd-kit.tsx
@@ -461,6 +461,7 @@ export const createDndKitAdapter = (dndKitExports: DndKitExports): DndAdapter =>
               groupModeModifierKey: sourceData.groupModeModifierKey,
               copyModeOverride: copyOverride,
               groupModeOverride: groupOverride,
+              onRuleDrop: sourceData.onRuleDrop,
             });
           }
         }
@@ -538,6 +539,7 @@ export const createDndKitAdapter = (dndKitExports: DndKitExports): DndAdapter =>
         actions: params.actions,
         copyModeModifierKey: params.copyModeModifierKey,
         groupModeModifierKey: params.groupModeModifierKey,
+        onRuleDrop: params.onRuleDrop,
       },
     });
 
@@ -658,6 +660,7 @@ export const createDndKitAdapter = (dndKitExports: DndKitExports): DndAdapter =>
         actions: params.actions,
         copyModeModifierKey: params.copyModeModifierKey,
         groupModeModifierKey: params.groupModeModifierKey,
+        onRuleDrop: params.onRuleDrop,
       },
     });
 

--- a/packages/dnd/src/adapters/pragmatic-dnd.tsx
+++ b/packages/dnd/src/adapters/pragmatic-dnd.tsx
@@ -45,7 +45,7 @@ import type { DragPreviewContextValue } from '../DragPreviewContext';
 import { isHotkeyPressed } from '../isHotkeyPressed';
 import { getQuadrant } from '../quadrantDetection';
 import { computeShadowQuery } from '../shadowQuery';
-import type { DragPreviewState, OnDragMoveCallback } from '../types';
+import type { DragPreviewState, OnDragMoveCallback, OnRuleDropCallback } from '../types';
 
 /**
  * The `@atlaskit/pragmatic-drag-and-drop` exports needed by the adapter.
@@ -403,6 +403,7 @@ export const createPragmaticDndAdapter = (pdndExports: PragmaticDndExports): Dnd
                 groupModeModifierKey: sourceData.__rqbGroupModeModifierKey as string,
                 copyModeOverride: copyOverride,
                 groupModeOverride: groupOverride,
+                onRuleDrop: sourceData.__rqbOnRuleDrop as OnRuleDropCallback | undefined,
               });
             }
           }
@@ -482,6 +483,7 @@ export const createPragmaticDndAdapter = (pdndExports: PragmaticDndExports): Dnd
             __rqbActions: paramsRef.current.actions,
             __rqbCopyModeModifierKey: paramsRef.current.copyModeModifierKey,
             __rqbGroupModeModifierKey: paramsRef.current.groupModeModifierKey,
+            __rqbOnRuleDrop: paramsRef.current.onRuleDrop,
           }),
           onDragStart: () => setIsDragging(true),
           onDrop: () => setIsDragging(false),
@@ -596,6 +598,7 @@ export const createPragmaticDndAdapter = (pdndExports: PragmaticDndExports): Dnd
           __rqbActions: paramsRef.current.actions,
           __rqbCopyModeModifierKey: paramsRef.current.copyModeModifierKey,
           __rqbGroupModeModifierKey: paramsRef.current.groupModeModifierKey,
+          __rqbOnRuleDrop: paramsRef.current.onRuleDrop,
         }),
         onDragStart: () => setIsDragging(true),
         onDrop: () => setIsDragging(false),

--- a/packages/dnd/src/adapters/react-dnd.tsx
+++ b/packages/dnd/src/adapters/react-dnd.tsx
@@ -77,6 +77,7 @@ const useRuleDragCommon = (
           actions: params.actions,
           copyModeModifierKey: params.copyModeModifierKey,
           groupModeModifierKey: params.groupModeModifierKey,
+          onRuleDrop: params.onRuleDrop,
         });
       },
     }),

--- a/packages/dnd/src/dndLogic.ts
+++ b/packages/dnd/src/dndLogic.ts
@@ -19,7 +19,7 @@ import {
   pathsAreEqual,
 } from 'react-querybuilder';
 import { isHotkeyPressed } from './isHotkeyPressed';
-import type { CustomCanDropParams } from './types';
+import type { CustomCanDropParams, OnRuleDropCallback } from './types';
 
 // #region canDrop validators
 
@@ -255,6 +255,7 @@ export const handleDrop = ({
   groupModeModifierKey,
   copyModeOverride,
   groupModeOverride,
+  onRuleDrop,
 }: {
   item: DraggedItem;
   dropResult: DropResult | null;
@@ -265,14 +266,16 @@ export const handleDrop = ({
   groupModeModifierKey: string;
   copyModeOverride?: boolean;
   groupModeOverride?: boolean;
+  onRuleDrop?: OnRuleDropCallback;
 }): void => {
   if (!dropResult) return;
 
   const dropEffect = copyModeOverride || isHotkeyPressed(copyModeModifierKey) ? 'copy' : 'move';
   const groupItems = groupModeOverride || isHotkeyPressed(groupModeModifierKey);
   const destinationPath = getDestinationPath(dropResult, groupItems);
+  const isCrossBuilder = schema.qbId !== dropResult.qbId;
 
-  if (schema.qbId === dropResult.qbId) {
+  if (!isCrossBuilder) {
     if (groupItems) {
       actions.groupRule(item.path, destinationPath, dropEffect === 'copy');
     } else {
@@ -300,6 +303,17 @@ export const handleDrop = ({
       }
     }
   }
+
+  onRuleDrop?.({
+    draggedItem: item,
+    sourceQbId: schema.qbId,
+    targetQbId: dropResult.qbId,
+    sourcePath: item.path,
+    targetPath: destinationPath,
+    dropEffect: dropEffect as DropEffect,
+    groupItems,
+    isCrossBuilder,
+  });
 };
 
 /**

--- a/packages/dnd/src/types.ts
+++ b/packages/dnd/src/types.ts
@@ -10,6 +10,7 @@ import type {
   Path,
   QueryBuilderContextProviderProps,
   RuleGroupTypeAny,
+  RuleType,
 } from 'react-querybuilder';
 import type { SetOptional } from 'type-fest';
 import type { DndAdapter } from './adapter';
@@ -108,6 +109,11 @@ export interface QueryBuilderDndProps extends QueryBuilderContextProviderProps {
    * prospective layout, and the preview path of the dragged item.
    */
   onDragMove?: OnDragMoveCallback;
+  /**
+   * Callback invoked after a drag-and-drop operation completes. Receives info
+   * about the dragged item, source/target paths, and drop effect.
+   */
+  onRuleDrop?: OnRuleDropCallback;
 }
 
 /**
@@ -145,6 +151,37 @@ export type OnDragMoveCallback = (params: {
 }) => void;
 
 /**
+ * Info provided to the {@link OnRuleDropCallback} after a drop completes.
+ *
+ * @group DnD
+ */
+export interface RuleDropInfo {
+  /** The dragged rule or group. */
+  draggedItem: RuleType | RuleGroupTypeAny;
+  /** The qbId of the source query builder. */
+  sourceQbId: string;
+  /** The qbId of the target query builder. */
+  targetQbId: string;
+  /** Path of the item in the source query builder before the drop. */
+  sourcePath: Path;
+  /** Path where the item was inserted in the target query builder. */
+  targetPath: Path;
+  /** Whether the item was moved or copied. */
+  dropEffect: DropEffect;
+  /** Whether the drop created a new group around the target. */
+  groupItems: boolean;
+  /** Whether the drop crossed query builder boundaries. */
+  isCrossBuilder: boolean;
+}
+
+/**
+ * Callback invoked after a drag-and-drop operation completes.
+ *
+ * @group DnD
+ */
+export type OnRuleDropCallback = (info: RuleDropInfo) => void;
+
+/**
  * Parameters describing a drag target position for shadow query computation.
  *
  * @group DnD
@@ -170,6 +207,7 @@ export interface QueryBuilderDndContextProps extends Pick<
   | 'hideDefaultDragPreview'
   | 'updateWhileDragging'
   | 'onDragMove'
+  | 'onRuleDrop'
 > {
   adapter?: DndAdapter;
   baseControls: Pick<Controls<FullField, string>, 'rule' | 'ruleGroup' | 'combinatorSelector'>;

--- a/website/docs/dnd.md
+++ b/website/docs/dnd.md
@@ -254,3 +254,33 @@ Default is `false`.
 `(params: { draggedItem, shadowQuery, originalQuery, previewPath }) => void`
 
 Callback invoked on each drag position change when [`updateWhileDragging`](#updatewhiledragging) is `true`. Receives the current shadow query (the preview query with the dragged item at its prospective position), the original query, and the preview path.
+
+### `onRuleDrop`
+
+`(info: RuleDropInfo) => void`
+
+Callback invoked after a drag-and-drop operation completes (both same-builder and cross-builder). The `info` parameter contains:
+
+| Property         | Type                           | Description                                       |
+| ---------------- | ------------------------------ | ------------------------------------------------- |
+| `draggedItem`    | `RuleType \| RuleGroupTypeAny` | The dragged rule or group                         |
+| `sourceQbId`     | `string`                       | The `qbId` of the source query builder            |
+| `targetQbId`     | `string`                       | The `qbId` of the target query builder            |
+| `sourcePath`     | `Path`                         | Path of the item before the drop                  |
+| `targetPath`     | `Path`                         | Path where the item was inserted                  |
+| `dropEffect`     | `'move' \| 'copy'`             | Whether the item was moved or copied              |
+| `groupItems`     | `boolean`                      | Whether a new group was created around the target |
+| `isCrossBuilder` | `boolean`                      | Whether the drop crossed query builder boundaries |
+
+```tsx
+<QueryBuilderDnD
+  dnd={pragmaticDndAdapter}
+  onRuleDrop={info => {
+    console.log(
+      `Rule ${info.isCrossBuilder ? 'transferred' : 'moved'} ` +
+        `from ${info.sourcePath} to ${info.targetPath}`
+    );
+  }}>
+  <QueryBuilder />
+</QueryBuilderDnD>
+```

--- a/website/versioned_docs/version-7/dnd.md
+++ b/website/versioned_docs/version-7/dnd.md
@@ -254,3 +254,33 @@ Default is `false`.
 `(params: { draggedItem, shadowQuery, originalQuery, previewPath }) => void`
 
 Callback invoked on each drag position change when [`updateWhileDragging`](#updatewhiledragging) is `true`. Receives the current shadow query (the preview query with the dragged item at its prospective position), the original query, and the preview path.
+
+### `onRuleDrop`
+
+`(info: RuleDropInfo) => void`
+
+Callback invoked after a drag-and-drop operation completes (both same-builder and cross-builder). The `info` parameter contains:
+
+| Property         | Type                           | Description                                       |
+| ---------------- | ------------------------------ | ------------------------------------------------- |
+| `draggedItem`    | `RuleType \| RuleGroupTypeAny` | The dragged rule or group                         |
+| `sourceQbId`     | `string`                       | The `qbId` of the source query builder            |
+| `targetQbId`     | `string`                       | The `qbId` of the target query builder            |
+| `sourcePath`     | `Path`                         | Path of the item before the drop                  |
+| `targetPath`     | `Path`                         | Path where the item was inserted                  |
+| `dropEffect`     | `'move' \| 'copy'`             | Whether the item was moved or copied              |
+| `groupItems`     | `boolean`                      | Whether a new group was created around the target |
+| `isCrossBuilder` | `boolean`                      | Whether the drop crossed query builder boundaries |
+
+```tsx
+<QueryBuilderDnD
+  dnd={pragmaticDndAdapter}
+  onRuleDrop={info => {
+    console.log(
+      `Rule ${info.isCrossBuilder ? 'transferred' : 'moved'} ` +
+        `from ${info.sourcePath} to ${info.targetPath}`
+    );
+  }}>
+  <QueryBuilder />
+</QueryBuilderDnD>
+```


### PR DESCRIPTION
Introduce an `onRuleDrop` callback prop that triggers after drag-and-drop operations, providing details about the dragged item and the drop effect.

- Fixes #823