### PR TITLE
Assign distinct element aliases for nested subqueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-N/A
+### Fixed
+
+- Subqueries generated for a rule's `match` mode now assign a distinct element alias per nesting level (`elem_alias`, `elem_alias_1`, ...) in the "sql", "parameterized"/"parameterized_named", "cel", and "drizzle" formats. Previously every level reused the same `elem_alias` binding, so a subquery nested within another subquery silently shadowed its parent's binding, making the outer element unreachable from the inner predicate. Output for non-nested subqueries is unchanged.
 
 ## [v8.21.1] - 2026-07-27
 

--- a/packages/core/src/types/export.ts
+++ b/packages/core/src/types/export.ts
@@ -337,6 +337,14 @@ export interface ValueProcessorOptions extends FormatQueryOptions {
    * @default false
    */
   parseNumbers?: boolean;
+  /**
+   * Nesting level of the subquery currently being processed. Incremented each time a rule
+   * processor recurses into a rule group stored in a rule's `value` (see `match` modes).
+   * Used to generate collision-free element aliases.
+   *
+   * @default 0
+   */
+  subqueryDepth?: number;
 }
 
 /**
@@ -366,6 +374,12 @@ export interface FormatQueryFinalOptions extends Required<
   validateRule: FormatQueryValidateRule;
   validationMap: ValidationMap;
   context?: Record<string, unknown>;
+  /**
+   * @see {@link ValueProcessorOptions.subqueryDepth}
+   *
+   * @default 0
+   */
+  subqueryDepth?: number;
 }
 
 /**

--- a/packages/core/src/utils/formatQuery/__tests__/formatQuery.CEL.test.ts
+++ b/packages/core/src/utils/formatQuery/__tests__/formatQuery.CEL.test.ts
@@ -10,6 +10,7 @@ import {
   queryForNumberParsing,
   queryIC,
   queryWithMatchModes,
+  queryWithNestedMatchModes,
   queryWithValueSourceField,
   testQueryDQ,
 } from '../formatQueryTestUtils';
@@ -39,6 +40,12 @@ it('formats CEL correctly', () => {
     )
   ).toBe('(f >= 12 && f <= 14)');
   expect(formatQuery(queryWithMatchModes, 'cel')).toBe(celStringForMatchModes);
+});
+
+it('assigns a distinct element alias to each subquery nesting level', () => {
+  expect(formatQuery(queryWithNestedMatchModes, 'cel')).toBe(
+    'fs.exists(elem_alias, elem_alias.fv.all(elem_alias_1, elem_alias_1.contains("S")))'
+  );
 });
 
 it('handles operator case variations', () => {

--- a/packages/core/src/utils/formatQuery/__tests__/formatQuery.Drizzle.test.ts
+++ b/packages/core/src/utils/formatQuery/__tests__/formatQuery.Drizzle.test.ts
@@ -17,6 +17,7 @@ import {
   queryForPreserveValueOrder,
   queryIC,
   queryWithMatchModes,
+  queryWithNestedMatchModes,
   queryWithValueSourceField,
 } from '../formatQueryTestUtils';
 
@@ -89,6 +90,12 @@ it('handles operator case variations', () => {
 it('handles nested arrays', () => {
   expect(
     formatQuery(queryWithMatchModes, { format: 'drizzle', preset: 'postgresql' })(
+      fields,
+      drizzleOperators
+    )
+  ).toBeTruthy();
+  expect(
+    formatQuery(queryWithNestedMatchModes, { format: 'drizzle', preset: 'postgresql' })(
       fields,
       drizzleOperators
     )

--- a/packages/core/src/utils/formatQuery/__tests__/formatQuery.SQL.test.ts
+++ b/packages/core/src/utils/formatQuery/__tests__/formatQuery.SQL.test.ts
@@ -29,6 +29,7 @@ import {
   queryForXor,
   queryIC,
   queryWithMatchModes,
+  queryWithNestedMatchModes,
   queryWithValueSourceField,
 } from '../formatQueryTestUtils';
 import { defaultValueProcessor, defaultValueProcessorByRule } from '../index';
@@ -106,6 +107,18 @@ it('formats SQL correctly', () => {
   );
   expect(formatQuery(queryWithMatchModes, { preset: 'postgresql' })).toBe(sqlStringForMatchModes);
   expect(formatQuery(queryWithMatchModes, 'sql')).toBe(`(1 = 1)`);
+});
+
+it('assigns a distinct element alias to each subquery nesting level', () => {
+  expect(formatQuery(queryWithNestedMatchModes, { preset: 'postgresql' })).toBe(
+    `(exists (select 1 from unnest("fs") as "elem_alias" where ((select count(*) from unnest("elem_alias") as "elem_alias_1" where ("elem_alias_1" like '%S%')) = array_length("elem_alias", 1))))`
+  );
+  expect(
+    formatQuery(queryWithNestedMatchModes, { format: 'parameterized', preset: 'postgresql' })
+  ).toEqual({
+    sql: `(exists (select 1 from unnest("fs") as "elem_alias" where ((select count(*) from unnest("elem_alias") as "elem_alias_1" where ("elem_alias_1" like $1)) = array_length("elem_alias", 1))))`,
+    params: ['%S%'],
+  });
 });
 
 it('assumes "sql" format when preset matches a SQL preset', () => {

--- a/packages/core/src/utils/formatQuery/defaultRuleProcessorCEL.ts
+++ b/packages/core/src/utils/formatQuery/defaultRuleProcessorCEL.ts
@@ -4,7 +4,7 @@ import { lc, nullOrUndefinedOrEmpty } from '../misc';
 import { parseNumber } from '../parseNumber';
 import { transformQuery } from '../transformQuery';
 import { defaultRuleGroupProcessorCEL } from './defaultRuleGroupProcessorCEL';
-import { processMatchMode, shouldRenderAsNumber } from './utils';
+import { processMatchMode, getSubqueryElementAlias, shouldRenderAsNumber } from './utils';
 
 const shouldNegate = (op: string) => op.startsWith('not') || op.startsWith('doesnot');
 
@@ -40,16 +40,16 @@ export const defaultRuleProcessorCEL: RuleProcessor = (
   } else if (matchEval) {
     const { mode, threshold } = matchEval;
 
-    // TODO?: Randomize this alias
-    const arrayElementAlias = 'elem_alias';
+    const subqueryDepth = opts.subqueryDepth ?? 0;
+    const arrayElementAlias = getSubqueryElementAlias(subqueryDepth);
 
     const celQuery = transformQuery(rule.value as RuleGroupType, {
       ruleProcessor: r => ({ ...r, field: `${arrayElementAlias}${r.field ? `.${r.field}` : ''}` }),
     });
-    const nestedArrayFilter = defaultRuleGroupProcessorCEL(
-      celQuery,
-      opts as FormatQueryFinalOptions
-    );
+    const nestedArrayFilter = defaultRuleGroupProcessorCEL(celQuery, {
+      ...(opts as FormatQueryFinalOptions),
+      subqueryDepth: subqueryDepth + 1,
+    });
 
     switch (mode) {
       case 'all':

--- a/packages/core/src/utils/formatQuery/defaultRuleProcessorDrizzle.ts
+++ b/packages/core/src/utils/formatQuery/defaultRuleProcessorDrizzle.ts
@@ -5,7 +5,12 @@ import { lc } from '../misc';
 import { parseNumber } from '../parseNumber';
 import { transformQuery } from '../transformQuery';
 import { defaultRuleGroupProcessorDrizzle } from './defaultRuleGroupProcessorDrizzle';
-import { isValidValue, processMatchMode, shouldRenderAsNumber } from './utils';
+import {
+  getSubqueryElementAlias,
+  isValidValue,
+  processMatchMode,
+  shouldRenderAsNumber,
+} from './utils';
 
 /**
  * Default rule processor used by {@link formatQuery} for the "drizzle" format.
@@ -70,8 +75,8 @@ export const defaultRuleProcessorDrizzle: RuleProcessor = (rule, _options): SQL 
 
     const { mode, threshold } = matchEval;
 
-    // TODO?: Randomize this alias
-    const arrayElementAlias = 'elem_alias';
+    const subqueryDepth = opts.subqueryDepth ?? 0;
+    const arrayElementAlias = getSubqueryElementAlias(subqueryDepth);
 
     const sqlQuery = transformQuery(rule.value as RuleGroupType, {
       ruleProcessor: r => ({ ...r, field: arrayElementAlias }),
@@ -80,6 +85,7 @@ export const defaultRuleProcessorDrizzle: RuleProcessor = (rule, _options): SQL 
     const nestedArrayFilter = defaultRuleGroupProcessorDrizzle(sqlQuery, {
       ...(opts as FormatQueryFinalOptions),
       context: { ...opts.context, useRawFields: true },
+      subqueryDepth: subqueryDepth + 1,
     });
 
     switch (mode) {

--- a/packages/core/src/utils/formatQuery/defaultRuleProcessorParameterized.ts
+++ b/packages/core/src/utils/formatQuery/defaultRuleProcessorParameterized.ts
@@ -8,6 +8,7 @@ import { defaultOperatorProcessorSQL } from './defaultRuleProcessorSQL';
 import { defaultValueProcessorByRule } from './defaultValueProcessorByRule';
 import {
   getQuotedFieldName,
+  getSubqueryElementAlias,
   processMatchMode,
   shouldRenderAsNumber,
   stripParamPrefix,
@@ -65,14 +66,18 @@ export const defaultRuleProcessorParameterized: RuleProcessor = (rule, opts, met
 
     const { mode, threshold } = matchEval;
 
-    // TODO?: Randomize this alias
-    const arrayElementAlias = 'elem_alias';
+    const subqueryDepth = opts.subqueryDepth ?? 0;
+    const arrayElementAlias = getSubqueryElementAlias(subqueryDepth);
 
     const { sql: nestedSQL, params: nestedParams } = defaultRuleGroupProcessorParameterized(
       transformQuery(rule.value as RuleGroupType, {
         ruleProcessor: r => ({ ...r, field: arrayElementAlias }),
       }),
-      { ...(opts as FormatQueryFinalOptions), fields: [] as FullField[] }
+      {
+        ...(opts as FormatQueryFinalOptions),
+        fields: [] as FullField[],
+        subqueryDepth: subqueryDepth + 1,
+      }
     );
     // Ignore the "parameterized_named" case because PostgreSQL doesn't support named parameters
     if (Array.isArray(nestedParams)) {

--- a/packages/core/src/utils/formatQuery/defaultRuleProcessorSQL.ts
+++ b/packages/core/src/utils/formatQuery/defaultRuleProcessorSQL.ts
@@ -3,7 +3,12 @@ import { lc } from '../misc';
 import { transformQuery } from '../transformQuery';
 import { defaultRuleGroupProcessorSQL } from './defaultRuleGroupProcessorSQL';
 import { defaultValueProcessorByRule } from './defaultValueProcessorByRule';
-import { getQuotedFieldName, mapSQLOperator, processMatchMode } from './utils';
+import {
+  getQuotedFieldName,
+  getSubqueryElementAlias,
+  mapSQLOperator,
+  processMatchMode,
+} from './utils';
 
 /**
  * Default operator processor used by {@link formatQuery} for "sql" and "parameterized*" formats.
@@ -42,14 +47,14 @@ export const defaultRuleProcessorSQL: RuleProcessor = (rule, opts = {}) => {
 
     const { mode, threshold } = matchEval;
 
-    // TODO?: Randomize this alias
-    const arrayElementAlias = 'elem_alias';
+    const subqueryDepth = opts.subqueryDepth ?? 0;
+    const arrayElementAlias = getSubqueryElementAlias(subqueryDepth);
 
     const nestedArrayFilter = defaultRuleGroupProcessorSQL(
       transformQuery(rule.value as RuleGroupType, {
         ruleProcessor: r => ({ ...r, field: arrayElementAlias }),
       }),
-      opts as FormatQueryFinalOptions
+      { ...(opts as FormatQueryFinalOptions), subqueryDepth: subqueryDepth + 1 }
     );
 
     switch (mode) {

--- a/packages/core/src/utils/formatQuery/formatQueryTestUtils.ts
+++ b/packages/core/src/utils/formatQuery/formatQueryTestUtils.ts
@@ -266,6 +266,35 @@ export const queryWithMatchModes: DefaultRuleGroupType = {
   ],
 };
 
+/**
+ * Match mode subquery nested within another match mode subquery. Each level's element alias must
+ * be distinct, otherwise the inner binding shadows the outer one.
+ */
+export const queryWithNestedMatchModes: DefaultRuleGroupType = {
+  combinator: 'and',
+  rules: [
+    {
+      field: 'fs',
+      operator: '=',
+      match: { mode: 'some' },
+      value: {
+        combinator: 'and',
+        rules: [
+          {
+            field: 'fv',
+            operator: '=',
+            match: { mode: 'all' },
+            value: {
+              combinator: 'and',
+              rules: [{ field: '', operator: 'contains', value: 'S' }],
+            },
+          },
+        ],
+      },
+    },
+  ],
+};
+
 export const testQueryDQ: DefaultRuleGroupType = {
   combinator: 'and',
   rules: [{ field: 'f1', operator: '=', value: `Te"st` }],

--- a/packages/core/src/utils/formatQuery/utils.ts
+++ b/packages/core/src/utils/formatQuery/utils.ts
@@ -475,6 +475,24 @@ export const processMatchMode = (rule: RuleType): null | false | ProcessedMatchM
 };
 
 /**
+ * Base alias assigned to the element binding of a subquery generated for a rule's
+ * {@link MatchMode `match` mode} (e.g. `unnest(field) as elem_alias`).
+ */
+export const subqueryElementAliasBase = 'elem_alias';
+
+/**
+ * Returns the element alias for a subquery at the given nesting depth. Depth 0 (the common,
+ * non-nested case) uses {@link subqueryElementAliasBase} unchanged; deeper levels are suffixed
+ * with the depth, so a subquery nested within a subquery cannot shadow its parent's binding.
+ *
+ * Deterministic by depth rather than randomized, so output remains stable and snapshot-friendly.
+ *
+ * @group Export
+ */
+export const getSubqueryElementAlias = (subqueryDepth = 0): string =>
+  subqueryDepth > 0 ? `${subqueryElementAliasBase}_${subqueryDepth}` : subqueryElementAliasBase;
+
+/**
  * "Replacer" method for JSON.stringify's second argument. Converts `bigint` values to
  * objects with a `$bigint` property having a value of a string representation of
  * the actual `bigint`-type value.

--- a/packages/core/src/utils/parseCEL/parseCEL.test.ts
+++ b/packages/core/src/utils/parseCEL/parseCEL.test.ts
@@ -720,6 +720,34 @@ describe('subqueries', () => {
     });
   });
 
+  describe('nested subqueries', () => {
+    it('parses depth-suffixed element aliases without shadowing', () => {
+      testParseCEL(
+        'tourStops.exists(elem_alias, elem_alias.users.all(elem_alias_1, elem_alias_1.city == "Milan"))',
+        wrapRule({
+          field: 'tourStops',
+          operator: '=',
+          match: { mode: 'some' },
+          value: {
+            combinator: 'and',
+            rules: [
+              {
+                field: 'users',
+                operator: '=',
+                match: { mode: 'all' },
+                value: {
+                  combinator: 'and',
+                  rules: [{ field: 'city', operator: '=', value: 'Milan' }],
+                },
+              },
+            ],
+          },
+        }),
+        { fields: subqueryFields }
+      );
+    });
+  });
+
   describe('.exists()', () => {
     it('basic', () => {
       testParseCEL(


### PR DESCRIPTION
Ensure that subqueries generated for a rule's `match` mode use unique element aliases at each nesting level, preventing shadowing of outer bindings.