### PR TITLE
Add reconfigure API to QueryManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-N/A
+### Added
+
+- `QueryManager#reconfigure(options, { replace })` updates a manager's configuration in place—propagating new `translations`, `fields`, `operators`, etc.—while keeping the current query, the undo/redo history, and all subscribers. Incoming options are shallow-merged over the current ones unless `replace` is `true`. Companion methods `getOptions()` and `getConfigVersion()` were added as well, and `useQueryManager` now re-renders when a manager is reconfigured.
 
 ## [v8.22.2] - 2026-08-05
 

--- a/packages/core/src/utils/QueryManager.test.ts
+++ b/packages/core/src/utils/QueryManager.test.ts
@@ -2035,6 +2035,35 @@ describe('reconfigure', () => {
     expect(q.canRedo()).toBe(false);
   });
 
+  it('reconciles history after a failed batch turns history off', () => {
+    const q = new QueryManager(undefined, { fields, history: true });
+    q.add(rule());
+    expect(q.canUndo()).toBe(true);
+
+    expect(() =>
+      q.batch(() => {
+        q.reconfigure({ history: false });
+        throw new Error('rollback');
+      })
+    ).toThrow('rollback');
+
+    expect(q.canUndo()).toBe(false);
+    expect(q.canRedo()).toBe(false);
+  });
+
+  it('records history for a mutation after history is toggled within a batch', () => {
+    const q = new QueryManager(undefined, { fields, history: true });
+
+    q.batch(() => {
+      q.reconfigure({ history: false });
+      q.reconfigure({ history: true });
+      q.add(rule());
+    });
+
+    expect(q.canUndo()).toBe(true);
+    expect(q.getHistory().past).toHaveLength(1);
+  });
+
   it('starts recording when history is turned on', () => {
     const q = new QueryManager(undefined, { fields });
     q.add(rule());

--- a/packages/core/src/utils/QueryManager.test.ts
+++ b/packages/core/src/utils/QueryManager.test.ts
@@ -1862,6 +1862,210 @@ describe('translations', () => {
   });
 });
 
+describe('reconfigure', () => {
+  const autoSelectOff = {
+    autoSelectField: false,
+    autoSelectOperator: false,
+    autoSelectValue: false,
+  } as const;
+
+  it('propagates new translations to the option lists', () => {
+    const q = new QueryManager(undefined, {
+      fields,
+      ...autoSelectOff,
+      translations: { fields: { placeholderLabel: 'Select a field' } },
+    });
+    expect((q.getFields() as FullField[])[0].label).toBe('Select a field');
+
+    q.reconfigure({ translations: { fields: { placeholderLabel: 'Choisir un champ' } } });
+
+    expect((q.getFields() as FullField[])[0].label).toBe('Choisir un champ');
+    expect(q.getFieldData(defaultPlaceholderName).label).toBe('Choisir un champ');
+  });
+
+  it('propagates new translations to operators and values', () => {
+    const q = new QueryManager(undefined, {
+      fields: [{ name: 'gender', label: 'Gender', values: [{ name: 'M', label: 'Male' }] }],
+      ...autoSelectOff,
+    });
+
+    q.reconfigure({
+      translations: {
+        operators: { placeholderName: '%', placeholderLabel: 'Op' },
+        values: { placeholderName: '$', placeholderLabel: 'Val' },
+      },
+    });
+
+    expect((q.getOperators('gender') as FullOption[])[0]).toMatchObject({
+      value: '%',
+      label: 'Op',
+    });
+    expect((q.getValues('gender', '=') as FullOption[])[0]).toMatchObject({
+      value: '$',
+      label: 'Val',
+    });
+    expect(q.createRule()).toMatchObject({ operator: '%' });
+  });
+
+  it('shallow-merges over the existing options', () => {
+    const q = new QueryManager(undefined, { fields, ...autoSelectOff });
+    q.reconfigure({ translations: { fields: { placeholderName: '#' } } });
+
+    // `fields` and the autoSelect options were not passed to `reconfigure` but are preserved.
+    expect(q.getFields()).toHaveLength(fields.length + 1);
+    expect(q.createRule()).toMatchObject({ field: '#' });
+  });
+
+  it('resets an option to its default when passed explicitly as undefined', () => {
+    const q = new QueryManager(undefined, { fields, combinators: [{ name: 'xor', label: 'XOR' }] });
+    expect(q.getCombinators()).toHaveLength(1);
+
+    q.reconfigure({ combinators: undefined });
+
+    expect(q.getCombinators().length).toBeGreaterThan(1);
+  });
+
+  it('discards the previous options when `replace` is true', () => {
+    const q = new QueryManager(undefined, { fields, ...autoSelectOff });
+    q.reconfigure({ validator: () => true }, { replace: true });
+
+    expect(q.getOptions()).toEqual({ validator: expect.any(Function) });
+    // `fields` is gone, so the list holds nothing but the placeholder.
+    expect(q.getFields()).toHaveLength(1);
+  });
+
+  it('returns the manager for chaining', () => {
+    const q = new QueryManager(undefined, { fields });
+    expect(q.reconfigure({})).toBe(q);
+  });
+
+  it('exposes the merged options as a frozen copy', () => {
+    const q = new QueryManager(undefined, { fields });
+    q.reconfigure({ listsAsArrays: true });
+
+    const options = q.getOptions();
+    expect(options).toMatchObject({ fields, listsAsArrays: true });
+    expect(Object.isFrozen(options)).toBe(true);
+    // A copy, so mutating it does not affect the manager.
+    expect(q.getOptions()).not.toBe(options);
+  });
+
+  it('leaves the query untouched', () => {
+    const q = new QueryManager<RuleGroupType>({ combinator: 'and', rules: [rule()] }, { fields });
+    const before = q.getQuery();
+
+    q.reconfigure({ fields: [{ name: 'other', label: 'Other' }] });
+
+    expect(q.getQuery()).toBe(before);
+    expect(q.getQuery().rules[0]).toMatchObject({ field: 'firstName' });
+  });
+
+  it('notifies subscribers and bumps the config version', () => {
+    const listener = vi.fn();
+    const q = new QueryManager(undefined, { fields });
+    expect(q.getConfigVersion()).toBe(0);
+    q.subscribe(listener);
+
+    q.reconfigure({ listsAsArrays: true });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(q.getConfigVersion()).toBe(1);
+
+    q.reconfigure({});
+    expect(q.getConfigVersion()).toBe(2);
+  });
+
+  it('notifies immediately inside a batch', () => {
+    const listener = vi.fn();
+    const q = new QueryManager(undefined, { fields });
+    q.subscribe(listener);
+
+    q.batch(() => {
+      q.reconfigure({ listsAsArrays: true });
+      expect(listener).toHaveBeenCalledTimes(1);
+      q.add(rule());
+    });
+
+    // Once for the reconfigure, once for the batch's query change.
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates the cached validation result', () => {
+    const q = new QueryManager(undefined, { fields });
+    expect(q.validate()).not.toBe(true);
+
+    q.reconfigure({ validator: () => true });
+
+    expect(q.validate()).toBe(true);
+  });
+
+  it('preserves history and trims the undo stack to a lower maxHistory', () => {
+    const q = new QueryManager(undefined, { fields, history: true });
+    q.add(rule('firstName')).add(rule('lastName')).add(rule('age'));
+    expect(q.getHistory().past).toHaveLength(3);
+
+    q.reconfigure({ history: { maxHistory: 1 } });
+
+    const { past } = q.getHistory();
+    expect(past).toHaveLength(1);
+    // The most recent entry is the one kept.
+    expect(past[0].rules).toHaveLength(2);
+    expect(q.canUndo()).toBe(true);
+  });
+
+  it('leaves a shorter undo stack alone when maxHistory is raised', () => {
+    const q = new QueryManager(undefined, { fields, history: { maxHistory: 5 } });
+    q.add(rule());
+
+    q.reconfigure({ history: { maxHistory: 50 } });
+
+    expect(q.getHistory().past).toHaveLength(1);
+  });
+
+  it('clears history when history is turned off', () => {
+    const q = new QueryManager(undefined, { fields, history: true });
+    q.add(rule());
+    q.undo();
+    expect(q.getHistory()).toMatchObject({ past: [], future: [expect.anything()] });
+
+    q.reconfigure({ history: false });
+
+    expect(q.getHistory()).toEqual({ past: [], future: [] });
+    expect(q.canUndo()).toBe(false);
+    expect(q.canRedo()).toBe(false);
+  });
+
+  it('starts recording when history is turned on', () => {
+    const q = new QueryManager(undefined, { fields });
+    q.add(rule());
+    expect(q.canUndo()).toBe(false);
+
+    q.reconfigure({ history: true });
+    q.add(rule('lastName'));
+
+    expect(q.canUndo()).toBe(true);
+    expect(q.getHistory().past).toHaveLength(1);
+  });
+
+  it('applies new behavior options to subsequent mutations', () => {
+    const q = new QueryManager<RuleGroupType>(
+      { combinator: 'and', rules: [rule()] },
+      { fields, strict: false }
+    );
+
+    expect(() => q.remove([9])).not.toThrow();
+    q.reconfigure({ strict: true });
+    expect(() => q.remove([9])).toThrow(QueryManagerError);
+  });
+
+  it('carries the reconfigured options into clones', () => {
+    const q = new QueryManager(undefined, { fields, ...autoSelectOff });
+    q.reconfigure({ translations: { fields: { placeholderName: '#' } } });
+
+    expect(q.clone().createRule()).toMatchObject({ field: '#' });
+  });
+});
+
 describe('group configuration', () => {
   const q = () =>
     new QueryManager<RuleGroupType>({ combinator: 'or', rules: [rule()] }, { fields });

--- a/packages/core/src/utils/QueryManager.ts
+++ b/packages/core/src/utils/QueryManager.ts
@@ -376,21 +376,27 @@ export class QueryManager<
   C extends FullCombinator = FullCombinator,
 > {
   #query: RG;
-  readonly #options: QueryManagerOptions<F, O, C>;
-  readonly #fields: FullOptionList<F>;
-  readonly #fieldMap: Partial<FullOptionRecord<FullField>>;
-  readonly #operators: FullOptionList<O>;
-  readonly #combinators: FullOptionList<C>;
-  readonly #idGenerator: () => string;
-  readonly #validator: QueryValidator;
-  readonly #strict: boolean;
-  readonly #respectDisabled: boolean;
-  readonly #onInvalidTarget: ((info: AbortInfo) => void) | undefined;
+  // The fields below are derived from the options and are reassigned by `reconfigure`, so none
+  // of them can be `readonly`. Anything handed out directly is frozen instead. They are all
+  // assigned by `#applyOptions`, which the constructor calls first thing; TypeScript can't see
+  // through the method call, hence the definite assignment assertions.
+  #options!: QueryManagerOptions<F, O, C>;
+  #fields!: FullOptionList<F>;
+  #fieldMap!: Partial<FullOptionRecord<FullField>>;
+  #operators!: FullOptionList<O>;
+  #combinators!: FullOptionList<C>;
+  #idGenerator!: () => string;
+  #validator!: QueryValidator;
+  #strict!: boolean;
+  #respectDisabled!: boolean;
+  #onInvalidTarget: ((info: AbortInfo) => void) | undefined;
   readonly #listeners = new Set<() => void>();
-  readonly #historyEnabled: boolean;
-  readonly #maxHistory: number;
-  readonly #coalesceMs: number;
-  readonly #now: () => number;
+  #historyEnabled!: boolean;
+  #maxHistory!: number;
+  #coalesceMs!: number;
+  #now!: () => number;
+  /** Incremented by every {@link QueryManager.reconfigure} call. See `getConfigVersion`. */
+  #configVersion = 0;
   #past: RG[] = [];
   #future: RG[] = [];
   #lastSig: string | undefined;
@@ -409,6 +415,20 @@ export class QueryManager<
   #validation: boolean | ValidationMap | undefined;
 
   constructor(query?: RG, options: QueryManagerOptions<F, O, C> = {}) {
+    this.#applyOptions(options);
+
+    this.#query = freeze(
+      query ? prepareRuleGroup(query, { idGenerator: this.#idGenerator }) : this.createRuleGroup(),
+      true
+    );
+  }
+
+  /**
+   * Assigns `#options` and every field derived from it. Shared by the constructor and
+   * {@link QueryManager.reconfigure}, so the two can never drift apart. Does not touch the
+   * query, the history stacks, the caches, or the subscriber list.
+   */
+  #applyOptions(options: QueryManagerOptions<F, O, C>): void {
     this.#options = options;
     this.#idGenerator = options.idGenerator ?? generateID;
     this.#validator = options.validator ?? defaultValidator;
@@ -449,11 +469,6 @@ export class QueryManager<
         optionList: (options.combinators ?? defaultCombinators) as FlexibleOptionListProp<C>,
         baseOption: options.baseCombinator,
       }).optionList,
-      true
-    );
-
-    this.#query = freeze(
-      query ? prepareRuleGroup(query, { idGenerator: this.#idGenerator }) : this.createRuleGroup(),
       true
     );
   }
@@ -895,6 +910,81 @@ export class QueryManager<
     );
     return this;
   }
+
+  // #endregion
+
+  // #region Configuration
+
+  /**
+   * The options currently in effect, as a frozen shallow copy. Reflects everything applied by
+   * the constructor and any subsequent {@link QueryManager.reconfigure} calls, but not the
+   * defaults filled in for options that were never provided.
+   */
+  getOptions(): Readonly<QueryManagerOptions<F, O, C>> {
+    return freeze({ ...this.#options });
+  }
+
+  /**
+   * Updates the manager's configuration in place, keeping the current query, the undo/redo
+   * history, and every subscriber. Use this to propagate new `translations`, `fields`,
+   * `operators`, and so on without discarding state:
+   *
+   * ```ts
+   * q.reconfigure({ translations: { fields: { placeholderLabel: 'Choisir un champ' } } });
+   * ```
+   *
+   * The incoming options are shallow-merged over the current ones, so keys left out are
+   * preserved. Passing a key explicitly as `undefined` resets it to its default. Object-valued
+   * options like `translations` are replaced wholesale rather than deep-merged — spread the
+   * current value in yourself to patch one key. Pass `{ replace: true }` to discard the
+   * existing options entirely and start from the incoming set.
+   *
+   * The query is never rewritten, even when the new options no longer describe it: a rule whose
+   * `field` is not in the new `fields` list is left as-is. Call
+   * {@link QueryManager.validate validate} to detect that, or `setQuery(getQuery())` to
+   * re-normalize.
+   *
+   * History options are honored immediately: lowering `maxHistory` trims the undo stack, and
+   * turning history off clears both stacks. Subscribers are notified once, and
+   * {@link QueryManager.getConfigVersion} is incremented, even inside a
+   * {@link QueryManager.batch batch} — configuration is not part of a batch's rollback.
+   */
+  reconfigure(
+    options: Partial<QueryManagerOptions<F, O, C>>,
+    config?: { replace?: boolean }
+  ): this {
+    this.#applyOptions(freeze(config?.replace ? { ...options } : { ...this.#options, ...options }));
+
+    // `#ensureCache` is keyed on query identity, and the query has not changed, so it will not
+    // clear this on its own. Validation depends on `validator` and `fields`, both of which may
+    // have just changed. `#idPathIndex` is derived from the query alone and stays valid.
+    this.#validation = undefined;
+
+    if (this.#historyEnabled) {
+      // Only ever shrinks; a raised `maxHistory` simply allows more entries from here on.
+      if (this.#past.length > this.#maxHistory) {
+        this.#past.splice(0, this.#past.length - this.#maxHistory);
+      }
+    } else {
+      this.clearHistory();
+    }
+
+    ++this.#configVersion;
+    this.#notify();
+
+    return this;
+  }
+
+  /**
+   * A counter incremented by every {@link QueryManager.reconfigure} call. Because reconfiguring
+   * leaves the query object untouched, subscribers that compare query identity alone cannot see
+   * it; this provides a snapshot that does change.
+   *
+   * Bound to the instance, so it can be passed directly to `useSyncExternalStore` alongside
+   * {@link QueryManager.subscribe}. The `useQueryManager` hook from `react-querybuilder`
+   * already does this.
+   */
+  getConfigVersion = (): number => this.#configVersion;
 
   // #endregion
 

--- a/packages/core/src/utils/QueryManager.ts
+++ b/packages/core/src/utils/QueryManager.ts
@@ -960,19 +960,35 @@ export class QueryManager<
     // have just changed. `#idPathIndex` is derived from the query alone and stays valid.
     this.#validation = undefined;
 
+    this.#reconcileHistoryConfig();
+
+    ++this.#configVersion;
+    this.#notify();
+
+    return this;
+  }
+
+  /**
+   * Brings the history stacks in line with the current history configuration. Unlike
+   * {@link QueryManager.clearHistory}, this does _not_ set `#historyBypassed`: it reflects a
+   * configuration change rather than a deliberate history repositioning, so a later mutation in
+   * the same batch must still be recorded normally.
+   *
+   * Called by {@link QueryManager.reconfigure} and again after a failed
+   * {@link QueryManager.batch batch} restores its snapshot, since that snapshot predates the
+   * configuration change (configuration is not part of a batch's rollback).
+   */
+  #reconcileHistoryConfig(): void {
     if (this.#historyEnabled) {
       // Only ever shrinks; a raised `maxHistory` simply allows more entries from here on.
       if (this.#past.length > this.#maxHistory) {
         this.#past.splice(0, this.#past.length - this.#maxHistory);
       }
     } else {
-      this.clearHistory();
+      this.#past = [];
+      this.#future = [];
+      this.#lastSig = undefined;
     }
-
-    ++this.#configVersion;
-    this.#notify();
-
-    return this;
   }
 
   /**
@@ -1076,6 +1092,9 @@ export class QueryManager<
         this.#future = snapshot.future;
         this.#lastSig = snapshot.lastSig;
         this.#lastAt = snapshot.lastAt;
+        // The snapshot predates any `reconfigure` call made inside the batch, and configuration
+        // is not rolled back, so the restored stacks must be re-reconciled against it.
+        this.#reconcileHistoryConfig();
       }
       throw error;
     } finally {

--- a/packages/react-querybuilder/src/hooks/useQueryManager.test.tsx
+++ b/packages/react-querybuilder/src/hooks/useQueryManager.test.tsx
@@ -1,4 +1,10 @@
-import { QueryManager, type RuleGroupType, type RuleType } from '@react-querybuilder/core';
+import {
+  defaultPlaceholderLabel,
+  QueryManager,
+  type FullField,
+  type RuleGroupType,
+  type RuleType,
+} from '@react-querybuilder/core';
 import { act, render, renderHook, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
@@ -163,6 +169,50 @@ describe('useQueryManager', () => {
         qm.redo();
       });
       expect(result.current[0].rules).toHaveLength(1);
+    });
+
+    it('re-renders when the manager is reconfigured', () => {
+      const { qm, result, getRenderCount } = renderCounter();
+      const before = getRenderCount();
+
+      act(() => {
+        qm.reconfigure({ fields, autoSelectField: false });
+      });
+
+      // The query object is unchanged, but the new configuration must reach the consumer.
+      expect(getRenderCount()).toBe(before + 1);
+      expect(result.current[1].getFields()).toHaveLength(fields.length + 1);
+    });
+
+    it('surfaces reconfigured translations in the rendered output', async () => {
+      const qm = new QueryManager<RuleGroupType>(undefined, { fields, autoSelectField: false });
+      const CustomUI = () => {
+        const [, manager] = useQueryManager(qm);
+        return (
+          <span data-testid="placeholder">{(manager.getFields() as FullField[])[0].label}</span>
+        );
+      };
+
+      render(<CustomUI />);
+      expect(screen.getByTestId('placeholder')).toHaveTextContent(defaultPlaceholderLabel);
+
+      await act(async () => {
+        qm.reconfigure({ translations: { fields: { placeholderLabel: 'Choisir un champ' } } });
+      });
+
+      expect(screen.getByTestId('placeholder')).toHaveTextContent('Choisir un champ');
+    });
+
+    it('stops observing config changes after unmount', () => {
+      const qm = new QueryManager<RuleGroupType>(undefined, { fields });
+      const { unmount } = renderHook(() => useQueryManager(qm));
+
+      unmount();
+
+      expect(() => {
+        qm.reconfigure({ listsAsArrays: true });
+      }).not.toThrow();
+      expect(qm.getConfigVersion()).toBe(1);
     });
 
     it('unsubscribes on unmount', () => {

--- a/packages/react-querybuilder/src/hooks/useQueryManager.ts
+++ b/packages/react-querybuilder/src/hooks/useQueryManager.ts
@@ -32,7 +32,8 @@ export function useQueryManager<
  *
  * The manager is created once and never recreated, so `query` is an _initial_ value and
  * `options` are captured on the first render only. Later changes to either argument are ignored.
- * To reconfigure the manager, construct it yourself and pass the instance instead.
+ * To change the configuration afterward, call `manager.reconfigure(...)` on the returned
+ * manager; this hook re-renders when it does.
  *
  * @group Hooks
  */
@@ -66,6 +67,11 @@ export function useQueryManager<
   // `getQuery` doubles as the server snapshot: QueryManager has no React or DOM dependencies,
   // and the query is frozen and only replaced by reference on commit.
   const query = useSyncExternalStore(manager.subscribe, manager.getQuery, manager.getQuery);
+
+  // `reconfigure` leaves the query object untouched, so the subscription above cannot see it.
+  // The config version is a snapshot that does change, which re-renders consumers whose output
+  // depends on options (translations, fields, etc.) rather than on the query.
+  useSyncExternalStore(manager.subscribe, manager.getConfigVersion, manager.getConfigVersion);
 
   return [query, manager];
 }

--- a/website/docs/utils/hooks.mdx
+++ b/website/docs/utils/hooks.mdx
@@ -142,6 +142,14 @@ const CustomUI = () => {
 
 Since the manager is stable, its methods are safe to call from event handlers and to use in dependency arrays. A [batch](./query-management#batching) triggers a single re-render regardless of how many changes it contains, and mutations that resolve to a no-op trigger none.
 
+To change the configuration after the first render, call [`reconfigure`](./query-management#reconfiguration) on the manager. The hook subscribes to the manager's config version in addition to its query, so a reconfiguration re-renders the component even though the query object is unchanged.
+
+```tsx
+useEffect(() => {
+  qm.reconfigure({ translations });
+}, [qm, translations]);
+```
+
 ## Component logic
 
 The core logic of each component is encapsulated in a reusable hook. Each main component is little more than a call to its respective hook plus the JSX that uses the properties returned from that hook. This enables creating a custom presentation layer without copying logic code from the default components.

--- a/website/docs/utils/query-management.mdx
+++ b/website/docs/utils/query-management.mdx
@@ -231,6 +231,29 @@ As with the query tools themselves, these methods are a no-op when the target pa
 
 `clone(options?: { regenerateIDs?: boolean })` returns an independent manager with the same configuration and the current query. Subscribers and history are not carried over. Because every mutation produces a new query object, the two managers share the initial query safely and diverge from the first change. Pass `{ regenerateIDs: true }` to give every rule and group in the clone a new `id`, which is useful when both queries will be used together.
 
+### Reconfiguration
+
+`reconfigure(options: Partial<QueryManagerOptions>, config?: { replace?: boolean })` updates the manager's configuration in place, keeping the current query, the undo/redo history, and every subscriber. Use it to propagate new `translations`, `fields`, `operators`, and so on without discarding state:
+
+```ts
+q.reconfigure({ translations: { fields: { placeholderLabel: 'Choisir un champ' } } });
+```
+
+The incoming options are shallow-merged over the current ones, so keys left out are preserved. Passing a key explicitly as `undefined` resets it to its default. Object-valued options like `translations` are replaced wholesale rather than deep-merged—spread the current value in yourself to patch a single key. Pass `{ replace: true }` to discard the existing options entirely and start from the incoming set.
+
+Related methods:
+
+- `getOptions(): QueryManagerOptions` — The options currently in effect, as a frozen shallow copy.
+- `getConfigVersion(): number` — A counter incremented by every `reconfigure` call. Bound to the instance, so it can be passed directly to React's `useSyncExternalStore` alongside `subscribe`. The [`useQueryManager`](./hooks#usequerymanager) hook already does this.
+
+:::note
+
+`reconfigure` never rewrites the query, even when the new options no longer describe it—a rule whose `field` is not in the new `fields` list is left as-is. Call [`validate()`](#validation-and-export) to detect that, or `setQuery(getQuery())` to re-normalize.
+
+Subscribers are notified once and `getConfigVersion()` is incremented, even inside a [batch](#batching); configuration is not part of a batch's rollback. History options are honored immediately: lowering `maxHistory` trims the undo stack, and turning history off clears both stacks.
+
+:::
+
 ### Subscriptions
 
 `subscribe(listener: () => void)` registers a listener called after every change to the query, and returns a function that unregisters it. Mutations that resolve to a no-op do not notify, and a [batch](#batching) notifies once no matter how many changes it contains.

--- a/website/versioned_docs/version-7/utils/hooks.mdx
+++ b/website/versioned_docs/version-7/utils/hooks.mdx
@@ -142,6 +142,14 @@ const CustomUI = () => {
 
 Since the manager is stable, its methods are safe to call from event handlers and to use in dependency arrays. A [batch](./query-management#batching) triggers a single re-render regardless of how many changes it contains, and mutations that resolve to a no-op trigger none.
 
+To change the configuration after the first render, call [`reconfigure`](./query-management#reconfiguration) on the manager. The hook subscribes to the manager's config version in addition to its query, so a reconfiguration re-renders the component even though the query object is unchanged.
+
+```tsx
+useEffect(() => {
+  qm.reconfigure({ translations });
+}, [qm, translations]);
+```
+
 ## Component logic
 
 The core logic of each component is encapsulated in a reusable hook. Each main component is little more than a call to its respective hook plus the JSX that uses the properties returned from that hook. This enables creating a custom presentation layer without copying logic code from the default components.

--- a/website/versioned_docs/version-7/utils/query-management.mdx
+++ b/website/versioned_docs/version-7/utils/query-management.mdx
@@ -231,6 +231,29 @@ As with the query tools themselves, these methods are a no-op when the target pa
 
 `clone(options?: { regenerateIDs?: boolean })` returns an independent manager with the same configuration and the current query. Subscribers and history are not carried over. Because every mutation produces a new query object, the two managers share the initial query safely and diverge from the first change. Pass `{ regenerateIDs: true }` to give every rule and group in the clone a new `id`, which is useful when both queries will be used together.
 
+### Reconfiguration
+
+`reconfigure(options: Partial<QueryManagerOptions>, config?: { replace?: boolean })` updates the manager's configuration in place, keeping the current query, the undo/redo history, and every subscriber. Use it to propagate new `translations`, `fields`, `operators`, and so on without discarding state:
+
+```ts
+q.reconfigure({ translations: { fields: { placeholderLabel: 'Choisir un champ' } } });
+```
+
+The incoming options are shallow-merged over the current ones, so keys left out are preserved. Passing a key explicitly as `undefined` resets it to its default. Object-valued options like `translations` are replaced wholesale rather than deep-merged—spread the current value in yourself to patch a single key. Pass `{ replace: true }` to discard the existing options entirely and start from the incoming set.
+
+Related methods:
+
+- `getOptions(): QueryManagerOptions` — The options currently in effect, as a frozen shallow copy.
+- `getConfigVersion(): number` — A counter incremented by every `reconfigure` call. Bound to the instance, so it can be passed directly to React's `useSyncExternalStore` alongside `subscribe`. The [`useQueryManager`](./hooks#usequerymanager) hook already does this.
+
+:::note
+
+`reconfigure` never rewrites the query, even when the new options no longer describe it—a rule whose `field` is not in the new `fields` list is left as-is. Call [`validate()`](#validation-and-export) to detect that, or `setQuery(getQuery())` to re-normalize.
+
+Subscribers are notified once and `getConfigVersion()` is incremented, even inside a [batch](#batching); configuration is not part of a batch's rollback. History options are honored immediately: lowering `maxHistory` trims the undo stack, and turning history off clears both stacks.
+
+:::
+
 ### Subscriptions
 
 `subscribe(listener: () => void)` registers a listener called after every change to the query, and returns a function that unregisters it. Mutations that resolve to a no-op do not notify, and a [batch](#batching) notifies once no matter how many changes it contains.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added in-place `QueryManager` reconfiguration without losing the current query, history, or subscribers.
  - Added options inspection and configuration-version accessors.
  - Supports merging, replacing, and resetting configuration options.
  - React components now re-render when manager configuration changes, including translated placeholders.

- **Documentation**
  - Added guidance and examples for reconfiguring query managers and using the new configuration APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->