### PR TITLE
Add RAQB migration docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-N/A
+### Added
+
+- [#1070] [Migration guide](https://react-querybuilder.js.org/docs/tips/migrate-from-raqb) for [`react-awesome-query-builder`](https://github.com/ukrbublik/react-awesome-query-builder) (RAQB). The conversion tools themselves (`parseRAQB`, `parseRAQBFields`, `formatRAQBFields`, and `defaultRule[Group]ProcessorRAQB`) live in the standalone [`@react-querybuilder/migrate-raqb`](https://github.com/react-querybuilder/migrate-raqb) package.
 
 ## [v8.21.2] - 2026-07-27
 
@@ -2390,6 +2392,7 @@ _(This list may look long, but the breaking changes should only affect a small m
 [#1066]: https://github.com/react-querybuilder/react-querybuilder/pull/1066
 [#1067]: https://github.com/react-querybuilder/react-querybuilder/pull/1067
 [#1068]: https://github.com/react-querybuilder/react-querybuilder/pull/1068
+[#1070]: https://github.com/react-querybuilder/react-querybuilder/pull/1070
 
 <!-- #endregion -->
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For a more complete introduction, see the [main package README](packages/react-q
 >
 > For rules engine functionality (if-then-else) use [`@react-querybuilder/rules-engine`](./packages/rules-engine).
 
-_For instructions on migrating from earlier versions of `react-querybuilder`, [click here](https://react-querybuilder.js.org/docs/migrate)._
+_For instructions on migrating from earlier versions of `react-querybuilder`, see the [version migration guide](https://react-querybuilder.js.org/docs/migrate). To migrate from `react-awesome-query-builder`, see the [RAQB migration guide](https://react-querybuilder.js.org/docs/tips/migrate-from-raqb)._
 
 ## Compatibility packages
 

--- a/website/docs/intro.mdx
+++ b/website/docs/intro.mdx
@@ -157,6 +157,8 @@ export default () => {
 
 Explore all React Query Builder options in the [main component documentation](./components/querybuilder). Try different configurations, export/import formats, and features in the interactive [demo](/demo).
 
+Coming from another library? See [how React Query Builder compares](./tips/comparison), and the guide for [migrating from react-awesome-query-builder](./tips/migrate-from-raqb).
+
 ## Training
 
 For an extended tutorial on configuration and customization of `react-querybuilder`, including information about integrating it with a backend API and advanced reporting components (grids, maps, charts, etc.), check out the course [Building Advanced Admin Reporting in React](https://www.newline.co/courses/building-advanced-admin-reporting-in-react), taught by this library's maintainer at [newline](https://www.newline.co/).

--- a/website/docs/tips/comparison.mdx
+++ b/website/docs/tips/comparison.mdx
@@ -1,0 +1,69 @@
+---
+title: Comparison with other libraries
+description: How React Query Builder compares to react-awesome-query-builder
+---
+
+The query builder library most often compared to React Query Builder (RQB) is [react-awesome-query-builder](https://github.com/ukrbublik/react-awesome-query-builder) (RAQB). Both render an interactive UI for building filter criteria, and both can export those criteria to several query languages, but they take meaningfully different approaches.
+
+This page summarizes the differences as of RQB v8 and RAQB v6.6.15 (May 2025). If you're moving an existing RAQB implementation to RQB, see [Migrating from react-awesome-query-builder](./migrate-from-raqb).
+
+## Philosophy
+
+|                 | React Query Builder                                                                | react-awesome-query-builder                                                      |
+| --------------- | ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Query storage   | Plain JSON ([`RuleGroupType`](../typescript#rules-and-groups)), serializable as-is | [immutable.js](https://immutable-js.com/) tree; plain JSON via `Utils.getTree()` |
+| Configuration   | Discrete props (`fields`, `operators`, `combinators`, `controlElements`, etc.)     | One monolithic `Config` object (types, widgets, operators, funcs, settings)      |
+| Packaging       | Composable packages — core, React, UI styles, and optional feature packages        | Core package plus UI-specific packages                                           |
+| Non-React usage | `@react-querybuilder/core` has no React dependency (server-safe)                   | Core depends on React                                                            |
+
+RQB's plain-JSON query format means you can store queries in a database, send them over the wire, diff them, and hand-edit them without any conversion step. RQB's discrete props mean you only configure (and only bundle) the parts you use.
+
+## Query model
+
+| Aspect         | React Query Builder                                                                                                                     | react-awesome-query-builder                                         |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Group children | `rules`                                                                                                                                 | `children1` (array, or keyed object when `children1AsArray: false`) |
+| Combinators    | `combinator` on the group, _or_ [independent combinators](../components/querybuilder#independent-combinators) interleaved between rules | `conjunction` on the group only                                     |
+| Negation       | `not` on groups                                                                                                                         | `not` on groups                                                     |
+| Rule value     | Scalar or array, depending on the operator                                                                                              | Always an array (one entry per operand)                             |
+| Subqueries     | [Match modes](./subqueries) — `all`, `some`, `none`, `atLeast`, `atMost`, `exactly` (with threshold)                                    | `!group` fields with `some`/`all`/`none` and count operators        |
+| Disabled rules | `disabled`                                                                                                                              | `isLocked`                                                          |
+| Muted rules    | [`muted`](../utils/export#muted-rules-and-groups) (kept in the query, excluded from exports)                                            | —                                                                   |
+| Ternary/CASE   | —                                                                                                                                       | `switch_group` / `case_group`                                       |
+| Value sources  | `value`, `field`, [expressions](../expr), [parameters](./parameter-manager)                                                             | `value`, `field`, `func`                                            |
+| Left-hand side | Expressions supported on the LHS as well as the RHS                                                                                     | `fieldSrc: "func"`                                                  |
+
+## Formats
+
+RQB's [`formatQuery`](../utils/export) supports considerably more export targets, and its [parsers](../utils/import) support more import sources.
+
+| Direction | React Query Builder                                                                                                                                                                                       | react-awesome-query-builder                                          |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Export    | JSON, SQL (plain/parameterized/named), MongoDB, CEL, JsonLogic, SpEL, ElasticSearch, JSONata, LDAP, natural language, Drizzle, TanStack DB, Prisma, Sequelize, Cypher, GraphQL, SPARQL, Gremlin, and more | SQL, MongoDB, JsonLogic, SpEL, ElasticSearch (partial), query string |
+| Import    | SQL, CEL, JsonLogic, MongoDB, SpEL, JSONata, Cypher, GraphQL, SPARQL, Gremlin, **RAQB**                                                                                                                   | JsonLogic, SpEL, SQL (separate package)                              |
+
+## Ecosystem
+
+| Aspect               | React Query Builder                                                                           | react-awesome-query-builder                          |
+| -------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| UI style packs       | Ant Design, Bootstrap, Bulma, Chakra UI, Fluent UI, Mantine, MUI/Material, PrimeReact, Tremor | Ant Design, MUI, Material (v4), Bootstrap, Fluent UI |
+| React Native         | `@react-querybuilder/native`                                                                  | —                                                    |
+| Drag-and-drop        | [`@react-querybuilder/dnd`](../dnd) (opt-in)                                                  | Built in                                             |
+| Date/time            | [`@react-querybuilder/datetime`](../datetime) (relative dates, per-dialect formatting)        | Built in (widgets and functions)                     |
+| Expressions          | [`@react-querybuilder/expr`](../expr)                                                         | Built in (config `funcs`)                            |
+| Rules engine         | [`@react-querybuilder/rules-engine`](../rules-engine)                                         | —                                                    |
+| Accessibility        | ARIA attributes, keyboard navigation, `data-testid` hooks                                     | Not documented                                       |
+| Internationalization | `translations` prop accepting strings or JSX                                                  | i18next-based locale packs                           |
+| Validation           | Per-field `validator` plus [`defaultValidator`](../utils/validation)                          | `sanitizeTree` / `validateTree` / `isValidTree`      |
+| Styling              | Unstyled by default with CSS custom properties; official style packs                          | Bundled SCSS per UI package                          |
+
+## Feature-by-feature notes
+
+Most RAQB concepts have a direct RQB counterpart. These are the exceptions:
+
+- **Ternary (`switch_group`)** — RAQB can build CASE/WHEN-style expressions. RQB has no equivalent in the query builder itself; conditional logic is generally modeled with [`@react-querybuilder/rules-engine`](../rules-engine) instead.
+- **`proximity` operator** — RAQB's full-text proximity operator (and its `operatorOptions`) has no RQB equivalent.
+- **`is_empty` / `is_not_empty`** — RQB expresses these as `=` and `!=` against an empty string.
+- **Locking** — RQB models this with the `disabled` property rather than a separate `locked` property, but the behavior and UI are equivalent. The [`showLockButtons`](../components/querybuilder#showlockbuttons) prop displays "Lock rule"/"Lock group" toggle buttons, which set `disabled` on the rule or group. As in RAQB, a locked group disables its header elements and all descendants. RQB has no equivalent to RAQB's `canDeleteLocked` setting.
+- **Date/time functions** — RAQB models `NOW`, `TODAY`, `RELATIVE_DATETIME`, etc. as functions. RQB treats the same concept as a _value_: [`@react-querybuilder/datetime`](../datetime) relative date/time values, which each rule processor serializes symbolically (e.g. `current_timestamp - interval '7 days'`).
+- **Cardinality operators** — RQB's match modes are a superset of RAQB's `!group` count operators, except that RQB has no strict-inequality modes (RAQB's `less`/`greater` counts).

--- a/website/docs/tips/migrate-from-raqb.mdx
+++ b/website/docs/tips/migrate-from-raqb.mdx
@@ -1,0 +1,525 @@
+---
+title: Migrating from react-awesome-query-builder
+description: Convert RAQB configs and query trees to React Query Builder
+---
+
+%importmd ../\_ts_admonition.md
+
+This guide covers moving an existing [react-awesome-query-builder](https://github.com/ukrbublik/react-awesome-query-builder) (RAQB) implementation to React Query Builder (RQB). For a broader feature-level overview, see [Comparison with other libraries](./comparison).
+
+Two utilities do most of the work:
+
+- `parseRAQB` converts a saved RAQB query tree to an RQB query object.
+- `parseRAQBFields` converts an RAQB `Config` (or just its `fields`) to an RQB `fields` array.
+
+Both are exported from [`@react-querybuilder/migrate-raqb`](https://github.com/react-querybuilder/migrate-raqb), a standalone package outside the main React Query Builder repository. Since migration is generally a one-time task, these utilities are packaged separately to keep them out of your production bundle.
+
+```bash npm2yarn
+npm i @react-querybuilder/migrate-raqb
+```
+
+```ts
+import { parseRAQB, parseRAQBFields } from '@react-querybuilder/migrate-raqb';
+```
+
+The package has no runtime dependencies—only a peer dependency on `@react-querybuilder/core` (v8.21.2 or later, which `react-querybuilder` itself depends on). It adds no dependency on RAQB or immutable.js.
+
+:::tip
+
+Once your queries are converted and saved in RQB format, uninstall `@react-querybuilder/migrate-raqb`. Nothing in your application needs it at runtime.
+
+:::
+
+## Concept mapping
+
+| RAQB                                | React Query Builder                                                              |
+| ----------------------------------- | -------------------------------------------------------------------------------- |
+| `Config`                            | Discrete props: `fields`, `operators`, `combinators`, `controlElements`          |
+| `Config.fields`                     | [`fields`](./managing-fields)                                                    |
+| `Query` + `Builder` render prop     | A single [`<QueryBuilder />`](../components/querybuilder) element                |
+| immutable tree + `Utils.getTree()`  | Plain JSON query object, used directly                                           |
+| `group` node                        | Rule group (an object with a `rules` array)                                      |
+| `properties.conjunction`            | `combinator`                                                                     |
+| `properties.not`                    | `not`                                                                            |
+| `rule` node                         | Rule (`{ field, operator, value }`)                                              |
+| `properties.valueSrc`               | `valueSource`                                                                    |
+| `properties.isLocked`               | `disabled` (see [`showLockButtons`](../components/querybuilder#showlockbuttons)) |
+| `rule_group` (`!group` field)       | Rule with a [match mode](./subqueries) and a nested group as its value           |
+| `switch_group` / `case_group`       | No equivalent — see [Unsupported constructs](#unsupported-constructs)            |
+| Widgets                             | [`valueEditorType` / `inputType`](./managing-fields) or a custom `valueEditor`   |
+| `funcs`                             | [`@react-querybuilder/expr`](../expr)                                            |
+| `sqlFormat`, `mongodbFormat`, etc.  | [`formatQuery`](../utils/export)                                                 |
+| `loadFromJsonLogic`, `loadFromSpel` | [`parseJsonLogic`, `parseSpEL`](../utils/import)                                 |
+
+## Rendering the component
+
+RAQB splits rendering across `<Query>`, a `renderBuilder` callback, and `<Builder>`, and keeps the query in an immutable.js tree that must be converted before it can be saved. RQB renders a single element and stores the query as plain JSON.
+
+```tsx title="Before (RAQB)"
+import { useCallback, useState } from 'react';
+import type {
+  BuilderProps,
+  Config,
+  ImmutableTree,
+  JsonGroup,
+} from '@react-awesome-query-builder/ui';
+import { BasicConfig, Builder, Query, Utils as QbUtils } from '@react-awesome-query-builder/ui';
+import '@react-awesome-query-builder/ui/css/styles.css';
+
+const config: Config = {
+  ...BasicConfig,
+  fields: {
+    price: { label: 'Price', type: 'number' },
+    color: {
+      label: 'Color',
+      type: 'select',
+      fieldSettings: {
+        listValues: [
+          { value: 'yellow', title: 'Yellow' },
+          { value: 'green', title: 'Green' },
+        ],
+      },
+    },
+  },
+  settings: {
+    ...BasicConfig.settings,
+    showNot: true,
+    showLock: true,
+    maxNesting: 3,
+    addRuleLabel: 'New rule',
+  },
+};
+
+const initialTree: JsonGroup = { id: QbUtils.uuid(), type: 'group' };
+
+export const App = () => {
+  const [tree, setTree] = useState(() => QbUtils.loadTree(initialTree));
+
+  const onChange = useCallback((immutableTree: ImmutableTree) => {
+    setTree(immutableTree);
+    // Convert before saving — the state itself is an immutable.js tree
+    console.log(QbUtils.getTree(immutableTree));
+  }, []);
+
+  const renderBuilder = useCallback(
+    (props: BuilderProps) => (
+      <div className="query-builder-container">
+        <div className="query-builder qb-lite">
+          <Builder {...props} />
+        </div>
+      </div>
+    ),
+    []
+  );
+
+  return (
+    <>
+      <Query {...config} value={tree} onChange={onChange} renderBuilder={renderBuilder} />
+      <pre>{QbUtils.sqlFormat(tree, config)}</pre>
+    </>
+  );
+};
+```
+
+```tsx title="After (RQB)"
+import { useState } from 'react';
+import type { Field, RuleGroupType } from 'react-querybuilder';
+import { formatQuery, QueryBuilder } from 'react-querybuilder';
+import 'react-querybuilder/dist/query-builder.css';
+
+const fields: Field[] = [
+  { name: 'price', label: 'Price', inputType: 'number' },
+  {
+    name: 'color',
+    label: 'Color',
+    valueEditorType: 'select',
+    values: [
+      { name: 'yellow', label: 'Yellow' },
+      { name: 'green', label: 'Green' },
+    ],
+  },
+];
+
+const initialQuery: RuleGroupType = { combinator: 'and', rules: [] };
+
+export const App = () => {
+  // Already plain JSON — save it as-is
+  const [query, setQuery] = useState(initialQuery);
+
+  return (
+    <>
+      <QueryBuilder
+        fields={fields}
+        query={query}
+        onQueryChange={setQuery}
+        showNotToggle
+        showLockButtons
+        maxLevels={3}
+        translations={{ addRule: { label: 'New rule' } }}
+      />
+      <pre>{formatQuery(query, 'sql')}</pre>
+    </>
+  );
+};
+```
+
+Notable differences:
+
+- Configuration is spread across discrete props instead of one `Config` object, so there's no base config to spread (no `BasicConfig`) and nothing to keep in state alongside the query.
+- `onQueryChange` receives the query object directly, so it can be passed straight to a `useState` setter and saved without conversion.
+- There is no `renderBuilder` indirection or required wrapper markup. Use [`controlClassnames`](../components/querybuilder#controlclassnames) and [`controlElements`](../components/querybuilder#controlelements) to customize markup and styling.
+- Export functions take the query object, not a tree plus a config.
+
+### Settings
+
+RAQB's `config.settings` correspond to individual `<QueryBuilder />` props:
+
+| RAQB setting                                         | RQB prop                                                                                                                                            |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `showNot`                                            | [`showNotToggle`](../components/querybuilder#shownottoggle)                                                                                         |
+| `showLock`                                           | [`showLockButtons`](../components/querybuilder#showlockbuttons)                                                                                     |
+| `canReorder` / `canRegroup`                          | [`enableDragAndDrop`](../components/querybuilder#enabledraganddrop) (requires [`@react-querybuilder/dnd`](../dnd))                                  |
+| `maxNesting`                                         | [`maxLevels`](../components/querybuilder#maxlevels)                                                                                                 |
+| `maxNumberOfRules`                                   | Return `false` from [`onAddRule`](../components/querybuilder#onaddrule)                                                                             |
+| `immutableGroupsMode` and friends                    | [`disabled`](../components/querybuilder#disabled) (all or by path)                                                                                  |
+| `clearValueOnChangeField` / `clearValueOnChangeOp`   | [`resetOnFieldChange`](../components/querybuilder#resetonfieldchange) / [`resetOnOperatorChange`](../components/querybuilder#resetonoperatorchange) |
+| `setOpOnChangeField`                                 | [`getDefaultOperator`](../components/querybuilder#getdefaultoperator), [`autoSelectOperator`](../components/querybuilder#autoselectoperator)        |
+| `defaultField` / `defaultOperator`                   | [`getDefaultField`](../components/querybuilder#getdefaultfield) / [`getDefaultOperator`](../components/querybuilder#getdefaultoperator)             |
+| `defaultConjunction`                                 | First entry of [`combinators`](../components/querybuilder#combinators), or the `combinator` of your initial query                                   |
+| `addRuleLabel`, `valuePlaceholder`, and other labels | [`translations`](../components/querybuilder#translations)                                                                                           |
+| `fieldSeparator`                                     | Handled at conversion time by `parseRAQBFields` (field names are flattened)                                                                         |
+
+## Converting the config
+
+`parseRAQBFields` accepts either a full RAQB `Config` object or just the `fields` map, and returns an RQB `fields` array.
+
+```ts
+import { parseRAQBFields } from '@react-querybuilder/migrate-raqb';
+
+const fields = parseRAQBFields({
+  price: {
+    label: 'Price',
+    type: 'number',
+    fieldSettings: { min: 0, max: 100 },
+  },
+  color: {
+    label: 'Color',
+    type: 'select',
+    fieldSettings: {
+      listValues: [
+        { value: 'yellow', title: 'Yellow' },
+        { value: 'green', title: 'Green' },
+      ],
+    },
+  },
+});
+```
+
+```json title="Result"
+[
+  { "name": "price", "label": "Price", "inputType": "number" },
+  {
+    "name": "color",
+    "label": "Color",
+    "valueEditorType": "select",
+    "values": [
+      { "name": "yellow", "label": "Yellow" },
+      { "name": "green", "label": "Green" }
+    ]
+  }
+]
+```
+
+Translation details:
+
+- Nested `!struct` fields are flattened to dot-separated names, matching the field paths stored in RAQB query trees. The separator comes from `settings.fieldSeparator` (default `"."`), or the `fieldSeparator` option.
+- `!group` fields become fields with `matchModes` and `subproperties`, which is RQB's [subquery](./subqueries) representation.
+- `type` maps to `inputType` (`number`, `date`, `time`, `datetime-local`, etc.) or `valueEditorType` (`select`, `multiselect`, `checkbox`).
+- `fieldSettings.listValues` and `fieldSettings.treeValues` map to `values`. Tree values are flattened.
+- `operators`, `defaultOperator`, `excludeOperators`, `valueSources`, and `defaultValue` are translated to their RQB equivalents.
+- Fields marked `hideForSelect` are omitted unless you pass `includeHidden: true`.
+- Export-time settings (`fieldName`, `tableName`, `jsonLogicVar`, `isSpelVariable`) and `fieldSettings.validateValue` are not translated.
+
+### `parseRAQBFields` options
+
+- `fieldSeparator` (`string`): Character used to join nested field names.
+- `operatorMap` (`Record<string, string>`): Additional or overriding operator name mappings. Should match the `operatorMap` passed to `parseRAQB`.
+- `includeHidden` (`boolean`): Include fields marked `hideForSelect`. Defaults to `false`.
+- `onUnsupported` (`(info: RAQBUnsupportedInfo) => void`): Called for each construct that could not be fully translated.
+
+## Converting queries
+
+`parseRAQB` accepts RAQB's **plain-JSON** tree — the output of `Utils.getTree(immutableTree)` — or a JSON string of the same. Immutable.js trees are not accepted; passing one throws an error explaining the fix.
+
+```ts
+// In your RAQB app, save the plain JSON form:
+const jsonTree = QbUtils.getTree(immutableTree);
+```
+
+```ts
+import { parseRAQB } from '@react-querybuilder/migrate-raqb';
+
+const query = parseRAQB(jsonTree);
+```
+
+```ts title="Example"
+parseRAQB({
+  type: 'group',
+  properties: { conjunction: 'AND' },
+  children1: [
+    {
+      type: 'rule',
+      properties: { field: 'price', operator: 'greater', value: [10], valueSrc: ['value'] },
+    },
+    {
+      type: 'rule',
+      properties: { field: 'color', operator: 'select_any_in', value: [['yellow', 'green']] },
+    },
+  ],
+});
+```
+
+```json title="Result"
+{
+  "combinator": "and",
+  "rules": [
+    { "field": "price", "operator": ">", "value": 10 },
+    { "field": "color", "operator": "in", "value": "yellow,green" }
+  ]
+}
+```
+
+Both `children1` shapes are supported: the default array form and the keyed-object form produced when `children1AsArray` is `false`.
+
+### Operator mapping
+
+| RAQB                                                           | RQB                                                             |
+| -------------------------------------------------------------- | --------------------------------------------------------------- |
+| `equal` / `not_equal`                                          | `=` / `!=`                                                      |
+| `less` / `less_or_equal`                                       | `<` / `<=`                                                      |
+| `greater` / `greater_or_equal`                                 | `>` / `>=`                                                      |
+| `like` / `not_like`                                            | `contains` / `doesNotContain`                                   |
+| `starts_with` / `ends_with`                                    | `beginsWith` / `endsWith`                                       |
+| `between` / `not_between`                                      | `between` / `notBetween`                                        |
+| `is_null` / `is_not_null`                                      | `null` / `notNull`                                              |
+| `is_empty` / `is_not_empty`                                    | `=` / `!=` with an empty string                                 |
+| `select_equals` / `select_not_equals`                          | `=` / `!=`                                                      |
+| `select_any_in` / `select_not_any_in`                          | `in` / `notIn`                                                  |
+| `multiselect_equals` / `multiselect_not_equals`                | `=` / `!=` (array value kept)                                   |
+| `multiselect_contains` / `multiselect_not_contains`            | `contains` / `doesNotContain`                                   |
+| `some` / `all` / `none`                                        | Match modes `some` / `all` / `none`                             |
+| `!group` counts `equal` / `greater_or_equal` / `less_or_equal` | Match modes `exactly` / `atLeast` / `atMost` with a `threshold` |
+
+Add to or override this map with the `operatorMap` option.
+
+### `parseRAQB` options
+
+Beyond the standard [import configuration](../utils/import#configuration) options (`fields`, `listsAsArrays`, `generateIDs`, `independentCombinators`, etc.), `parseRAQB` accepts:
+
+- `operatorMap` (`Record<string, DefaultOperatorName>`): Additional or overriding RAQB-to-RQB operator mappings, merged over the defaults.
+- `functionMap` (`Record<string, string>`): Additional or overriding RAQB-to-`expr` function name mappings, merged over the defaults.
+- `funcArgOrder` (`Record<string, string[]>`): Explicit argument order per RAQB function name. By default, argument order follows the key order of the serialized function object.
+- `relativeDateTimes` (`boolean`): Convert RAQB's built-in date/time functions to relative date/time values instead of expressions. Defaults to `true`. See [Date and time functions](#date-and-time-functions).
+- `onUnsupported` (`(info: RAQBUnsupportedInfo) => void`): Called for each construct that could not be converted.
+
+As with other parsers, passing `fields` restricts the output to rules whose fields exist in the list.
+
+## Functions and expressions
+
+RAQB's `valueSrc: "func"` operands convert to RQB [expressions](../expr). Right-hand side functions become `valueSource: "expression"` with an expression object as the value; a function on the _left_ side (`fieldSrc: "func"`) becomes the rule's `lhs` property.
+
+```ts title="Example"
+parseRAQB({
+  type: 'group',
+  properties: { conjunction: 'AND' },
+  children1: [
+    {
+      type: 'rule',
+      properties: {
+        field: 'name',
+        operator: 'equal',
+        valueSrc: ['func'],
+        value: [{ func: 'LOWER', args: { str: { value: 'Steve', valueSrc: 'value' } } }],
+      },
+    },
+  ],
+});
+```
+
+```json title="Result"
+{
+  "combinator": "and",
+  "rules": [
+    {
+      "field": "name",
+      "operator": "=",
+      "valueSource": "expression",
+      "value": { "kind": "func", "fn": "lower", "args": [{ "kind": "value", "value": "Steve" }] }
+    }
+  ]
+}
+```
+
+:::caution
+
+Queries containing expressions require [`@react-querybuilder/expr`](../expr) to render, validate, or serialize. Wrap your query builder in `QueryBuilderExpressions` and register the export processor as described in the [expressions documentation](../expr). Without that package, expression values will not display or export correctly.
+
+:::
+
+RAQB's `LOWER` and `UPPER` map to `expr`'s `lower` and `upper`, and `LINEAR_REGRESSION` is expanded to the equivalent arithmetic expression. Every other RAQB function—apart from the date/time functions described below—is passed through under its original name and reported to `onUnsupported`. To render or export those, either register matching function metadata with `@react-querybuilder/expr` or map them to existing functions with `functionMap`.
+
+## Date and time functions
+
+RAQB's built-in date/time functions don't really compute anything—they describe a date relative to "now". RQB represents that concept as a _value_ rather than an expression, so `parseRAQB` converts them to [`@react-querybuilder/datetime`](../datetime)'s relative date/time value shape (`{ mode: "relative", anchor, offset, unit }`), which every date/time rule processor serializes symbolically (e.g. `current_timestamp - interval '7 days'`).
+
+| RAQB                                      | RQB value                                          |
+| ----------------------------------------- | -------------------------------------------------- |
+| `NOW()`                                   | `{ anchor: 'now', offset: 0 }`                     |
+| `TODAY()` / `START_OF_TODAY()`            | `{ anchor: 'startOfDay', offset: 0 }`              |
+| `TRUNCATE_DATETIME(NOW(), dim)`           | `{ anchor: 'startOf<Dim>', offset: 0 }`            |
+| `RELATIVE_DATE(TIME)(date, op, val, dim)` | `{ anchor: <from date>, offset: ±val, unit: dim }` |
+
+```ts title="Example"
+parseRAQB({
+  type: 'group',
+  properties: { conjunction: 'AND' },
+  children1: [
+    {
+      type: 'rule',
+      properties: {
+        field: 'created',
+        operator: 'between',
+        valueSrc: ['func', 'func'],
+        value: [
+          {
+            func: 'RELATIVE_DATETIME',
+            args: { op: { value: 'minus' }, val: { value: 7 }, dim: { value: 'day' } },
+          },
+          { func: 'NOW', args: {} },
+        ],
+      },
+    },
+  ],
+});
+```
+
+```json title="Result"
+{
+  "combinator": "and",
+  "rules": [
+    {
+      "field": "created",
+      "operator": "between",
+      "value": [
+        { "mode": "relative", "anchor": "now", "offset": -7, "unit": "day" },
+        { "mode": "relative", "anchor": "now", "offset": 0, "unit": "day" }
+      ]
+    }
+  ]
+}
+```
+
+With `@react-querybuilder/datetime`'s SQL rule processor, that query exports as `"created" between current_timestamp - interval '7 days' and current_timestamp`.
+
+A few RAQB calls fall outside what relative values can express, and are converted to expressions instead (and reported to `onUnsupported`):
+
+- A `"second"` dimension. RQB's smallest relative unit is `minute`.
+- Truncation to `hour`, `minute`, or `second`. RQB truncates only to day, week, month, or year.
+- Truncation applied _after_ an offset, e.g. `TRUNCATE_DATETIME(RELATIVE_DATETIME(NOW(), 'minus', 3, 'day'), 'month')`. RQB applies the anchor first and the offset second, so only the reverse nesting is representable.
+
+Pass `relativeDateTimes: false` to convert date/time functions to expressions like any other function.
+
+## Unsupported constructs
+
+`parseRAQB` never throws on unrecognized content (aside from immutable.js input). Anything it can't convert is skipped, and a partial query is always returned. Use `onUnsupported` to log or surface what was dropped.
+
+```ts
+const unsupported: RAQBUnsupportedInfo[] = [];
+
+const query = parseRAQB(jsonTree, {
+  onUnsupported: info => unsupported.push(info),
+});
+```
+
+Reported constructs include:
+
+- **`switch_group` / `case_group`** (RAQB's ternary mode). RQB has no equivalent; consider [`@react-querybuilder/rules-engine`](../rules-engine) for conditional logic.
+- **`proximity`** and its `operatorOptions`, which have no RQB counterpart.
+- **`!group` strict-inequality count operators** (`less`, `greater`), since RQB match modes cover only `exactly`, `atLeast`, and `atMost`.
+- **Functions with no `@react-querybuilder/expr` equivalent**, which pass through by name.
+
+## Putting it together
+
+```tsx
+import { QueryBuilder } from 'react-querybuilder';
+import { parseRAQB, parseRAQBFields } from '@react-querybuilder/migrate-raqb';
+import raqbConfig from './raqbConfig';
+import savedTree from './savedQuery.json';
+
+const fields = parseRAQBFields(raqbConfig);
+const defaultQuery = parseRAQB(savedTree, { fields });
+
+export const App = () => <QueryBuilder fields={fields} defaultQuery={defaultQuery} />;
+```
+
+## Converting back to RAQB
+
+The reverse conversion is useful for a phased migration where both query builders must read the same stored queries. `@react-querybuilder/migrate-raqb` exports `formatRAQB` for this purpose. (There is no `"raqb"` `formatQuery` export format; `formatRAQB` wraps `formatQuery`'s `ruleGroupProcessor` option, which takes precedence over `format`.)
+
+```ts
+import { formatRAQB } from '@react-querybuilder/migrate-raqb';
+import { Utils } from '@react-awesome-query-builder/core';
+
+const jsonTree = formatRAQB(query, { fields });
+const immutableTree = Utils.checkTree(Utils.loadTree(jsonTree), raqbConfig);
+```
+
+Pass `fields` for the most faithful output—several RAQB operators collapse to a single RQB operator, and the field's `valueEditorType` is used to disambiguate them.
+
+`formatRAQBFields`, the inverse of `parseRAQBFields`, is exported from the same package:
+
+```ts
+import { formatRAQBFields } from '@react-querybuilder/migrate-raqb';
+
+const raqbConfig = { ...BasicConfig, fields: formatRAQBFields(fields) };
+```
+
+`formatRAQB` accepts all [`formatQuery` options](../utils/export) except `format`, `ruleGroupProcessor`, and `fallbackExpression`, plus `fallbackTree` (the tree returned when the query is empty or fails validation) and:
+
+| Option                  | Default | Description                                                                                            |
+| ----------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `raqbOperatorMap`       | `{}`    | Additional/overriding RQB-to-RAQB operator mappings, keyed by RQB operator name.                       |
+| `raqbFunctionMap`       | `{}`    | Additional/overriding expression-function-to-RAQB function name mappings.                              |
+| `raqbFuncArgOrder`      | `{}`    | Argument names per RAQB function name. Defaults cover RAQB's built-ins; others get `arg0`, `arg1`, ... |
+| `raqbFieldSeparator`    | `"."`   | Separator used to qualify sub-query rule fields with their parent `!group` field name.                 |
+| `raqbRelativeDateTimes` | `true`  | Convert relative date/time values to RAQB's built-in date/time functions.                              |
+| `raqbValueTypes`        | `false` | Emit `valueType` entries inferred from each field's `inputType`/`valueEditorType`.                     |
+
+The mapping is the inverse of the tables above, with these caveats:
+
+- RQB's `doesNotBeginWith` and `doesNotEndWith` have no RAQB default equivalent (there is no `not_starts_with`/`not_ends_with`); rules using them are omitted unless you supply a `raqbOperatorMap` entry.
+- The `"parameter"` value source has no RAQB counterpart, so those rules are omitted.
+- `in`/`notIn` map to `select_any_in`/`select_not_any_in`, which RAQB only allows for `select` and `multiselect` fields. On a plain text field RAQB's `checkTree` will reject the rule.
+- Field-to-field comparisons are more restricted in RAQB: its `field` widget for the `text` type supports only `equal`, `not_equal`, and `proximity`, so `contains`/`beginsWith`/`endsWith`/`<`/`>` against another field are rejected.
+- RAQB clamps inverted ranges, so a `between` rule with `preserveValueOrder` and out-of-order bounds (e.g. `[100, 0]`) becomes `[100, 100]` once loaded.
+- `bigint` values are narrowed to `number`, since RAQB trees must be JSON-serializable.
+- `endOf*` relative date/time anchors are emitted as plain values, since RAQB's built-in functions only truncate to the _start_ of a period.
+- RAQB defines no `XOR` conjunction. `xor` combinators are emitted as `"XOR"` rather than silently degraded, so RAQB's `checkTree` will flag them unless a matching custom conjunction is configured.
+- RAQB's several operators that collapse to one RQB operator (`equal`/`select_equals`/`multiselect_equals` → `=`) are disambiguated using each field's `valueEditorType`, so pass `fields` for the most faithful output.
+- When `validator` results invalidate the entire query, `formatRAQB` returns `fallbackTree` (`raqbFallback`, an empty `AND` group, by default). If you call `formatQuery` directly with `defaultRuleGroupProcessorRAQB`, pass `fallbackExpression: raqbFallback as unknown as string`—`formatQuery` short-circuits _before_ the rule group processor runs, and its own default fallback is a SQL string.
+
+To combine RAQB output with other `formatQuery` behavior, or to supply a custom `ruleProcessor`, use `defaultRuleGroupProcessorRAQB` directly. RAQB options then move into `context`:
+
+```ts
+import { formatQuery } from 'react-querybuilder';
+import { defaultRuleGroupProcessorRAQB, raqbFallback } from '@react-querybuilder/migrate-raqb';
+
+const jsonTree = formatQuery(query, {
+  ruleGroupProcessor: defaultRuleGroupProcessorRAQB,
+  fields,
+  context: { raqbValueTypes: true },
+  fallbackExpression: raqbFallback as unknown as string,
+});
+```
+
+RAQB's last stable release was 6.6.15 in May 2025; these utilities exist to give RAQB users a straightforward path to React Query Builder.

--- a/website/docs/utils/export.mdx
+++ b/website/docs/utils/export.mdx
@@ -622,6 +622,99 @@ Output (string):
 .has('firstName', 'Steve').has('lastName', 'Vai')
 ```
 
+### react-awesome-query-builder
+
+Generate a [react-awesome-query-builder](https://github.com/ukrbublik/react-awesome-query-builder) (RAQB) query tree in its plain-JSON form, suitable for RAQB's `Utils.loadTree()`.
+
+This is _not_ a built-in export format. Since most projects need it exactly once, it lives in the separate [`@react-querybuilder/migrate-raqb`](https://github.com/react-querybuilder/migrate-raqb) package, which exports a `formatRAQB` function.
+
+```bash npm2yarn
+npm i @react-querybuilder/migrate-raqb
+```
+
+```ts
+import { Utils } from '@react-awesome-query-builder/core';
+import { formatRAQB } from '@react-querybuilder/migrate-raqb';
+
+const jsonTree = formatRAQB(query, { fields });
+const immutableTree = Utils.checkTree(Utils.loadTree(jsonTree), config);
+```
+
+This is the inverse of [`parseRAQB`](./import#react-awesome-query-builder). See [Migrating from react-awesome-query-builder](../tips/migrate-from-raqb) for the full concept mapping.
+
+Output (object):
+
+```json
+{
+  "type": "group",
+  "properties": { "conjunction": "AND", "not": false },
+  "children1": [
+    {
+      "type": "rule",
+      "properties": {
+        "field": "firstName",
+        "operator": "equal",
+        "value": ["Steve"],
+        "valueSrc": ["value"]
+      }
+    },
+    {
+      "type": "rule",
+      "properties": {
+        "field": "lastName",
+        "operator": "equal",
+        "value": ["Vai"],
+        "valueSrc": ["value"]
+      }
+    }
+  ]
+}
+```
+
+A companion function, `formatRAQBFields`, converts an RQB `fields` array to the `fields` section of an RAQB `Config`:
+
+```ts
+import { formatRAQBFields } from '@react-querybuilder/migrate-raqb';
+
+const config = { ...BasicConfig, fields: formatRAQBFields(fields) };
+```
+
+`formatRAQB` accepts all `formatQuery` options except `format`, `ruleGroupProcessor`, and `fallbackExpression`, plus the RAQB-specific options below and `fallbackTree` (the tree returned when the query is empty or fails validation).
+
+```ts
+const jsonTree = formatRAQB(query, { fields, raqbFieldSeparator: '.', raqbValueTypes: true });
+```
+
+| Option                  | Default | Description                                                                                            |
+| ----------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `raqbOperatorMap`       | `{}`    | Additional/overriding RQB-to-RAQB operator mappings, keyed by RQB operator name.                       |
+| `raqbFunctionMap`       | `{}`    | Additional/overriding expression-function-to-RAQB function name mappings.                              |
+| `raqbFuncArgOrder`      | `{}`    | Argument names per RAQB function name. Defaults cover RAQB's built-ins; others get `arg0`, `arg1`, ... |
+| `raqbFieldSeparator`    | `"."`   | Separator used to qualify sub-query rule fields with their parent `!group` field name.                 |
+| `raqbRelativeDateTimes` | `true`  | Convert relative date/time values to RAQB's built-in date/time functions.                              |
+| `raqbValueTypes`        | `false` | Emit `valueType` entries inferred from each field's `inputType`/`valueEditorType`.                     |
+
+To combine RAQB output with other `formatQuery` behavior, or to supply a custom `ruleProcessor`, use the underlying `defaultRuleGroupProcessorRAQB` with the [`ruleGroupProcessor`](#rule-group-processor) option, which takes precedence over `format`. RAQB options then move into `context`, and `raqbFallback` should be passed as `fallbackExpression` if a `validator` can invalidate the whole query.
+
+```ts
+import { defaultRuleGroupProcessorRAQB, raqbFallback } from '@react-querybuilder/migrate-raqb';
+
+const jsonTree = formatQuery(query, {
+  ruleGroupProcessor: defaultRuleGroupProcessorRAQB,
+  fields,
+  context: { raqbValueTypes: true },
+  fallbackExpression: raqbFallback as unknown as string,
+});
+```
+
+:::note
+
+RAQB's default configuration has no equivalent for RQB's `doesNotBeginWith`/`doesNotEndWith` operators, the `"parameter"` value source, or `endOf*` relative date/time anchors. Rules using them are omitted (or, for `endOf*` anchors, emitted as plain values). Use `raqbOperatorMap` to map them onto custom RAQB operators.
+
+RAQB also restricts some constructs that RQB permits—notably `in`/`notIn` on non-`select` fields and most field-to-field comparisons. See [Migrating from react-awesome-query-builder](../tips/migrate-from-raqb#converting-back-to-raqb) for the full list.
+
+:::
+
 ### Diagnostics
 
 Generate a diagnostics result object using the "diagnostics" format. The output includes an annotated copy of the query tree, a flat diagnostics array, aggregate statistics, and a per-field summary.

--- a/website/docs/utils/import.mdx
+++ b/website/docs/utils/import.mdx
@@ -616,6 +616,32 @@ Output (`RuleGroupType`):
 }
 ```
 
+## react-awesome-query-builder
+
+`parseRAQB` converts a [react-awesome-query-builder](https://github.com/ukrbublik/react-awesome-query-builder) (RAQB) query tree to an RQB query. It is _not_ part of this package—since most projects need it exactly once, it lives in the separate [`@react-querybuilder/migrate-raqb`](https://github.com/react-querybuilder/migrate-raqb) package.
+
+```bash npm2yarn
+npm i @react-querybuilder/migrate-raqb
+```
+
+```ts
+import { parseRAQB, parseRAQBFields } from '@react-querybuilder/migrate-raqb';
+
+const fields = parseRAQBFields(raqbConfig.fields);
+const query = parseRAQB(Utils.getTree(immutableTree), { fields });
+```
+
+Output (`RuleGroupType`):
+
+```json
+{
+  "combinator": "and",
+  "rules": [{ "field": "price", "operator": ">", "value": 10 }]
+}
+```
+
+See [Migrating from react-awesome-query-builder](../tips/migrate-from-raqb) for the full concept mapping, operator translation table, and options.
+
 ## Configuration
 
 ### Lists as arrays

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -82,6 +82,8 @@ export default {
         'tips/parameter-manager',
         'tips/path',
         'tips/common-mistakes',
+        'tips/comparison',
+        'tips/migrate-from-raqb',
       ],
     },
     'compat',

--- a/website/versioned_docs/version-7/intro.mdx
+++ b/website/versioned_docs/version-7/intro.mdx
@@ -157,6 +157,8 @@ export default () => {
 
 Explore all React Query Builder options in the [main component documentation](./components/querybuilder). Try different configurations, export/import formats, and features in the interactive [demo](/demo).
 
+Coming from another library? See [how React Query Builder compares](./tips/comparison), and the guide for [migrating from react-awesome-query-builder](./tips/migrate-from-raqb).
+
 ## Training
 
 For an extended tutorial on configuration and customization of `react-querybuilder`, including information about integrating it with a backend API and advanced reporting components (grids, maps, charts, etc.), check out the course [Building Advanced Admin Reporting in React](https://www.newline.co/courses/building-advanced-admin-reporting-in-react), taught by this library's maintainer at [newline](https://www.newline.co/).

--- a/website/versioned_docs/version-7/tips/comparison.mdx
+++ b/website/versioned_docs/version-7/tips/comparison.mdx
@@ -1,0 +1,69 @@
+---
+title: Comparison with other libraries
+description: How React Query Builder compares to react-awesome-query-builder
+---
+
+The query builder library most often compared to React Query Builder (RQB) is [react-awesome-query-builder](https://github.com/ukrbublik/react-awesome-query-builder) (RAQB). Both render an interactive UI for building filter criteria, and both can export those criteria to several query languages, but they take meaningfully different approaches.
+
+This page summarizes the differences as of RQB v8 and RAQB v6.6.15 (May 2025). If you're moving an existing RAQB implementation to RQB, see [Migrating from react-awesome-query-builder](./migrate-from-raqb).
+
+## Philosophy
+
+|                 | React Query Builder                                                                | react-awesome-query-builder                                                      |
+| --------------- | ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Query storage   | Plain JSON ([`RuleGroupType`](../typescript#rules-and-groups)), serializable as-is | [immutable.js](https://immutable-js.com/) tree; plain JSON via `Utils.getTree()` |
+| Configuration   | Discrete props (`fields`, `operators`, `combinators`, `controlElements`, etc.)     | One monolithic `Config` object (types, widgets, operators, funcs, settings)      |
+| Packaging       | Composable packages — core, React, UI styles, and optional feature packages        | Core package plus UI-specific packages                                           |
+| Non-React usage | `@react-querybuilder/core` has no React dependency (server-safe)                   | Core depends on React                                                            |
+
+RQB's plain-JSON query format means you can store queries in a database, send them over the wire, diff them, and hand-edit them without any conversion step. RQB's discrete props mean you only configure (and only bundle) the parts you use.
+
+## Query model
+
+| Aspect         | React Query Builder                                                                                                                     | react-awesome-query-builder                                         |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Group children | `rules`                                                                                                                                 | `children1` (array, or keyed object when `children1AsArray: false`) |
+| Combinators    | `combinator` on the group, _or_ [independent combinators](../components/querybuilder#independent-combinators) interleaved between rules | `conjunction` on the group only                                     |
+| Negation       | `not` on groups                                                                                                                         | `not` on groups                                                     |
+| Rule value     | Scalar or array, depending on the operator                                                                                              | Always an array (one entry per operand)                             |
+| Subqueries     | [Match modes](./subqueries) — `all`, `some`, `none`, `atLeast`, `atMost`, `exactly` (with threshold)                                    | `!group` fields with `some`/`all`/`none` and count operators        |
+| Disabled rules | `disabled`                                                                                                                              | `isLocked`                                                          |
+| Muted rules    | [`muted`](../utils/export#muted-rules-and-groups) (kept in the query, excluded from exports)                                            | —                                                                   |
+| Ternary/CASE   | —                                                                                                                                       | `switch_group` / `case_group`                                       |
+| Value sources  | `value`, `field`, [expressions](../expr), [parameters](./parameter-manager)                                                             | `value`, `field`, `func`                                            |
+| Left-hand side | Expressions supported on the LHS as well as the RHS                                                                                     | `fieldSrc: "func"`                                                  |
+
+## Formats
+
+RQB's [`formatQuery`](../utils/export) supports considerably more export targets, and its [parsers](../utils/import) support more import sources.
+
+| Direction | React Query Builder                                                                                                                                                                                       | react-awesome-query-builder                                          |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Export    | JSON, SQL (plain/parameterized/named), MongoDB, CEL, JsonLogic, SpEL, ElasticSearch, JSONata, LDAP, natural language, Drizzle, TanStack DB, Prisma, Sequelize, Cypher, GraphQL, SPARQL, Gremlin, and more | SQL, MongoDB, JsonLogic, SpEL, ElasticSearch (partial), query string |
+| Import    | SQL, CEL, JsonLogic, MongoDB, SpEL, JSONata, Cypher, GraphQL, SPARQL, Gremlin, **RAQB**                                                                                                                   | JsonLogic, SpEL, SQL (separate package)                              |
+
+## Ecosystem
+
+| Aspect               | React Query Builder                                                                           | react-awesome-query-builder                          |
+| -------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| UI style packs       | Ant Design, Bootstrap, Bulma, Chakra UI, Fluent UI, Mantine, MUI/Material, PrimeReact, Tremor | Ant Design, MUI, Material (v4), Bootstrap, Fluent UI |
+| React Native         | `@react-querybuilder/native`                                                                  | —                                                    |
+| Drag-and-drop        | [`@react-querybuilder/dnd`](../dnd) (opt-in)                                                  | Built in                                             |
+| Date/time            | [`@react-querybuilder/datetime`](../datetime) (relative dates, per-dialect formatting)        | Built in (widgets and functions)                     |
+| Expressions          | [`@react-querybuilder/expr`](../expr)                                                         | Built in (config `funcs`)                            |
+| Rules engine         | [`@react-querybuilder/rules-engine`](../rules-engine)                                         | —                                                    |
+| Accessibility        | ARIA attributes, keyboard navigation, `data-testid` hooks                                     | Not documented                                       |
+| Internationalization | `translations` prop accepting strings or JSX                                                  | i18next-based locale packs                           |
+| Validation           | Per-field `validator` plus [`defaultValidator`](../utils/validation)                          | `sanitizeTree` / `validateTree` / `isValidTree`      |
+| Styling              | Unstyled by default with CSS custom properties; official style packs                          | Bundled SCSS per UI package                          |
+
+## Feature-by-feature notes
+
+Most RAQB concepts have a direct RQB counterpart. These are the exceptions:
+
+- **Ternary (`switch_group`)** — RAQB can build CASE/WHEN-style expressions. RQB has no equivalent in the query builder itself; conditional logic is generally modeled with [`@react-querybuilder/rules-engine`](../rules-engine) instead.
+- **`proximity` operator** — RAQB's full-text proximity operator (and its `operatorOptions`) has no RQB equivalent.
+- **`is_empty` / `is_not_empty`** — RQB expresses these as `=` and `!=` against an empty string.
+- **Locking** — RQB models this with the `disabled` property rather than a separate `locked` property, but the behavior and UI are equivalent. The [`showLockButtons`](../components/querybuilder#showlockbuttons) prop displays "Lock rule"/"Lock group" toggle buttons, which set `disabled` on the rule or group. As in RAQB, a locked group disables its header elements and all descendants. RQB has no equivalent to RAQB's `canDeleteLocked` setting.
+- **Date/time functions** — RAQB models `NOW`, `TODAY`, `RELATIVE_DATETIME`, etc. as functions. RQB treats the same concept as a _value_: [`@react-querybuilder/datetime`](../datetime) relative date/time values, which each rule processor serializes symbolically (e.g. `current_timestamp - interval '7 days'`).
+- **Cardinality operators** — RQB's match modes are a superset of RAQB's `!group` count operators, except that RQB has no strict-inequality modes (RAQB's `less`/`greater` counts).

--- a/website/versioned_docs/version-7/tips/migrate-from-raqb.mdx
+++ b/website/versioned_docs/version-7/tips/migrate-from-raqb.mdx
@@ -1,0 +1,531 @@
+---
+title: Migrating from react-awesome-query-builder
+description: Convert RAQB configs and query trees to React Query Builder
+---
+
+%importmd ../\_ts_admonition.md
+
+This guide covers moving an existing [react-awesome-query-builder](https://github.com/ukrbublik/react-awesome-query-builder) (RAQB) implementation to React Query Builder (RQB). For a broader feature-level overview, see [Comparison with other libraries](./comparison).
+
+Two utilities do most of the work:
+
+- `parseRAQB` converts a saved RAQB query tree to an RQB query object.
+- `parseRAQBFields` converts an RAQB `Config` (or just its `fields`) to an RQB `fields` array.
+
+Both are exported from [`@react-querybuilder/migrate-raqb`](https://github.com/react-querybuilder/migrate-raqb), a standalone package outside the main React Query Builder repository. Since migration is generally a one-time task, these utilities are packaged separately to keep them out of your production bundle.
+
+```bash npm2yarn
+npm i @react-querybuilder/migrate-raqb
+```
+
+```ts
+import { parseRAQB, parseRAQBFields } from '@react-querybuilder/migrate-raqb';
+```
+
+The package has no runtime dependencies—only a peer dependency on `@react-querybuilder/core` (v8.21.2 or later). It adds no dependency on RAQB or immutable.js.
+
+:::info
+
+`@react-querybuilder/migrate-raqb` requires React Query Builder v8. If you're migrating from RAQB, migrate straight to [the latest version](/docs/next/tips/migrate-from-raqb)—there's no reason to land on v7 first. Run the conversion under v8, save the resulting queries, and the output is plain JSON that works anywhere.
+
+:::
+
+:::tip
+
+Once your queries are converted and saved in RQB format, uninstall `@react-querybuilder/migrate-raqb`. Nothing in your application needs it at runtime.
+
+:::
+
+## Concept mapping
+
+| RAQB                                | React Query Builder                                                              |
+| ----------------------------------- | -------------------------------------------------------------------------------- |
+| `Config`                            | Discrete props: `fields`, `operators`, `combinators`, `controlElements`          |
+| `Config.fields`                     | [`fields`](./managing-fields)                                                    |
+| `Query` + `Builder` render prop     | A single [`<QueryBuilder />`](../components/querybuilder) element                |
+| immutable tree + `Utils.getTree()`  | Plain JSON query object, used directly                                           |
+| `group` node                        | Rule group (an object with a `rules` array)                                      |
+| `properties.conjunction`            | `combinator`                                                                     |
+| `properties.not`                    | `not`                                                                            |
+| `rule` node                         | Rule (`{ field, operator, value }`)                                              |
+| `properties.valueSrc`               | `valueSource`                                                                    |
+| `properties.isLocked`               | `disabled` (see [`showLockButtons`](../components/querybuilder#showlockbuttons)) |
+| `rule_group` (`!group` field)       | Rule with a [match mode](./subqueries) and a nested group as its value           |
+| `switch_group` / `case_group`       | No equivalent — see [Unsupported constructs](#unsupported-constructs)            |
+| Widgets                             | [`valueEditorType` / `inputType`](./managing-fields) or a custom `valueEditor`   |
+| `funcs`                             | [`@react-querybuilder/expr`](../expr)                                            |
+| `sqlFormat`, `mongodbFormat`, etc.  | [`formatQuery`](../utils/export)                                                 |
+| `loadFromJsonLogic`, `loadFromSpel` | [`parseJsonLogic`, `parseSpEL`](../utils/import)                                 |
+
+## Rendering the component
+
+RAQB splits rendering across `<Query>`, a `renderBuilder` callback, and `<Builder>`, and keeps the query in an immutable.js tree that must be converted before it can be saved. RQB renders a single element and stores the query as plain JSON.
+
+```tsx title="Before (RAQB)"
+import { useCallback, useState } from 'react';
+import type {
+  BuilderProps,
+  Config,
+  ImmutableTree,
+  JsonGroup,
+} from '@react-awesome-query-builder/ui';
+import { BasicConfig, Builder, Query, Utils as QbUtils } from '@react-awesome-query-builder/ui';
+import '@react-awesome-query-builder/ui/css/styles.css';
+
+const config: Config = {
+  ...BasicConfig,
+  fields: {
+    price: { label: 'Price', type: 'number' },
+    color: {
+      label: 'Color',
+      type: 'select',
+      fieldSettings: {
+        listValues: [
+          { value: 'yellow', title: 'Yellow' },
+          { value: 'green', title: 'Green' },
+        ],
+      },
+    },
+  },
+  settings: {
+    ...BasicConfig.settings,
+    showNot: true,
+    showLock: true,
+    maxNesting: 3,
+    addRuleLabel: 'New rule',
+  },
+};
+
+const initialTree: JsonGroup = { id: QbUtils.uuid(), type: 'group' };
+
+export const App = () => {
+  const [tree, setTree] = useState(() => QbUtils.loadTree(initialTree));
+
+  const onChange = useCallback((immutableTree: ImmutableTree) => {
+    setTree(immutableTree);
+    // Convert before saving — the state itself is an immutable.js tree
+    console.log(QbUtils.getTree(immutableTree));
+  }, []);
+
+  const renderBuilder = useCallback(
+    (props: BuilderProps) => (
+      <div className="query-builder-container">
+        <div className="query-builder qb-lite">
+          <Builder {...props} />
+        </div>
+      </div>
+    ),
+    []
+  );
+
+  return (
+    <>
+      <Query {...config} value={tree} onChange={onChange} renderBuilder={renderBuilder} />
+      <pre>{QbUtils.sqlFormat(tree, config)}</pre>
+    </>
+  );
+};
+```
+
+```tsx title="After (RQB)"
+import { useState } from 'react';
+import type { Field, RuleGroupType } from 'react-querybuilder';
+import { formatQuery, QueryBuilder } from 'react-querybuilder';
+import 'react-querybuilder/dist/query-builder.css';
+
+const fields: Field[] = [
+  { name: 'price', label: 'Price', inputType: 'number' },
+  {
+    name: 'color',
+    label: 'Color',
+    valueEditorType: 'select',
+    values: [
+      { name: 'yellow', label: 'Yellow' },
+      { name: 'green', label: 'Green' },
+    ],
+  },
+];
+
+const initialQuery: RuleGroupType = { combinator: 'and', rules: [] };
+
+export const App = () => {
+  // Already plain JSON — save it as-is
+  const [query, setQuery] = useState(initialQuery);
+
+  return (
+    <>
+      <QueryBuilder
+        fields={fields}
+        query={query}
+        onQueryChange={setQuery}
+        showNotToggle
+        showLockButtons
+        maxLevels={3}
+        translations={{ addRule: { label: 'New rule' } }}
+      />
+      <pre>{formatQuery(query, 'sql')}</pre>
+    </>
+  );
+};
+```
+
+Notable differences:
+
+- Configuration is spread across discrete props instead of one `Config` object, so there's no base config to spread (no `BasicConfig`) and nothing to keep in state alongside the query.
+- `onQueryChange` receives the query object directly, so it can be passed straight to a `useState` setter and saved without conversion.
+- There is no `renderBuilder` indirection or required wrapper markup. Use [`controlClassnames`](../components/querybuilder#controlclassnames) and [`controlElements`](../components/querybuilder#controlelements) to customize markup and styling.
+- Export functions take the query object, not a tree plus a config.
+
+### Settings
+
+RAQB's `config.settings` correspond to individual `<QueryBuilder />` props:
+
+| RAQB setting                                         | RQB prop                                                                                                                                            |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `showNot`                                            | [`showNotToggle`](../components/querybuilder#shownottoggle)                                                                                         |
+| `showLock`                                           | [`showLockButtons`](../components/querybuilder#showlockbuttons)                                                                                     |
+| `canReorder` / `canRegroup`                          | [`enableDragAndDrop`](../components/querybuilder#enabledraganddrop) (requires [`@react-querybuilder/dnd`](../dnd))                                  |
+| `maxNesting`                                         | [`maxLevels`](../components/querybuilder#maxlevels)                                                                                                 |
+| `maxNumberOfRules`                                   | Return `false` from [`onAddRule`](../components/querybuilder#onaddrule)                                                                             |
+| `immutableGroupsMode` and friends                    | [`disabled`](../components/querybuilder#disabled) (all or by path)                                                                                  |
+| `clearValueOnChangeField` / `clearValueOnChangeOp`   | [`resetOnFieldChange`](../components/querybuilder#resetonfieldchange) / [`resetOnOperatorChange`](../components/querybuilder#resetonoperatorchange) |
+| `setOpOnChangeField`                                 | [`getDefaultOperator`](../components/querybuilder#getdefaultoperator), [`autoSelectOperator`](../components/querybuilder#autoselectoperator)        |
+| `defaultField` / `defaultOperator`                   | [`getDefaultField`](../components/querybuilder#getdefaultfield) / [`getDefaultOperator`](../components/querybuilder#getdefaultoperator)             |
+| `defaultConjunction`                                 | First entry of [`combinators`](../components/querybuilder#combinators), or the `combinator` of your initial query                                   |
+| `addRuleLabel`, `valuePlaceholder`, and other labels | [`translations`](../components/querybuilder#translations)                                                                                           |
+| `fieldSeparator`                                     | Handled at conversion time by `parseRAQBFields` (field names are flattened)                                                                         |
+
+## Converting the config
+
+`parseRAQBFields` accepts either a full RAQB `Config` object or just the `fields` map, and returns an RQB `fields` array.
+
+```ts
+import { parseRAQBFields } from '@react-querybuilder/migrate-raqb';
+
+const fields = parseRAQBFields({
+  price: {
+    label: 'Price',
+    type: 'number',
+    fieldSettings: { min: 0, max: 100 },
+  },
+  color: {
+    label: 'Color',
+    type: 'select',
+    fieldSettings: {
+      listValues: [
+        { value: 'yellow', title: 'Yellow' },
+        { value: 'green', title: 'Green' },
+      ],
+    },
+  },
+});
+```
+
+```json title="Result"
+[
+  { "name": "price", "label": "Price", "inputType": "number" },
+  {
+    "name": "color",
+    "label": "Color",
+    "valueEditorType": "select",
+    "values": [
+      { "name": "yellow", "label": "Yellow" },
+      { "name": "green", "label": "Green" }
+    ]
+  }
+]
+```
+
+Translation details:
+
+- Nested `!struct` fields are flattened to dot-separated names, matching the field paths stored in RAQB query trees. The separator comes from `settings.fieldSeparator` (default `"."`), or the `fieldSeparator` option.
+- `!group` fields become fields with `matchModes` and `subproperties`, which is RQB's [subquery](./subqueries) representation.
+- `type` maps to `inputType` (`number`, `date`, `time`, `datetime-local`, etc.) or `valueEditorType` (`select`, `multiselect`, `checkbox`).
+- `fieldSettings.listValues` and `fieldSettings.treeValues` map to `values`. Tree values are flattened.
+- `operators`, `defaultOperator`, `excludeOperators`, `valueSources`, and `defaultValue` are translated to their RQB equivalents.
+- Fields marked `hideForSelect` are omitted unless you pass `includeHidden: true`.
+- Export-time settings (`fieldName`, `tableName`, `jsonLogicVar`, `isSpelVariable`) and `fieldSettings.validateValue` are not translated.
+
+### `parseRAQBFields` options
+
+- `fieldSeparator` (`string`): Character used to join nested field names.
+- `operatorMap` (`Record<string, string>`): Additional or overriding operator name mappings. Should match the `operatorMap` passed to `parseRAQB`.
+- `includeHidden` (`boolean`): Include fields marked `hideForSelect`. Defaults to `false`.
+- `onUnsupported` (`(info: RAQBUnsupportedInfo) => void`): Called for each construct that could not be fully translated.
+
+## Converting queries
+
+`parseRAQB` accepts RAQB's **plain-JSON** tree — the output of `Utils.getTree(immutableTree)` — or a JSON string of the same. Immutable.js trees are not accepted; passing one throws an error explaining the fix.
+
+```ts
+// In your RAQB app, save the plain JSON form:
+const jsonTree = QbUtils.getTree(immutableTree);
+```
+
+```ts
+import { parseRAQB } from '@react-querybuilder/migrate-raqb';
+
+const query = parseRAQB(jsonTree);
+```
+
+```ts title="Example"
+parseRAQB({
+  type: 'group',
+  properties: { conjunction: 'AND' },
+  children1: [
+    {
+      type: 'rule',
+      properties: { field: 'price', operator: 'greater', value: [10], valueSrc: ['value'] },
+    },
+    {
+      type: 'rule',
+      properties: { field: 'color', operator: 'select_any_in', value: [['yellow', 'green']] },
+    },
+  ],
+});
+```
+
+```json title="Result"
+{
+  "combinator": "and",
+  "rules": [
+    { "field": "price", "operator": ">", "value": 10 },
+    { "field": "color", "operator": "in", "value": "yellow,green" }
+  ]
+}
+```
+
+Both `children1` shapes are supported: the default array form and the keyed-object form produced when `children1AsArray` is `false`.
+
+### Operator mapping
+
+| RAQB                                                           | RQB                                                             |
+| -------------------------------------------------------------- | --------------------------------------------------------------- |
+| `equal` / `not_equal`                                          | `=` / `!=`                                                      |
+| `less` / `less_or_equal`                                       | `<` / `<=`                                                      |
+| `greater` / `greater_or_equal`                                 | `>` / `>=`                                                      |
+| `like` / `not_like`                                            | `contains` / `doesNotContain`                                   |
+| `starts_with` / `ends_with`                                    | `beginsWith` / `endsWith`                                       |
+| `between` / `not_between`                                      | `between` / `notBetween`                                        |
+| `is_null` / `is_not_null`                                      | `null` / `notNull`                                              |
+| `is_empty` / `is_not_empty`                                    | `=` / `!=` with an empty string                                 |
+| `select_equals` / `select_not_equals`                          | `=` / `!=`                                                      |
+| `select_any_in` / `select_not_any_in`                          | `in` / `notIn`                                                  |
+| `multiselect_equals` / `multiselect_not_equals`                | `=` / `!=` (array value kept)                                   |
+| `multiselect_contains` / `multiselect_not_contains`            | `contains` / `doesNotContain`                                   |
+| `some` / `all` / `none`                                        | Match modes `some` / `all` / `none`                             |
+| `!group` counts `equal` / `greater_or_equal` / `less_or_equal` | Match modes `exactly` / `atLeast` / `atMost` with a `threshold` |
+
+Add to or override this map with the `operatorMap` option.
+
+### `parseRAQB` options
+
+Beyond the standard [import configuration](../utils/import#configuration) options (`fields`, `listsAsArrays`, `generateIDs`, `independentCombinators`, etc.), `parseRAQB` accepts:
+
+- `operatorMap` (`Record<string, DefaultOperatorName>`): Additional or overriding RAQB-to-RQB operator mappings, merged over the defaults.
+- `functionMap` (`Record<string, string>`): Additional or overriding RAQB-to-`expr` function name mappings, merged over the defaults.
+- `funcArgOrder` (`Record<string, string[]>`): Explicit argument order per RAQB function name. By default, argument order follows the key order of the serialized function object.
+- `relativeDateTimes` (`boolean`): Convert RAQB's built-in date/time functions to relative date/time values instead of expressions. Defaults to `true`. See [Date and time functions](#date-and-time-functions).
+- `onUnsupported` (`(info: RAQBUnsupportedInfo) => void`): Called for each construct that could not be converted.
+
+As with other parsers, passing `fields` restricts the output to rules whose fields exist in the list.
+
+## Functions and expressions
+
+RAQB's `valueSrc: "func"` operands convert to RQB [expressions](../expr). Right-hand side functions become `valueSource: "expression"` with an expression object as the value; a function on the _left_ side (`fieldSrc: "func"`) becomes the rule's `lhs` property.
+
+```ts title="Example"
+parseRAQB({
+  type: 'group',
+  properties: { conjunction: 'AND' },
+  children1: [
+    {
+      type: 'rule',
+      properties: {
+        field: 'name',
+        operator: 'equal',
+        valueSrc: ['func'],
+        value: [{ func: 'LOWER', args: { str: { value: 'Steve', valueSrc: 'value' } } }],
+      },
+    },
+  ],
+});
+```
+
+```json title="Result"
+{
+  "combinator": "and",
+  "rules": [
+    {
+      "field": "name",
+      "operator": "=",
+      "valueSource": "expression",
+      "value": { "kind": "func", "fn": "lower", "args": [{ "kind": "value", "value": "Steve" }] }
+    }
+  ]
+}
+```
+
+:::caution
+
+Queries containing expressions require [`@react-querybuilder/expr`](../expr) to render, validate, or serialize. Wrap your query builder in `QueryBuilderExpressions` and register the export processor as described in the [expressions documentation](../expr). Without that package, expression values will not display or export correctly.
+
+:::
+
+RAQB's `LOWER` and `UPPER` map to `expr`'s `lower` and `upper`, and `LINEAR_REGRESSION` is expanded to the equivalent arithmetic expression. Every other RAQB function—apart from the date/time functions described below—is passed through under its original name and reported to `onUnsupported`. To render or export those, either register matching function metadata with `@react-querybuilder/expr` or map them to existing functions with `functionMap`.
+
+## Date and time functions
+
+RAQB's built-in date/time functions don't really compute anything—they describe a date relative to "now". RQB represents that concept as a _value_ rather than an expression, so `parseRAQB` converts them to [`@react-querybuilder/datetime`](../datetime)'s relative date/time value shape (`{ mode: "relative", anchor, offset, unit }`), which every date/time rule processor serializes symbolically (e.g. `current_timestamp - interval '7 days'`).
+
+| RAQB                                      | RQB value                                          |
+| ----------------------------------------- | -------------------------------------------------- |
+| `NOW()`                                   | `{ anchor: 'now', offset: 0 }`                     |
+| `TODAY()` / `START_OF_TODAY()`            | `{ anchor: 'startOfDay', offset: 0 }`              |
+| `TRUNCATE_DATETIME(NOW(), dim)`           | `{ anchor: 'startOf<Dim>', offset: 0 }`            |
+| `RELATIVE_DATE(TIME)(date, op, val, dim)` | `{ anchor: <from date>, offset: ±val, unit: dim }` |
+
+```ts title="Example"
+parseRAQB({
+  type: 'group',
+  properties: { conjunction: 'AND' },
+  children1: [
+    {
+      type: 'rule',
+      properties: {
+        field: 'created',
+        operator: 'between',
+        valueSrc: ['func', 'func'],
+        value: [
+          {
+            func: 'RELATIVE_DATETIME',
+            args: { op: { value: 'minus' }, val: { value: 7 }, dim: { value: 'day' } },
+          },
+          { func: 'NOW', args: {} },
+        ],
+      },
+    },
+  ],
+});
+```
+
+```json title="Result"
+{
+  "combinator": "and",
+  "rules": [
+    {
+      "field": "created",
+      "operator": "between",
+      "value": [
+        { "mode": "relative", "anchor": "now", "offset": -7, "unit": "day" },
+        { "mode": "relative", "anchor": "now", "offset": 0, "unit": "day" }
+      ]
+    }
+  ]
+}
+```
+
+With `@react-querybuilder/datetime`'s SQL rule processor, that query exports as `"created" between current_timestamp - interval '7 days' and current_timestamp`.
+
+A few RAQB calls fall outside what relative values can express, and are converted to expressions instead (and reported to `onUnsupported`):
+
+- A `"second"` dimension. RQB's smallest relative unit is `minute`.
+- Truncation to `hour`, `minute`, or `second`. RQB truncates only to day, week, month, or year.
+- Truncation applied _after_ an offset, e.g. `TRUNCATE_DATETIME(RELATIVE_DATETIME(NOW(), 'minus', 3, 'day'), 'month')`. RQB applies the anchor first and the offset second, so only the reverse nesting is representable.
+
+Pass `relativeDateTimes: false` to convert date/time functions to expressions like any other function.
+
+## Unsupported constructs
+
+`parseRAQB` never throws on unrecognized content (aside from immutable.js input). Anything it can't convert is skipped, and a partial query is always returned. Use `onUnsupported` to log or surface what was dropped.
+
+```ts
+const unsupported: RAQBUnsupportedInfo[] = [];
+
+const query = parseRAQB(jsonTree, {
+  onUnsupported: info => unsupported.push(info),
+});
+```
+
+Reported constructs include:
+
+- **`switch_group` / `case_group`** (RAQB's ternary mode). RQB has no equivalent; consider [`@react-querybuilder/rules-engine`](../rules-engine) for conditional logic.
+- **`proximity`** and its `operatorOptions`, which have no RQB counterpart.
+- **`!group` strict-inequality count operators** (`less`, `greater`), since RQB match modes cover only `exactly`, `atLeast`, and `atMost`.
+- **Functions with no `@react-querybuilder/expr` equivalent**, which pass through by name.
+
+## Putting it together
+
+```tsx
+import { QueryBuilder } from 'react-querybuilder';
+import { parseRAQB, parseRAQBFields } from '@react-querybuilder/migrate-raqb';
+import raqbConfig from './raqbConfig';
+import savedTree from './savedQuery.json';
+
+const fields = parseRAQBFields(raqbConfig);
+const defaultQuery = parseRAQB(savedTree, { fields });
+
+export const App = () => <QueryBuilder fields={fields} defaultQuery={defaultQuery} />;
+```
+
+## Converting back to RAQB
+
+The reverse conversion is useful for a phased migration where both query builders must read the same stored queries. `@react-querybuilder/migrate-raqb` exports `formatRAQB` for this purpose. (There is no `"raqb"` `formatQuery` export format; `formatRAQB` wraps `formatQuery`'s `ruleGroupProcessor` option, which takes precedence over `format`.)
+
+```ts
+import { formatRAQB } from '@react-querybuilder/migrate-raqb';
+import { Utils } from '@react-awesome-query-builder/core';
+
+const jsonTree = formatRAQB(query, { fields });
+const immutableTree = Utils.checkTree(Utils.loadTree(jsonTree), raqbConfig);
+```
+
+Pass `fields` for the most faithful output—several RAQB operators collapse to a single RQB operator, and the field's `valueEditorType` is used to disambiguate them.
+
+`formatRAQBFields`, the inverse of `parseRAQBFields`, is exported from the same package:
+
+```ts
+import { formatRAQBFields } from '@react-querybuilder/migrate-raqb';
+
+const raqbConfig = { ...BasicConfig, fields: formatRAQBFields(fields) };
+```
+
+`formatRAQB` accepts all [`formatQuery` options](../utils/export) except `format`, `ruleGroupProcessor`, and `fallbackExpression`, plus `fallbackTree` (the tree returned when the query is empty or fails validation) and:
+
+| Option                  | Default | Description                                                                                            |
+| ----------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `raqbOperatorMap`       | `{}`    | Additional/overriding RQB-to-RAQB operator mappings, keyed by RQB operator name.                       |
+| `raqbFunctionMap`       | `{}`    | Additional/overriding expression-function-to-RAQB function name mappings.                              |
+| `raqbFuncArgOrder`      | `{}`    | Argument names per RAQB function name. Defaults cover RAQB's built-ins; others get `arg0`, `arg1`, ... |
+| `raqbFieldSeparator`    | `"."`   | Separator used to qualify sub-query rule fields with their parent `!group` field name.                 |
+| `raqbRelativeDateTimes` | `true`  | Convert relative date/time values to RAQB's built-in date/time functions.                              |
+| `raqbValueTypes`        | `false` | Emit `valueType` entries inferred from each field's `inputType`/`valueEditorType`.                     |
+
+The mapping is the inverse of the tables above, with these caveats:
+
+- RQB's `doesNotBeginWith` and `doesNotEndWith` have no RAQB default equivalent (there is no `not_starts_with`/`not_ends_with`); rules using them are omitted unless you supply a `raqbOperatorMap` entry.
+- The `"parameter"` value source has no RAQB counterpart, so those rules are omitted.
+- `in`/`notIn` map to `select_any_in`/`select_not_any_in`, which RAQB only allows for `select` and `multiselect` fields. On a plain text field RAQB's `checkTree` will reject the rule.
+- Field-to-field comparisons are more restricted in RAQB: its `field` widget for the `text` type supports only `equal`, `not_equal`, and `proximity`, so `contains`/`beginsWith`/`endsWith`/`<`/`>` against another field are rejected.
+- RAQB clamps inverted ranges, so a `between` rule with `preserveValueOrder` and out-of-order bounds (e.g. `[100, 0]`) becomes `[100, 100]` once loaded.
+- `bigint` values are narrowed to `number`, since RAQB trees must be JSON-serializable.
+- `endOf*` relative date/time anchors are emitted as plain values, since RAQB's built-in functions only truncate to the _start_ of a period.
+- RAQB defines no `XOR` conjunction. `xor` combinators are emitted as `"XOR"` rather than silently degraded, so RAQB's `checkTree` will flag them unless a matching custom conjunction is configured.
+- RAQB's several operators that collapse to one RQB operator (`equal`/`select_equals`/`multiselect_equals` → `=`) are disambiguated using each field's `valueEditorType`, so pass `fields` for the most faithful output.
+- When `validator` results invalidate the entire query, `formatRAQB` returns `fallbackTree` (`raqbFallback`, an empty `AND` group, by default). If you call `formatQuery` directly with `defaultRuleGroupProcessorRAQB`, pass `fallbackExpression: raqbFallback as unknown as string`—`formatQuery` short-circuits _before_ the rule group processor runs, and its own default fallback is a SQL string.
+
+To combine RAQB output with other `formatQuery` behavior, or to supply a custom `ruleProcessor`, use `defaultRuleGroupProcessorRAQB` directly. RAQB options then move into `context`:
+
+```ts
+import { formatQuery } from 'react-querybuilder';
+import { defaultRuleGroupProcessorRAQB, raqbFallback } from '@react-querybuilder/migrate-raqb';
+
+const jsonTree = formatQuery(query, {
+  ruleGroupProcessor: defaultRuleGroupProcessorRAQB,
+  fields,
+  context: { raqbValueTypes: true },
+  fallbackExpression: raqbFallback as unknown as string,
+});
+```
+
+RAQB's last stable release was 6.6.15 in May 2025; these utilities exist to give RAQB users a straightforward path to React Query Builder.

--- a/website/versioned_docs/version-7/utils/export.mdx
+++ b/website/versioned_docs/version-7/utils/export.mdx
@@ -622,6 +622,99 @@ Output (string):
 .has('firstName', 'Steve').has('lastName', 'Vai')
 ```
 
+### react-awesome-query-builder
+
+Generate a [react-awesome-query-builder](https://github.com/ukrbublik/react-awesome-query-builder) (RAQB) query tree in its plain-JSON form, suitable for RAQB's `Utils.loadTree()`.
+
+This is _not_ a built-in export format. Since most projects need it exactly once, it lives in the separate [`@react-querybuilder/migrate-raqb`](https://github.com/react-querybuilder/migrate-raqb) package, which exports a `formatRAQB` function.
+
+```bash npm2yarn
+npm i @react-querybuilder/migrate-raqb
+```
+
+```ts
+import { Utils } from '@react-awesome-query-builder/core';
+import { formatRAQB } from '@react-querybuilder/migrate-raqb';
+
+const jsonTree = formatRAQB(query, { fields });
+const immutableTree = Utils.checkTree(Utils.loadTree(jsonTree), config);
+```
+
+This is the inverse of `parseRAQB`. See [Migrating from react-awesome-query-builder](../tips/migrate-from-raqb) for the full concept mapping.
+
+Output (object):
+
+```json
+{
+  "type": "group",
+  "properties": { "conjunction": "AND", "not": false },
+  "children1": [
+    {
+      "type": "rule",
+      "properties": {
+        "field": "firstName",
+        "operator": "equal",
+        "value": ["Steve"],
+        "valueSrc": ["value"]
+      }
+    },
+    {
+      "type": "rule",
+      "properties": {
+        "field": "lastName",
+        "operator": "equal",
+        "value": ["Vai"],
+        "valueSrc": ["value"]
+      }
+    }
+  ]
+}
+```
+
+A companion function, `formatRAQBFields`, converts an RQB `fields` array to the `fields` section of an RAQB `Config`:
+
+```ts
+import { formatRAQBFields } from '@react-querybuilder/migrate-raqb';
+
+const config = { ...BasicConfig, fields: formatRAQBFields(fields) };
+```
+
+`formatRAQB` accepts all `formatQuery` options except `format`, `ruleGroupProcessor`, and `fallbackExpression`, plus the RAQB-specific options below and `fallbackTree` (the tree returned when the query is empty or fails validation).
+
+```ts
+const jsonTree = formatRAQB(query, { fields, raqbFieldSeparator: '.', raqbValueTypes: true });
+```
+
+| Option                  | Default | Description                                                                                            |
+| ----------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `raqbOperatorMap`       | `{}`    | Additional/overriding RQB-to-RAQB operator mappings, keyed by RQB operator name.                       |
+| `raqbFunctionMap`       | `{}`    | Additional/overriding expression-function-to-RAQB function name mappings.                              |
+| `raqbFuncArgOrder`      | `{}`    | Argument names per RAQB function name. Defaults cover RAQB's built-ins; others get `arg0`, `arg1`, ... |
+| `raqbFieldSeparator`    | `"."`   | Separator used to qualify sub-query rule fields with their parent `!group` field name.                 |
+| `raqbRelativeDateTimes` | `true`  | Convert relative date/time values to RAQB's built-in date/time functions.                              |
+| `raqbValueTypes`        | `false` | Emit `valueType` entries inferred from each field's `inputType`/`valueEditorType`.                     |
+
+To combine RAQB output with other `formatQuery` behavior, or to supply a custom `ruleProcessor`, use the underlying `defaultRuleGroupProcessorRAQB` with the [`ruleGroupProcessor`](#rule-group-processor) option, which takes precedence over `format`. RAQB options then move into `context`, and `raqbFallback` should be passed as `fallbackExpression` if a `validator` can invalidate the whole query.
+
+```ts
+import { defaultRuleGroupProcessorRAQB, raqbFallback } from '@react-querybuilder/migrate-raqb';
+
+const jsonTree = formatQuery(query, {
+  ruleGroupProcessor: defaultRuleGroupProcessorRAQB,
+  fields,
+  context: { raqbValueTypes: true },
+  fallbackExpression: raqbFallback as unknown as string,
+});
+```
+
+:::note
+
+RAQB's default configuration has no equivalent for RQB's `doesNotBeginWith`/`doesNotEndWith` operators, the `"parameter"` value source, or `endOf*` relative date/time anchors. Rules using them are omitted (or, for `endOf*` anchors, emitted as plain values). Use `raqbOperatorMap` to map them onto custom RAQB operators.
+
+RAQB also restricts some constructs that RQB permits—notably `in`/`notIn` on non-`select` fields and most field-to-field comparisons. See [Migrating from react-awesome-query-builder](../tips/migrate-from-raqb#converting-back-to-raqb) for the full list.
+
+:::
+
 ### Diagnostics
 
 Generate a diagnostics result object using the "diagnostics" format. The output includes an annotated copy of the query tree, a flat diagnostics array, aggregate statistics, and a per-field summary.

--- a/website/versioned_docs/version-7/utils/import.mdx
+++ b/website/versioned_docs/version-7/utils/import.mdx
@@ -616,6 +616,32 @@ Output (`RuleGroupType`):
 }
 ```
 
+## react-awesome-query-builder
+
+`parseRAQB` converts a [react-awesome-query-builder](https://github.com/ukrbublik/react-awesome-query-builder) (RAQB) query tree to an RQB query. It is _not_ part of this package—since most projects need it exactly once, it lives in the separate [`@react-querybuilder/migrate-raqb`](https://github.com/react-querybuilder/migrate-raqb) package.
+
+```bash npm2yarn
+npm i @react-querybuilder/migrate-raqb
+```
+
+```ts
+import { parseRAQB, parseRAQBFields } from '@react-querybuilder/migrate-raqb';
+
+const fields = parseRAQBFields(raqbConfig.fields);
+const query = parseRAQB(Utils.getTree(immutableTree), { fields });
+```
+
+Output (`RuleGroupType`):
+
+```json
+{
+  "combinator": "and",
+  "rules": [{ "field": "price", "operator": ">", "value": 10 }]
+}
+```
+
+See [Migrating from react-awesome-query-builder](../tips/migrate-from-raqb) for the full concept mapping, operator translation table, and options.
+
 ## Configuration
 
 ### Lists as arrays

--- a/website/versioned_sidebars/version-7-sidebars.json
+++ b/website/versioned_sidebars/version-7-sidebars.json
@@ -81,7 +81,9 @@
         "tips/custom-bind-variables",
         "tips/parameter-manager",
         "tips/path",
-        "tips/common-mistakes"
+        "tips/common-mistakes",
+        "tips/comparison",
+        "tips/migrate-from-raqb"
       ]
     },
     "compat",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive comparison between React Query Builder and React Awesome Query Builder.
  * Added migration guidance covering query trees, field configurations, supported options, limitations, and reverse conversion.
  * Documented import and export utilities for converting between both query formats.
  * Added links to the new guides throughout the documentation and navigation.
  * Updated the changelog with the migration resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->