### PR TITLE
Add `dragHandleProps`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-N/A
+### Added
+
+- New `dragHandleProps` prop on the `DragHandle` component. The `@dnd-kit` adapter uses it to pass drag-handle ARIA attributes and sensor listeners through as JSX props; its `useRuleDnD`/`useRuleGroupDnD` hooks now return a `dragHandleProps` object.
+
+### Changed
+
+- The `@dnd-kit` adapter now applies drag-handle ARIA attributes and sensor listeners as JSX props (via `dragHandleProps`) instead of through imperative DOM manipulation. Custom `dragHandle` components used with the dnd-kit adapter must now spread `dragHandleProps` onto their root element to remain draggable. Disabled rule groups now expose drag-handle ARIA attributes (without activator listeners).
 
 ## [v8.19.1] - 2026-06-10
 

--- a/packages/antd/src/AntDDragHandle.tsx
+++ b/packages/antd/src/AntDDragHandle.tsx
@@ -22,6 +22,7 @@ export const AntDDragHandle: React.ForwardRefExoticComponent<
     {
       className,
       title,
+      dragHandleProps,
       // Props that should not be in extraProps
       testID: _testID,
       level: _level,
@@ -35,5 +36,13 @@ export const AntDDragHandle: React.ForwardRefExoticComponent<
       ...extraProps
     },
     dragRef
-  ) => <HolderOutlined className={className} title={title} {...extraProps} ref={dragRef} />
+  ) => (
+    <HolderOutlined
+      className={className}
+      title={title}
+      {...extraProps}
+      {...dragHandleProps}
+      ref={dragRef}
+    />
+  )
 );

--- a/packages/dnd/src/adapter.ts
+++ b/packages/dnd/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { Ref } from 'react';
+import type { HTMLAttributes, Ref } from 'react';
 import type {
   DropEffect,
   Path,
@@ -73,6 +73,12 @@ export interface AdapterUseRuleDnDResult {
   dropMonitorId: string | symbol;
   dragRef: Ref<HTMLSpanElement>;
   dndRef: Ref<HTMLDivElement>;
+  /**
+   * Props to spread onto the drag handle element (e.g. ARIA attributes and
+   * sensor event listeners). Applied as JSX props rather than imperative DOM
+   * manipulation.
+   */
+  dragHandleProps?: HTMLAttributes<HTMLElement>;
   dropEffect?: DropEffect;
   groupItems?: boolean;
   dropNotAllowed?: boolean;
@@ -90,6 +96,12 @@ export interface AdapterUseRuleGroupDnDResult {
   previewRef: Ref<HTMLDivElement>;
   dragRef: Ref<HTMLSpanElement>;
   dropRef: Ref<HTMLDivElement>;
+  /**
+   * Props to spread onto the drag handle element (e.g. ARIA attributes and
+   * sensor event listeners). Applied as JSX props rather than imperative DOM
+   * manipulation.
+   */
+  dragHandleProps?: HTMLAttributes<HTMLElement>;
   dropEffect?: DropEffect;
   groupItems?: boolean;
   dropNotAllowed?: boolean;

--- a/packages/dnd/src/adapters/dnd-kit.test.tsx
+++ b/packages/dnd/src/adapters/dnd-kit.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, renderHook, screen } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
 import * as React from 'react';
 import type {
   DraggedItem,
@@ -821,7 +821,7 @@ describe('createDndKitAdapter', () => {
       const adapter = createDndKitAdapter(mock);
 
       const TestComponent = () => {
-        const { dragRef } = adapter.useRuleDnD({
+        const { dragRef, dragHandleProps } = adapter.useRuleDnD({
           path: [0],
           disabled: false,
           schema: mockSchema(),
@@ -830,7 +830,7 @@ describe('createDndKitAdapter', () => {
           copyModeModifierKey: 'alt',
           groupModeModifierKey: 'ctrl',
         });
-        return <span ref={dragRef} data-testid="handle" />;
+        return <span ref={dragRef} data-testid="handle" {...dragHandleProps} />;
       };
 
       render(
@@ -860,7 +860,7 @@ describe('createDndKitAdapter', () => {
       const adapter = createDndKitAdapter(mock);
 
       const TestComponent = () => {
-        const { dragRef } = adapter.useRuleGroupDnD({
+        const { dragRef, dragHandleProps } = adapter.useRuleGroupDnD({
           path: [1],
           disabled: false,
           schema: mockSchema(),
@@ -869,7 +869,7 @@ describe('createDndKitAdapter', () => {
           copyModeModifierKey: 'alt',
           groupModeModifierKey: 'ctrl',
         });
-        return <span ref={dragRef} data-testid="handle" />;
+        return <span ref={dragRef} data-testid="handle" {...dragHandleProps} />;
       };
 
       render(
@@ -883,22 +883,22 @@ describe('createDndKitAdapter', () => {
       expect(handle.getAttribute('tabindex')).toBe('0');
     });
 
-    it('does not set attributes when drag is disabled', () => {
+    it('exposes ARIA attributes but no listeners on a disabled drag handle', () => {
       const mock = createMockDndKit({
-        useDraggable: vi
-          .fn()
-          .mockReturnValue({
-            setNodeRef: vi.fn(),
-            setActivatorNodeRef: vi.fn(),
-            isDragging: false,
-            listeners: {},
-            attributes: { role: 'button', tabIndex: 0 },
-          }),
+        useDraggable: vi.fn().mockReturnValue({
+          setNodeRef: vi.fn(),
+          setActivatorNodeRef: vi.fn(),
+          isDragging: false,
+          // dnd-kit returns `undefined` listeners when dragging is disabled
+          listeners: undefined,
+          attributes: { role: 'button', tabIndex: 0, 'aria-disabled': true },
+        }),
       });
       const adapter = createDndKitAdapter(mock);
 
+      let dragHandleProps: ReturnType<typeof adapter.useRuleGroupDnD>['dragHandleProps'];
       const TestComponent = () => {
-        const { dragRef } = adapter.useRuleGroupDnD({
+        const r = adapter.useRuleGroupDnD({
           path: [],
           disabled: false,
           schema: mockSchema(),
@@ -907,7 +907,8 @@ describe('createDndKitAdapter', () => {
           copyModeModifierKey: 'alt',
           groupModeModifierKey: 'ctrl',
         });
-        return <span ref={dragRef} data-testid="handle" />;
+        dragHandleProps = r.dragHandleProps;
+        return <span ref={r.dragRef} data-testid="handle" {...r.dragHandleProps} />;
       };
 
       render(
@@ -917,8 +918,12 @@ describe('createDndKitAdapter', () => {
       );
 
       const handle = screen.getByTestId('handle');
-      // Root group (path []) has drag disabled, so no attributes set
-      expect(handle.getAttribute('role')).toBeNull();
+      // Root group (path []) has drag disabled. Unlike before, the handle still
+      // receives its ARIA attributes (incl. aria-disabled)...
+      expect(handle.getAttribute('role')).toBe('button');
+      expect(handle.getAttribute('aria-disabled')).toBe('true');
+      // ...but carries no activation listeners.
+      expect(dragHandleProps).not.toHaveProperty('onPointerDown');
     });
   });
 
@@ -939,7 +944,7 @@ describe('createDndKitAdapter', () => {
       const adapter = createDndKitAdapter(mock);
 
       const TestComponent = () => {
-        const { dragRef } = adapter.useRuleDnD({
+        const { dragRef, dragHandleProps } = adapter.useRuleDnD({
           path: [0],
           disabled: false,
           schema: mockSchema(),
@@ -948,7 +953,7 @@ describe('createDndKitAdapter', () => {
           copyModeModifierKey: 'alt',
           groupModeModifierKey: 'ctrl',
         });
-        return <span ref={dragRef} data-testid="handle" />;
+        return <span ref={dragRef} data-testid="handle" {...dragHandleProps} />;
       };
 
       render(
@@ -958,14 +963,14 @@ describe('createDndKitAdapter', () => {
       );
 
       const handle = screen.getByTestId('handle');
-      const pointerEvent = new Event('pointerdown', { bubbles: true });
-      handle.dispatchEvent(pointerEvent);
+      fireEvent.pointerDown(handle);
 
+      // Spread as a JSX prop, so the sensor listener fires via React's synthetic
+      // event system and receives a SyntheticEvent wrapping the native event.
       expect(onPointerDown).toHaveBeenCalledTimes(1);
-      expect(onPointerDown).toHaveBeenCalledWith(
-        expect.objectContaining({ nativeEvent: pointerEvent })
-      );
-      expect(onPointerDown).toHaveBeenCalledWith(expect.any(Event));
+      const event = onPointerDown.mock.calls[0][0];
+      expect(event.nativeEvent).toBeInstanceOf(Event);
+      expect(event.type).toBe('pointerdown');
     });
 
     it('attaches sensor listeners to drag handle in useRuleGroupDnD', () => {
@@ -984,7 +989,7 @@ describe('createDndKitAdapter', () => {
       const adapter = createDndKitAdapter(mock);
 
       const TestComponent = () => {
-        const { dragRef } = adapter.useRuleGroupDnD({
+        const { dragRef, dragHandleProps } = adapter.useRuleGroupDnD({
           path: [1],
           disabled: false,
           schema: mockSchema(),
@@ -993,7 +998,7 @@ describe('createDndKitAdapter', () => {
           copyModeModifierKey: 'alt',
           groupModeModifierKey: 'ctrl',
         });
-        return <span ref={dragRef} data-testid="handle" />;
+        return <span ref={dragRef} data-testid="handle" {...dragHandleProps} />;
       };
 
       render(
@@ -1003,14 +1008,14 @@ describe('createDndKitAdapter', () => {
       );
 
       const handle = screen.getByTestId('handle');
-      const pointerEvent = new Event('pointerdown', { bubbles: true });
-      handle.dispatchEvent(pointerEvent);
+      fireEvent.pointerDown(handle);
 
+      // Spread as a JSX prop, so the sensor listener fires via React's synthetic
+      // event system and receives a SyntheticEvent wrapping the native event.
       expect(onPointerDown).toHaveBeenCalledTimes(1);
-      expect(onPointerDown).toHaveBeenCalledWith(
-        expect.objectContaining({ nativeEvent: pointerEvent })
-      );
-      expect(onPointerDown).toHaveBeenCalledWith(expect.any(Event));
+      const event = onPointerDown.mock.calls[0][0];
+      expect(event.nativeEvent).toBeInstanceOf(Event);
+      expect(event.type).toBe('pointerdown');
     });
   });
 
@@ -1514,7 +1519,7 @@ describe('createDndKitAdapter', () => {
     });
   });
 
-  describe('branch coverage: null attribute values', () => {
+  describe('null attribute values', () => {
     it('skips setting attributes with null values in useRuleDnD', () => {
       const mock = createMockDndKit({
         useDraggable: vi
@@ -1530,7 +1535,7 @@ describe('createDndKitAdapter', () => {
       const adapter = createDndKitAdapter(mock);
 
       const TestComponent = () => {
-        const { dragRef } = adapter.useRuleDnD({
+        const { dragRef, dragHandleProps } = adapter.useRuleDnD({
           path: [0],
           disabled: false,
           schema: mockSchema(),
@@ -1539,7 +1544,7 @@ describe('createDndKitAdapter', () => {
           copyModeModifierKey: 'alt',
           groupModeModifierKey: 'ctrl',
         });
-        return <span ref={dragRef} data-testid="handle" />;
+        return <span ref={dragRef} data-testid="handle" {...dragHandleProps} />;
       };
 
       render(
@@ -1568,7 +1573,7 @@ describe('createDndKitAdapter', () => {
       const adapter = createDndKitAdapter(mock);
 
       const TestComponent = () => {
-        const { dragRef } = adapter.useRuleGroupDnD({
+        const { dragRef, dragHandleProps } = adapter.useRuleGroupDnD({
           path: [1],
           disabled: false,
           schema: mockSchema(),
@@ -1577,7 +1582,7 @@ describe('createDndKitAdapter', () => {
           copyModeModifierKey: 'alt',
           groupModeModifierKey: 'ctrl',
         });
-        return <span ref={dragRef} data-testid="handle" />;
+        return <span ref={dragRef} data-testid="handle" {...dragHandleProps} />;
       };
 
       render(

--- a/packages/dnd/src/adapters/dnd-kit.tsx
+++ b/packages/dnd/src/adapters/dnd-kit.tsx
@@ -8,14 +8,7 @@ import type {
   useSensors as useSensorsImport,
 } from '@dnd-kit/core';
 import * as React from 'react';
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
 import type {
   DndDropTargetType,
   DraggedItem,

--- a/packages/dnd/src/adapters/dnd-kit.tsx
+++ b/packages/dnd/src/adapters/dnd-kit.tsx
@@ -12,7 +12,6 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -91,41 +90,6 @@ const getDropId = (
   path: number[],
   qbId: string
 ): string => `drop-${type}-${qbId}-${path.join('_')}`;
-
-/**
- * Attaches dnd-kit's React synthetic event listeners (e.g. `onPointerDown`)
- * as native DOM event listeners on the given node. This bridges the gap
- * between the ref-based adapter interface and dnd-kit's listener-based API.
- */
-const useNativeListeners = (
-  nodeRef: React.RefObject<HTMLElement | null>,
-  listeners: Record<string, Function> | undefined
-): void => {
-  useEffect(() => {
-    const node = nodeRef.current;
-    if (!node || !listeners) return undefined;
-
-    const nativeHandlers: [string, EventListener][] = [];
-
-    for (const [reactEventName, handler] of Object.entries(listeners)) {
-      const nativeEventName = reactEventName.slice(2).toLowerCase();
-      const nativeHandler: EventListener = e => {
-        // Need to make sure the instance type stays the same, so add property
-        // instead of create new event with nativeEvent property
-        (e as Event & { nativeEvent: Event }).nativeEvent = e;
-        return handler(e);
-      };
-      node.addEventListener(nativeEventName, nativeHandler);
-      nativeHandlers.push([nativeEventName, nativeHandler]);
-    }
-
-    return () => {
-      for (const [name, handler] of nativeHandlers) {
-        node.removeEventListener(name, handler);
-      }
-    };
-  }, [nodeRef, listeners]);
-};
 
 // #endregion
 
@@ -518,7 +482,6 @@ export const createDndKitAdapter = (dndKitExports: DndKitExports): DndAdapter =>
 
   const useRuleDnD = (params: DndAdapterRuleDnDParams): AdapterUseRuleDnDResult => {
     const { activeDragItem, timerCopyMode, timerGroupMode } = useContext(DragStateContext);
-    const activatorNodeRef = useRef<HTMLSpanElement>(null);
     const containerNodeRef = useRef<HTMLDivElement>(null);
 
     const dragId = getDragId('rule', params.path, params.schema.qbId);
@@ -599,26 +562,19 @@ export const createDndKitAdapter = (dndKitExports: DndKitExports): DndAdapter =>
     // Drag handle ref: activator node
     const dragRef: React.RefCallback<HTMLSpanElement> = useCallback(
       (node: HTMLSpanElement | null) => {
-        activatorNodeRef.current = node;
         setActivatorNodeRef(node);
       },
       [setActivatorNodeRef]
     );
 
-    // Set ARIA attributes on drag handle
-    // TODO: Spread these as JSX props instead of imperitive DOM manipulation
-    useEffect(() => {
-      const node = activatorNodeRef.current;
-      if (!node || !attributes) return;
-      for (const [key, value] of Object.entries(attributes)) {
-        if (value != null) {
-          node.setAttribute(key === 'tabIndex' ? 'tabindex' : key, String(value));
-        }
-      }
-    }, [attributes]);
-
-    // Attach sensor listeners (e.g. onPointerDown) to the drag handle
-    useNativeListeners(activatorNodeRef, listeners);
+    // ARIA attributes and sensor listeners (e.g. onPointerDown) for the drag
+    // handle, spread as JSX props by the consuming component. `listeners` is
+    // `undefined` when dragging is disabled, so a disabled handle still gets
+    // its ARIA attributes (incl. `aria-disabled`) but no activation listeners.
+    const dragHandleProps = useMemo(
+      () => ({ ...attributes, ...listeners }) as React.HTMLAttributes<HTMLElement>,
+      [attributes, listeners]
+    );
 
     return {
       isDragging,
@@ -627,6 +583,7 @@ export const createDndKitAdapter = (dndKitExports: DndKitExports): DndAdapter =>
       dropMonitorId: dropId,
       dndRef,
       dragRef,
+      dragHandleProps,
       dropEffect: timerCopyMode || isHotkeyPressed(params.copyModeModifierKey) ? 'copy' : 'move',
       groupItems: timerGroupMode || isHotkeyPressed(params.groupModeModifierKey),
       dropNotAllowed,
@@ -639,7 +596,6 @@ export const createDndKitAdapter = (dndKitExports: DndKitExports): DndAdapter =>
 
   const useRuleGroupDnD = (params: DndAdapterRuleGroupDnDParams): AdapterUseRuleGroupDnDResult => {
     const { activeDragItem, timerCopyMode, timerGroupMode } = useContext(DragStateContext);
-    const activatorNodeRef = useRef<HTMLSpanElement>(null);
 
     const dragId = getDragId('ruleGroup', params.path, params.schema.qbId);
     const dropId = getDropId('ruleGroup', params.path, params.schema.qbId);
@@ -725,26 +681,20 @@ export const createDndKitAdapter = (dndKitExports: DndKitExports): DndAdapter =>
     // Drag handle ref: activator node
     const dragRef: React.RefCallback<HTMLSpanElement> = useCallback(
       (node: HTMLSpanElement | null) => {
-        activatorNodeRef.current = node;
         setActivatorNodeRef(node);
       },
       [setActivatorNodeRef]
     );
 
-    // Set ARIA attributes on drag handle
-    // TODO: Spread these as JSX props instead of imperitive DOM manipulation
-    useEffect(() => {
-      const node = activatorNodeRef.current;
-      if (!node || !attributes || isDragDisabled) return;
-      for (const [key, value] of Object.entries(attributes)) {
-        if (value != null) {
-          node.setAttribute(key === 'tabIndex' ? 'tabindex' : key, String(value));
-        }
-      }
-    }, [attributes, isDragDisabled]);
-
-    // Attach sensor listeners (e.g. onPointerDown) to the drag handle
-    useNativeListeners(activatorNodeRef, listeners);
+    // ARIA attributes and sensor listeners for the drag handle, spread as JSX
+    // props by the consuming component. Treated identically to rules: dnd-kit
+    // returns `listeners: undefined` when `isDragDisabled`, so a disabled group
+    // handle still gets its ARIA attributes (incl. `aria-disabled`) but no
+    // activation listeners.
+    const dragHandleProps = useMemo(
+      () => ({ ...attributes, ...listeners }) as React.HTMLAttributes<HTMLElement>,
+      [attributes, listeners]
+    );
 
     return {
       isDragging,
@@ -754,6 +704,7 @@ export const createDndKitAdapter = (dndKitExports: DndKitExports): DndAdapter =>
       previewRef,
       dragRef,
       dropRef,
+      dragHandleProps,
       dropEffect: timerCopyMode || isHotkeyPressed(params.copyModeModifierKey) ? 'copy' : 'move',
       groupItems: timerGroupMode || isHotkeyPressed(params.groupModeModifierKey),
       dropNotAllowed,

--- a/packages/fluent/src/FluentDragHandle.tsx
+++ b/packages/fluent/src/FluentDragHandle.tsx
@@ -11,10 +11,25 @@ export const FluentDragHandle: React.ForwardRefExoticComponent<
   (DragHandleProps & TextProps) & React.RefAttributes<HTMLSpanElement>
 > = forwardRef<HTMLSpanElement, DragHandleProps & TextProps>(
   (
-    { className, title, label, testID, schema: _schema, ruleOrGroup: _ruleOrGroup, ...otherProps },
+    {
+      className,
+      title,
+      label,
+      testID,
+      dragHandleProps,
+      schema: _schema,
+      ruleOrGroup: _ruleOrGroup,
+      ...otherProps
+    },
     dragRef
   ) => (
-    <Text data-testid={testID} className={className} title={title} {...otherProps} ref={dragRef}>
+    <Text
+      data-testid={testID}
+      className={className}
+      title={title}
+      {...otherProps}
+      {...dragHandleProps}
+      ref={dragRef}>
       {label}
     </Text>
   )

--- a/packages/material/src/MaterialDragHandle.tsx
+++ b/packages/material/src/MaterialDragHandle.tsx
@@ -35,6 +35,7 @@ export const MaterialDragHandle: React.ForwardRefExoticComponent<
       validation,
       schema,
       ruleOrGroup,
+      dragHandleProps,
       muiComponents: muiComponentsProp,
       ...otherProps
     },
@@ -57,6 +58,7 @@ export const MaterialDragHandle: React.ForwardRefExoticComponent<
           validation={validation}
           schema={schema}
           ruleOrGroup={ruleOrGroup}
+          dragHandleProps={dragHandleProps}
         />
       );
     }
@@ -64,7 +66,7 @@ export const MaterialDragHandle: React.ForwardRefExoticComponent<
     const { DragIndicator } = muiComponents;
 
     return (
-      <span key={key} ref={dragRef} className={className} title={title}>
+      <span key={key} ref={dragRef} className={className} title={title} {...dragHandleProps}>
         <DragIndicator {...otherProps} />
       </span>
     );

--- a/packages/native/vitest.config.ts
+++ b/packages/native/vitest.config.ts
@@ -1,27 +1,23 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig(
-  import('vitest-native').then(
-    ({ reactNative }) =>
-      ({
-        plugins: [reactNative()],
-        oxc: {
-          jsx: {
-            runtime: 'automatic',
-            importSource: 'react',
-          },
-        },
-        test: {
-          globals: true,
-          testTimeout: 30_000,
-          alias: {
-            'react-querybuilder': '../../packages/react-querybuilder/src',
-            '@react-querybuilder/core': '../../packages/core/src',
-            '@rqb-testing': '../../utils/testing',
-            '@rqb-dbquerytestutils': '../../packages/core/src/utils/formatQuery/dbqueryTestUtils',
-          },
-        },
-        // oxlint-disable-next-line typescript/no-explicit-any
-      }) as any
-  )
+  import('vitest-native').then(({ reactNative }) => ({
+    plugins: [reactNative({ engine: 'mock' })],
+    oxc: {
+      jsx: {
+        runtime: 'automatic',
+        importSource: 'react',
+      } as const,
+    },
+    test: {
+      globals: true,
+      testTimeout: 30_000,
+      alias: {
+        'react-querybuilder': '../../packages/react-querybuilder/src',
+        '@react-querybuilder/core': '../../packages/core/src',
+        '@rqb-testing': '../../utils/testing',
+        '@rqb-dbquerytestutils': '../../packages/core/src/utils/formatQuery/dbqueryTestUtils',
+      },
+    },
+  }))
 );

--- a/packages/prime/src/PrimeDragHandle.tsx
+++ b/packages/prime/src/PrimeDragHandle.tsx
@@ -19,6 +19,7 @@ export const PrimeDragHandle: React.ForwardRefExoticComponent<
     {
       className,
       title,
+      dragHandleProps,
       // Props that should not be in extraProps
       testID: _testID,
       level: _level,
@@ -37,6 +38,7 @@ export const PrimeDragHandle: React.ForwardRefExoticComponent<
       className={`pi pi-ellipsis-v ${className ?? /* v8 ignore start -- @preserve */ '' /* v8 ignore stop -- @preserve */}`}
       title={title}
       {...extraProps}
+      {...dragHandleProps}
       ref={dragRef}
     />
   )

--- a/packages/react-querybuilder/src/components/DragHandle.tsx
+++ b/packages/react-querybuilder/src/components/DragHandle.tsx
@@ -10,7 +10,12 @@ import type { DragHandleProps } from '../types';
 export const DragHandle: React.ForwardRefExoticComponent<
   DragHandleProps & React.RefAttributes<HTMLSpanElement>
 > = forwardRef<HTMLSpanElement, DragHandleProps>((props, dragRef) => (
-  <span data-testid={props.testID} ref={dragRef} className={props.className} title={props.title}>
+  <span
+    {...props.dragHandleProps}
+    data-testid={props.testID}
+    ref={dragRef}
+    className={props.className}
+    title={props.title}>
     {props.label}
   </span>
 ));

--- a/packages/react-querybuilder/src/components/Rule.test.tsx
+++ b/packages/react-querybuilder/src/components/Rule.test.tsx
@@ -404,6 +404,18 @@ describe('dynamic classNames', () => {
     );
     expect(getRuleClassname).toHaveBeenCalledWith(rule, { fieldData: fieldMap.f1 });
   });
+
+  // Covers dnd-only branches normally exercised by @react-querybuilder/dnd
+  it('adds dnd classNames for dragging/copy/group/disallowed states', () => {
+    render(<Rule {...getProps()} isDragging isOver dropEffect="copy" groupItems dropNotAllowed />);
+    expect(screen.getByTestId(TestID.rule)).toHaveClass(
+      sc.dndDragging,
+      sc.dndOver,
+      sc.dndCopy,
+      sc.dndGroup,
+      sc.dndDropNotAllowed
+    );
+  });
 });
 
 describe('deprecated props', () => {

--- a/packages/react-querybuilder/src/components/Rule.tsx
+++ b/packages/react-querybuilder/src/components/Rule.tsx
@@ -208,6 +208,7 @@ export const RuleComponents: React.MemoExoticComponent<
           title={r.translations.dragHandle.title}
           label={r.translations.dragHandle.label}
           className={r.classNames.dragHandle}
+          dragHandleProps={r.dragHandleProps}
           ruleOrGroup={r.rule}
         />
       )}

--- a/packages/react-querybuilder/src/components/RuleGroup.test.tsx
+++ b/packages/react-querybuilder/src/components/RuleGroup.test.tsx
@@ -532,6 +532,13 @@ describe('dynamic classNames', () => {
       'custom-combinatorBased-class'
     );
   });
+
+  // Covers dnd-only branches normally exercised by @react-querybuilder/dnd
+  it('adds dnd classNames to the header for copy/disallowed states', () => {
+    render(<RuleGroup {...getRuleGroupProps()} isOver dropEffect="copy" dropNotAllowed />);
+    const header = screen.getByTestId(TestID.ruleGroup).querySelector(`.${sc.header}`)!;
+    expect(header).toHaveClass(sc.dndOver, sc.dndCopy, sc.dndDropNotAllowed);
+  });
 });
 
 describe('dnd warnings', () => {

--- a/packages/react-querybuilder/src/components/RuleGroup.tsx
+++ b/packages/react-querybuilder/src/components/RuleGroup.tsx
@@ -190,6 +190,7 @@ export const RuleGroupHeaderComponents: React.MemoExoticComponent<
           title={rg.translations.dragHandle.title}
           label={rg.translations.dragHandle.label}
           className={rg.classNames.dragHandle}
+          dragHandleProps={rg.dragHandleProps}
           ruleOrGroup={rg.ruleGroup}
         />
       )}

--- a/packages/react-querybuilder/src/types/props.ts
+++ b/packages/react-querybuilder/src/types/props.ts
@@ -47,6 +47,7 @@ import type {
 import type {
   ComponentType,
   ForwardRefExoticComponent,
+  HTMLAttributes,
   MouseEvent as ReactMouseEvent,
   ReactNode,
   Ref,
@@ -352,6 +353,13 @@ export interface ShiftActionsProps extends CommonSubComponentProps {
 export interface DragHandleProps extends CommonSubComponentProps {
   label?: ReactNode;
   ruleOrGroup: RuleGroupTypeAny | RuleType;
+  /**
+   * Props to spread onto the drag handle element, supplied by the active
+   * drag-and-drop adapter (e.g. ARIA attributes and sensor event listeners).
+   * Custom `dragHandle` components should spread these onto the same element
+   * that receives the forwarded `ref`.
+   */
+  dragHandleProps?: HTMLAttributes<HTMLElement>;
 }
 
 /**
@@ -650,6 +658,8 @@ export interface UseRuleGroupDnD {
   previewRef: Ref<HTMLDivElement>;
   dragRef: Ref<HTMLSpanElement>;
   dropRef: Ref<HTMLDivElement>;
+  /** Props to spread onto the drag handle element (ARIA attributes, listeners). */
+  dragHandleProps?: HTMLAttributes<HTMLElement>;
   /** `"move"` by default; `"copy"` if the modifier key is pressed. */
   dropEffect?: DropEffect;
   /** True if the dragged and hovered items should form a new group. */
@@ -689,6 +699,8 @@ export interface UseRuleDnD {
   dropMonitorId: string | symbol;
   dragRef: Ref<HTMLSpanElement>;
   dndRef: Ref<HTMLDivElement>;
+  /** Props to spread onto the drag handle element (ARIA attributes, listeners). */
+  dragHandleProps?: HTMLAttributes<HTMLElement>;
   /** `"move"` by default; `"copy"` if the modifier key is pressed. */
   dropEffect?: DropEffect;
   /** True if the dragged and hovered items should form a new group. */

--- a/utils/testing/testDragHandle.tsx
+++ b/utils/testing/testDragHandle.tsx
@@ -30,5 +30,10 @@ export const testDragHandle = (
       render(<DragHandle {...props} className="foo" />);
       expect(screen.getByTitle(title)).toHaveClass('foo');
     });
+
+    it('should spread dragHandleProps onto the handle', () => {
+      render(<DragHandle {...props} dragHandleProps={{ 'aria-roledescription': 'draggable' }} />);
+      expect(screen.getByTitle(title)).toHaveAttribute('aria-roledescription', 'draggable');
+    });
   });
 };

--- a/website/docs/components/querybuilder-controlelements.md
+++ b/website/docs/components/querybuilder-controlelements.md
@@ -228,18 +228,19 @@ Provides a draggable handle for reordering rules and groups. Defaults to [`DragH
 
 Receives the forwarded `ref` and the following props per the `DragHandleProps` interface:
 
-| Prop          | Type                                      | Description                                                  |
-| ------------- | ----------------------------------------- | ------------------------------------------------------------ |
-| `label`       | `ReactNode`                               | `translations.dragHandle.label`, e.g. "⁞⁞"                   |
-| `title`       | `string`                                  | `translations.dragHandle.title`, e.g. "Drag handle"          |
-| `className`   | `string`                                  | CSS `classNames` to be applied                               |
-| `level`       | `number`                                  | The `level` of this rule/group                               |
-| `context`     | `any`                                     | Container for custom props that are passed to all components |
-| `validation`  | <code>boolean \| ValidationResult</code>  | Validation result of this rule/group                         |
-| `disabled`    | `boolean`                                 | Whether this rule/group is disabled/locked                   |
-| `path`        | `Path`                                    | [Path](../tips/path) of this rule/group                      |
-| `schema`      | `Schema`                                  | Query [schema](../typescript#miscellaneous)                  |
-| `ruleOrGroup` | <code>RuleGroupTypeAny \| RuleType</code> | This group or rule, depending on the parent component        |
+| Prop              | Type                                      | Description                                                                                                                                                                   |
+| ----------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `label`           | `ReactNode`                               | `translations.dragHandle.label`, e.g. "⁞⁞"                                                                                                                                    |
+| `title`           | `string`                                  | `translations.dragHandle.title`, e.g. "Drag handle"                                                                                                                           |
+| `className`       | `string`                                  | CSS `classNames` to be applied                                                                                                                                                |
+| `level`           | `number`                                  | The `level` of this rule/group                                                                                                                                                |
+| `context`         | `any`                                     | Container for custom props that are passed to all components                                                                                                                  |
+| `validation`      | <code>boolean \| ValidationResult</code>  | Validation result of this rule/group                                                                                                                                          |
+| `disabled`        | `boolean`                                 | Whether this rule/group is disabled/locked                                                                                                                                    |
+| `path`            | `Path`                                    | [Path](../tips/path) of this rule/group                                                                                                                                       |
+| `schema`          | `Schema`                                  | Query [schema](../typescript#miscellaneous)                                                                                                                                   |
+| `ruleOrGroup`     | <code>RuleGroupTypeAny \| RuleType</code> | This group or rule, depending on the parent component                                                                                                                         |
+| `dragHandleProps` | `HTMLAttributes<HTMLElement>`             | Props (e.g. ARIA attributes and drag event listeners) supplied by the active [drag-and-drop adapter](../dnd); spread these onto the element that receives the forwarded `ref` |
 
 </details>
 

--- a/website/docs/dnd.md
+++ b/website/docs/dnd.md
@@ -74,7 +74,26 @@ const App = () => (
 );
 ```
 
-The dnd-kit adapter uses `PointerSensor` and `KeyboardSensor` by default, with a 5px activation distance to prevent accidental drags. ARIA attributes are automatically applied to drag handles for accessibility.
+The dnd-kit adapter uses `PointerSensor` and `KeyboardSensor` by default, with a 5px activation distance to prevent accidental drags. Drag-handle ARIA attributes and sensor event listeners are passed to the [drag handle](./components/draghandle) as JSX props through a `dragHandleProps` object, so accessibility attributes are applied automatically.
+
+:::info[Custom drag handles]
+
+The default `DragHandle` component spreads `dragHandleProps` for you. If you supply a [custom `dragHandle` component](./components/querybuilder-controlelements#draghandle), it must spread `dragHandleProps` onto the element that receives the forwarded `ref`, otherwise the handle will not respond to drag interactions:
+
+```tsx
+import { forwardRef } from 'react';
+import type { DragHandleProps } from 'react-querybuilder';
+
+const CustomDragHandle = forwardRef<HTMLSpanElement, DragHandleProps>(
+  ({ className, title, label, dragHandleProps }, dragRef) => (
+    <span ref={dragRef} className={className} title={title} {...dragHandleProps}>
+      {label}
+    </span>
+  )
+);
+```
+
+:::
 
 ### Using the `react-dnd` adapter
 
@@ -155,12 +174,12 @@ const myAdapter: DndAdapter = {
   // Hook providing drag-and-drop behavior for rule components
   useRuleDnD: params => {
     // Implement using your DnD library's primitives
-    // Must return: isDragging, dragMonitorId, isOver, dropMonitorId, dragRef, dndRef, dropEffect?, groupItems?, dropNotAllowed?
+    // Must return: isDragging, dragMonitorId, isOver, dropMonitorId, dragRef, dndRef, dragHandleProps?, dropEffect?, groupItems?, dropNotAllowed?
   },
 
   // Hook providing drag-and-drop behavior for rule group components
   useRuleGroupDnD: params => {
-    // Must return: isDragging, dragMonitorId, isOver, dropMonitorId, previewRef, dragRef, dropRef, dropEffect?, groupItems?, dropNotAllowed?
+    // Must return: isDragging, dragMonitorId, isOver, dropMonitorId, previewRef, dragRef, dropRef, dragHandleProps?, dropEffect?, groupItems?, dropNotAllowed?
   },
 
   // Hook providing drop-target behavior for inline combinators
@@ -171,6 +190,8 @@ const myAdapter: DndAdapter = {
 ```
 
 The shared logic functions `canDropOnRule`, `canDropOnRuleGroup`, `canDropOnInlineCombinator`, `buildDropResult`, and `handleDrop` are exported from `@react-querybuilder/dnd` and can be used in custom adapter implementations to ensure consistent drop validation and behavior.
+
+The optional `dragHandleProps` field returned by `useRuleDnD`/`useRuleGroupDnD` is spread onto the [drag handle](./components/draghandle) as JSX props. Use it to supply drag-handle attributes and event listeners (such as ARIA attributes and pointer/keyboard sensor listeners) without imperative DOM manipulation.
 
 ## Props
 


### PR DESCRIPTION
Introduce `dragHandleProps` to improve accessibility of drag handles in the drag-and-drop components.